### PR TITLE
Typo fix in CodeBuild job names

### DIFF
--- a/codebuild/cloudformation.yml
+++ b/codebuild/cloudformation.yml
@@ -154,7 +154,7 @@ Resources:
   CodeBuildProjectX86Proofs:
     Type: "AWS::CodeBuild::Project"
     Properties:
-      Name: !Sub ${ProjectName}-proofs
+      Name: !Sub ${ProjectName}-x86-proofs
       Description: !Ref ProjectDescription
       Source:
         Location: !Ref SourceLocation
@@ -223,7 +223,7 @@ Resources:
   CodeBuildProjectArmProofs:
     Type: "AWS::CodeBuild::Project"
     Properties:
-      Name: !Sub ${ProjectName}-proofs
+      Name: !Sub ${ProjectName}-arm-proofs
       Description: !Ref ProjectDescription
       Source:
         Location: !Ref SourceLocation


### PR DESCRIPTION
Typo fix in CodeBuild job names.

Tested manually on my account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
