### PR TITLE
Add alternative variants of 4x4 multiplication and squaring

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -79,9 +79,11 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       fastmul/bignum_ksqr_16_32.o \
       fastmul/bignum_ksqr_32_64.o \
       fastmul/bignum_mul_4_8.o \
+      fastmul/bignum_mul_4_8_alt.o \
       fastmul/bignum_mul_6_12.o \
       fastmul/bignum_mul_8_16.o \
       fastmul/bignum_sqr_4_8.o \
+      fastmul/bignum_sqr_4_8_alt.o \
       fastmul/bignum_sqr_6_12.o \
       fastmul/bignum_sqr_8_16.o \
       generic/bignum_add.o \

--- a/arm/fastmul/Makefile
+++ b/arm/fastmul/Makefile
@@ -37,9 +37,11 @@ OBJ = bignum_emontredc_8n.o \
       bignum_ksqr_16_32.o \
       bignum_ksqr_32_64.o \
       bignum_mul_4_8.o \
+      bignum_mul_4_8_alt.o \
       bignum_mul_6_12.o \
       bignum_mul_8_16.o \
       bignum_sqr_4_8.o \
+      bignum_sqr_4_8_alt.o \
       bignum_sqr_6_12.o \
       bignum_sqr_8_16.o
 

--- a/arm/fastmul/bignum_mul_4_8_alt.S
+++ b/arm/fastmul/bignum_mul_4_8_alt.S
@@ -1,0 +1,170 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply z := x * y
+// Inputs x[4], y[4]; output z[8]
+//
+//    extern void bignum_mul_4_8_alt
+//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_mul_4_8_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+#define y x2
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define b0 x7
+#define b1 x8
+#define b2 x9
+#define b3 x10
+
+#define h x11
+#define l x12
+
+#define u0 x13
+#define u1 x14
+#define u2 x15
+#define u3 x16
+
+// These alias to the input arguments when no longer needed
+
+#define u4 a0
+#define u5 a1
+#define u6 a2
+#define u7 a3
+
+bignum_mul_4_8_alt:
+
+// Load operands and set up row 0 = [u4;...;u0] = a0 * [b3;...;b0]
+
+                ldp     a0, a1, [x]
+                ldp     b0, b1, [y]
+
+                mul     u0, a0, b0
+                umulh   u1, a0, b0
+                mul     l, a0, b1
+                umulh   u2, a0, b1
+                adds    u1, u1, l
+
+                ldp     b2, b3, [y, #16]
+
+                mul     l, a0, b2
+                umulh   u3, a0, b2
+                adcs    u2, u2, l
+
+                mul     l, a0, b3
+                umulh   u4, a0, b3
+                adcs    u3, u3, l
+                adc     u4, u4, xzr
+
+                ldp     a2, a3, [x, #16]
+
+// Row 1 = [u5;...;u0] = [a1;a0] * [b3;...;b0]
+
+                mul     l, a1, b0
+                umulh   h, a1, b0
+                adds    u1, u1, l
+
+                adcs    u2, u2, h
+                mul     l, a1, b1
+                umulh   h, a1, b1
+                adc     h, h, xzr
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a1, b2
+                umulh   h, a1, b2
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a1, b3
+                umulh   h, a1, b3
+                adc     h, h, xzr
+                adds    u4, u4, l
+                adc     u5, h, xzr
+
+// Row 2 = [u6;...;u0] = [a2;a1;a0] * [b3;...;b0]
+
+                mul     l, a2, b0
+                umulh   h, a2, b0
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a2, b1
+                umulh   h, a2, b1
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a2, b2
+                umulh   h, a2, b2
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                mul     l, a2, b3
+                umulh   h, a2, b3
+                adc     h, h, xzr
+                adds    u5, u5, l
+                adc     u6, h, xzr
+
+// Row 3 = [u7;...;u0] = [a3;...a0] * [b3;...;b0]
+
+                mul     l, a3, b0
+                umulh   h, a3, b0
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a3, b1
+                umulh   h, a3, b1
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                mul     l, a3, b2
+                umulh   h, a3, b2
+                adc     h, h, xzr
+                adds    u5, u5, l
+
+                adcs    u6, u6, h
+                mul     l, a3, b3
+                umulh   h, a3, b3
+                adc     h, h, xzr
+                adds    u6, u6, l
+                adc     u7, h, xzr
+
+// Store back final result [a3;...a0] * [b3;...;b0] = a * b
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+                stp     u6, u7, [z, #48]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arm/fastmul/bignum_sqr_4_8_alt.S
+++ b/arm/fastmul/bignum_sqr_4_8_alt.S
@@ -1,0 +1,133 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square, z := x^2
+// Input x[4]; output z[8]
+//
+//    extern void bignum_sqr_4_8_alt
+//     (uint64_t z[static 8], uint64_t x[static 4]);
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_sqr_4_8_alt
+        .text
+        .balign 4
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+
+#define l x6
+#define h x7
+
+#define u0 x8
+#define u1 x9
+#define u2 x10
+#define u3 x11
+#define u4 x12
+#define u5 x13
+#define u6 x14
+
+// This one is the same as h, which is safe with this computation sequence
+
+#define u7 h
+
+bignum_sqr_4_8_alt:
+
+// Load all the elements, set up an initial window [u6;...u1] = [23;03;01]
+// and chain in the addition of 02 + 12 + 13 (no carry-out is possible).
+// This gives all the "heterogeneous" terms of the squaring ready to double
+
+                ldp     a0, a1, [x]
+
+                mul     u1, a0, a1
+                umulh   u2, a0, a1
+
+                ldp     a2, a3, [x, #16]
+
+                mul     u3, a0, a3
+                umulh   u4, a0, a3
+
+                mul     l, a0, a2
+                umulh   h, a0, a2
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a1, a2
+                umulh   h, a1, a2
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                mul     u5, a2, a3
+                umulh   u6, a2, a3
+
+                adcs    u4, u4, h
+                mul     l, a1, a3
+                umulh   h, a1, a3
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                adc     u6, u6, xzr
+
+// Now just double it; this simple approach seems to work better than extr
+
+                adds    u1, u1, u1
+                adcs    u2, u2, u2
+                adcs    u3, u3, u3
+                adcs    u4, u4, u4
+                adcs    u5, u5, u5
+                adcs    u6, u6, u6
+                cset    u7, cs
+
+// Add the homogeneous terms 00 + 11 + 22 + 33
+
+                umulh   l, a0, a0
+                mul     u0, a0, a0
+                adds    u1, u1, l
+
+                mul     l, a1, a1
+                adcs    u2, u2, l
+                umulh   l, a1, a1
+                adcs    u3, u3, l
+
+                mul     l, a2, a2
+                adcs    u4, u4, l
+                umulh   l, a2, a2
+                adcs    u5, u5, l
+
+                mul     l, a3, a3
+                adcs    u6, u6, l
+                umulh   l, a3, a3
+                adc     u7, u7, l
+
+// Store back final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+                stp     u4, u5, [z, #32]
+                stp     u6, u7, [z, #48]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arm/proofs/bignum_mul_4_8_alt.ml
+++ b/arm/proofs/bignum_mul_4_8_alt.ml
@@ -1,0 +1,159 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* 4x4->8 multiply optimized for uarchs with higher multiplier throughput.   *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "arm/fastmul/bignum_mul_4_8_alt.o";;
+ ****)
+
+let bignum_mul_4_8_alt_mc =
+  define_assert_from_elf "bignum_mul_4_8_alt_mc" "arm/fastmul/bignum_mul_4_8_alt.o"
+[
+  0xa9401023;       (* arm_LDP X3 X4 X1 (Immediate_Offset (iword (&0))) *)
+  0xa9402047;       (* arm_LDP X7 X8 X2 (Immediate_Offset (iword (&0))) *)
+  0x9b077c6d;       (* arm_MUL X13 X3 X7 *)
+  0x9bc77c6e;       (* arm_UMULH X14 X3 X7 *)
+  0x9b087c6c;       (* arm_MUL X12 X3 X8 *)
+  0x9bc87c6f;       (* arm_UMULH X15 X3 X8 *)
+  0xab0c01ce;       (* arm_ADDS X14 X14 X12 *)
+  0xa9412849;       (* arm_LDP X9 X10 X2 (Immediate_Offset (iword (&16))) *)
+  0x9b097c6c;       (* arm_MUL X12 X3 X9 *)
+  0x9bc97c70;       (* arm_UMULH X16 X3 X9 *)
+  0xba0c01ef;       (* arm_ADCS X15 X15 X12 *)
+  0x9b0a7c6c;       (* arm_MUL X12 X3 X10 *)
+  0x9bca7c63;       (* arm_UMULH X3 X3 X10 *)
+  0xba0c0210;       (* arm_ADCS X16 X16 X12 *)
+  0x9a1f0063;       (* arm_ADC X3 X3 XZR *)
+  0xa9411825;       (* arm_LDP X5 X6 X1 (Immediate_Offset (iword (&16))) *)
+  0x9b077c8c;       (* arm_MUL X12 X4 X7 *)
+  0x9bc77c8b;       (* arm_UMULH X11 X4 X7 *)
+  0xab0c01ce;       (* arm_ADDS X14 X14 X12 *)
+  0xba0b01ef;       (* arm_ADCS X15 X15 X11 *)
+  0x9b087c8c;       (* arm_MUL X12 X4 X8 *)
+  0x9bc87c8b;       (* arm_UMULH X11 X4 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c01ef;       (* arm_ADDS X15 X15 X12 *)
+  0xba0b0210;       (* arm_ADCS X16 X16 X11 *)
+  0x9b097c8c;       (* arm_MUL X12 X4 X9 *)
+  0x9bc97c8b;       (* arm_UMULH X11 X4 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b0a7c8c;       (* arm_MUL X12 X4 X10 *)
+  0x9bca7c8b;       (* arm_UMULH X11 X4 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0x9a1f0164;       (* arm_ADC X4 X11 XZR *)
+  0x9b077cac;       (* arm_MUL X12 X5 X7 *)
+  0x9bc77cab;       (* arm_UMULH X11 X5 X7 *)
+  0xab0c01ef;       (* arm_ADDS X15 X15 X12 *)
+  0xba0b0210;       (* arm_ADCS X16 X16 X11 *)
+  0x9b087cac;       (* arm_MUL X12 X5 X8 *)
+  0x9bc87cab;       (* arm_UMULH X11 X5 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b097cac;       (* arm_MUL X12 X5 X9 *)
+  0x9bc97cab;       (* arm_UMULH X11 X5 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0xba0b0084;       (* arm_ADCS X4 X4 X11 *)
+  0x9b0a7cac;       (* arm_MUL X12 X5 X10 *)
+  0x9bca7cab;       (* arm_UMULH X11 X5 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0084;       (* arm_ADDS X4 X4 X12 *)
+  0x9a1f0165;       (* arm_ADC X5 X11 XZR *)
+  0x9b077ccc;       (* arm_MUL X12 X6 X7 *)
+  0x9bc77ccb;       (* arm_UMULH X11 X6 X7 *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b087ccc;       (* arm_MUL X12 X6 X8 *)
+  0x9bc87ccb;       (* arm_UMULH X11 X6 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0xba0b0084;       (* arm_ADCS X4 X4 X11 *)
+  0x9b097ccc;       (* arm_MUL X12 X6 X9 *)
+  0x9bc97ccb;       (* arm_UMULH X11 X6 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0084;       (* arm_ADDS X4 X4 X12 *)
+  0xba0b00a5;       (* arm_ADCS X5 X5 X11 *)
+  0x9b0a7ccc;       (* arm_MUL X12 X6 X10 *)
+  0x9bca7ccb;       (* arm_UMULH X11 X6 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c00a5;       (* arm_ADDS X5 X5 X12 *)
+  0x9a1f0166;       (* arm_ADC X6 X11 XZR *)
+  0xa900380d;       (* arm_STP X13 X14 X0 (Immediate_Offset (iword (&0))) *)
+  0xa901400f;       (* arm_STP X15 X16 X0 (Immediate_Offset (iword (&16))) *)
+  0xa9021003;       (* arm_STP X3 X4 X0 (Immediate_Offset (iword (&32))) *)
+  0xa9031805;       (* arm_STP X5 X6 X0 (Immediate_Offset (iword (&48))) *)
+  0xd65f03c0        (* arm_RET X30 *)
+];;
+
+let BIGNUM_MUL_4_8_ALT_EXEC = ARM_MK_EXEC_RULE bignum_mul_4_8_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_MUL_4_8_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+     nonoverlapping (word pc,0x138) (z,8 * 8)
+     ==> ensures arm
+          (\s. aligned_bytes_loaded s (word pc) bignum_mul_4_8_alt_mc /\
+               read PC s = word pc /\
+               C_ARGUMENTS [z; x; y] s /\
+               bignum_from_memory (x,4) s = a /\
+               bignum_from_memory (y,4) s = b)
+          (\s. read PC s = word (pc + 0x134) /\
+               bignum_from_memory (z,8) s = a * b)
+          (MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
+                      X10; X11; X12; X13; X14; X15; X16] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+  ARM_ACCSTEPS_TAC BIGNUM_MUL_4_8_ALT_EXEC (1--77) (1--77) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  MAP_EVERY EXPAND_TAC ["a"; "b"] THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC);;
+
+let BIGNUM_MUL_4_8_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc returnaddress.
+     nonoverlapping (word pc,0x138) (z,8 * 8)
+     ==> ensures arm
+          (\s. aligned_bytes_loaded s (word pc) bignum_mul_4_8_alt_mc /\
+               read PC s = word pc /\
+               read X30 s = returnaddress /\
+               C_ARGUMENTS [z; x; y] s /\
+               bignum_from_memory (x,4) s = a /\
+               bignum_from_memory (y,4) s = b)
+          (\s. read PC s = returnaddress /\
+               bignum_from_memory (z,8) s = a * b)
+          (MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
+                      X10; X11; X12; X13; X14; X15; X16] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_MUL_4_8_ALT_EXEC
+     BIGNUM_MUL_4_8_ALT_CORRECT);;

--- a/arm/proofs/bignum_sqr_4_8_alt.ml
+++ b/arm/proofs/bignum_sqr_4_8_alt.ml
@@ -1,0 +1,127 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* 4x4->8 squaring optimized for uarchs with higher multiplier throughput.   *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "arm/fastmul/bignum_sqr_4_8_alt.o";;
+ ****)
+
+let bignum_sqr_4_8_alt_mc =
+  define_assert_from_elf "bignum_sqr_4_8_alt_mc" "arm/fastmul/bignum_sqr_4_8_alt.o"
+[
+  0xa9400c22;       (* arm_LDP X2 X3 X1 (Immediate_Offset (iword (&0))) *)
+  0x9b037c49;       (* arm_MUL X9 X2 X3 *)
+  0x9bc37c4a;       (* arm_UMULH X10 X2 X3 *)
+  0xa9411424;       (* arm_LDP X4 X5 X1 (Immediate_Offset (iword (&16))) *)
+  0x9b057c4b;       (* arm_MUL X11 X2 X5 *)
+  0x9bc57c4c;       (* arm_UMULH X12 X2 X5 *)
+  0x9b047c46;       (* arm_MUL X6 X2 X4 *)
+  0x9bc47c47;       (* arm_UMULH X7 X2 X4 *)
+  0xab06014a;       (* arm_ADDS X10 X10 X6 *)
+  0xba07016b;       (* arm_ADCS X11 X11 X7 *)
+  0x9b047c66;       (* arm_MUL X6 X3 X4 *)
+  0x9bc47c67;       (* arm_UMULH X7 X3 X4 *)
+  0x9a1f00e7;       (* arm_ADC X7 X7 XZR *)
+  0xab06016b;       (* arm_ADDS X11 X11 X6 *)
+  0x9b057c8d;       (* arm_MUL X13 X4 X5 *)
+  0x9bc57c8e;       (* arm_UMULH X14 X4 X5 *)
+  0xba07018c;       (* arm_ADCS X12 X12 X7 *)
+  0x9b057c66;       (* arm_MUL X6 X3 X5 *)
+  0x9bc57c67;       (* arm_UMULH X7 X3 X5 *)
+  0x9a1f00e7;       (* arm_ADC X7 X7 XZR *)
+  0xab06018c;       (* arm_ADDS X12 X12 X6 *)
+  0xba0701ad;       (* arm_ADCS X13 X13 X7 *)
+  0x9a1f01ce;       (* arm_ADC X14 X14 XZR *)
+  0xab090129;       (* arm_ADDS X9 X9 X9 *)
+  0xba0a014a;       (* arm_ADCS X10 X10 X10 *)
+  0xba0b016b;       (* arm_ADCS X11 X11 X11 *)
+  0xba0c018c;       (* arm_ADCS X12 X12 X12 *)
+  0xba0d01ad;       (* arm_ADCS X13 X13 X13 *)
+  0xba0e01ce;       (* arm_ADCS X14 X14 X14 *)
+  0x9a9f37e7;       (* arm_CSET X7 Condition_CS *)
+  0x9bc27c46;       (* arm_UMULH X6 X2 X2 *)
+  0x9b027c48;       (* arm_MUL X8 X2 X2 *)
+  0xab060129;       (* arm_ADDS X9 X9 X6 *)
+  0x9b037c66;       (* arm_MUL X6 X3 X3 *)
+  0xba06014a;       (* arm_ADCS X10 X10 X6 *)
+  0x9bc37c66;       (* arm_UMULH X6 X3 X3 *)
+  0xba06016b;       (* arm_ADCS X11 X11 X6 *)
+  0x9b047c86;       (* arm_MUL X6 X4 X4 *)
+  0xba06018c;       (* arm_ADCS X12 X12 X6 *)
+  0x9bc47c86;       (* arm_UMULH X6 X4 X4 *)
+  0xba0601ad;       (* arm_ADCS X13 X13 X6 *)
+  0x9b057ca6;       (* arm_MUL X6 X5 X5 *)
+  0xba0601ce;       (* arm_ADCS X14 X14 X6 *)
+  0x9bc57ca6;       (* arm_UMULH X6 X5 X5 *)
+  0x9a0600e7;       (* arm_ADC X7 X7 X6 *)
+  0xa9002408;       (* arm_STP X8 X9 X0 (Immediate_Offset (iword (&0))) *)
+  0xa9012c0a;       (* arm_STP X10 X11 X0 (Immediate_Offset (iword (&16))) *)
+  0xa902340c;       (* arm_STP X12 X13 X0 (Immediate_Offset (iword (&32))) *)
+  0xa9031c0e;       (* arm_STP X14 X7 X0 (Immediate_Offset (iword (&48))) *)
+  0xd65f03c0        (* arm_RET X30 *)
+];;
+
+let BIGNUM_SQR_4_8_ALT_EXEC = ARM_MK_EXEC_RULE bignum_sqr_4_8_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_SQR_4_8_ALT_CORRECT = time prove
+ (`!z x a pc.
+     nonoverlapping (word pc,0xc8) (z,8 * 8)
+     ==> ensures arm
+          (\s. aligned_bytes_loaded s (word pc) bignum_sqr_4_8_alt_mc /\
+               read PC s = word pc /\
+               C_ARGUMENTS [z; x] s /\
+               bignum_from_memory (x,4) s = a)
+          (\s. read PC s = word (pc + 0xc4) /\
+               bignum_from_memory (z,8) s = a EXP 2)
+          (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9;
+                      X10; X11; X12; X13; X14] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  ARM_ACCSTEPS_TAC BIGNUM_SQR_4_8_ALT_EXEC (1--49) (1--49) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[GSYM WORD_BITVAL; COND_SWAP]) THEN
+  EXPAND_TAC "a" THEN REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC);;
+
+let BIGNUM_SQR_4_8_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc returnaddress.
+     nonoverlapping (word pc,0xc8) (z,8 * 8)
+     ==> ensures arm
+          (\s. aligned_bytes_loaded s (word pc) bignum_sqr_4_8_alt_mc /\
+               read PC s = word pc /\
+               read X30 s = returnaddress /\
+               C_ARGUMENTS [z; x] s /\
+               bignum_from_memory (x,4) s = a)
+          (\s. read PC s = returnaddress /\
+               bignum_from_memory (z,8) s = a EXP 2)
+          (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9;
+                      X10; X11; X12; X13; X14] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_SQR_4_8_ALT_EXEC
+    BIGNUM_SQR_4_8_ALT_CORRECT);;

--- a/benchmarks/benchmark.c
+++ b/benchmarks/benchmark.c
@@ -307,11 +307,15 @@ void call_bignum_mul_p521(void) repeat(bignum_mul_p521(b0,b1,b2))
 
 void call_bignum_mul_4_8(void) repeat(bignum_mul_4_8(b0,b1,b2))
 
+void call_bignum_mul_4_8_alt(void) repeat(bignum_mul_4_8_alt(b0,b1,b2))
+
 void call_bignum_mul_6_12(void) repeat(bignum_mul_6_12(b0,b1,b2))
 
 void call_bignum_mul_8_16(void) repeat(bignum_mul_8_16(b0,b1,b2))
 
 void call_bignum_sqr_4_8(void) repeat(bignum_sqr_4_8(b0,b1))
+
+void call_bignum_sqr_4_8_alt(void) repeat(bignum_sqr_4_8_alt(b0,b1))
 
 void call_bignum_sqr_6_12(void) repeat(bignum_sqr_6_12(b0,b1))
 
@@ -707,6 +711,7 @@ int main(void)
   timingtest(all,"bignum_mul (16x16 -> 32)",call_bignum_mul__16_32);
   timingtest(all,"bignum_mul (32x32 -> 64)",call_bignum_mul__32_64);
   timingtest(bmi,"bignum_mul_4_8",call_bignum_mul_4_8);
+  timingtest(all,"bignum_mul_4_8_alt",call_bignum_mul_4_8_alt);
   timingtest(bmi,"bignum_mul_6_12",call_bignum_mul_6_12);
   timingtest(bmi,"bignum_mul_8_16",call_bignum_mul_8_16);
   timingtest(bmi,"bignum_mul_p256k1",call_bignum_mul_p256k1);
@@ -745,6 +750,7 @@ int main(void)
   timingtest(all,"bignum_sqr (16 -> 32)",call_bignum_sqr__16_32);
   timingtest(all,"bignum_sqr (32 -> 64)",call_bignum_sqr__32_64);
   timingtest(bmi,"bignum_sqr_4_8",call_bignum_sqr_4_8);
+  timingtest(all,"bignum_sqr_4_8_alt",call_bignum_sqr_4_8_alt);
   timingtest(bmi,"bignum_sqr_6_12",call_bignum_sqr_6_12);
   timingtest(bmi,"bignum_sqr_8_16",call_bignum_sqr_8_16);
   timingtest(bmi,"bignum_sqr_p256k1",call_bignum_sqr_p256k1);

--- a/include/s2n-bignum-c89.h
+++ b/include/s2n-bignum-c89.h
@@ -429,6 +429,7 @@ extern void bignum_mul (uint64_t k, uint64_t *z, uint64_t m, uint64_t *x, uint64
 /*  Multiply z := x * y */
 /*  Inputs x[4], y[4]; output z[8] */
 extern void bignum_mul_4_8 (uint64_t z[8], uint64_t x[4], uint64_t y[4]);
+extern void bignum_mul_4_8_alt (uint64_t z[8], uint64_t x[4], uint64_t y[4]);
 
 /*  Multiply z := x * y */
 /*  Inputs x[6], y[6]; output z[12] */
@@ -561,6 +562,7 @@ extern void bignum_sqr (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
 /*  Square, z := x^2 */
 /*  Input x[4]; output z[8] */
 extern void bignum_sqr_4_8 (uint64_t z[8], uint64_t x[4]);
+extern void bignum_sqr_4_8_alt (uint64_t z[8], uint64_t x[4]);
 
 /*  Square, z := x^2 */
 /*  Input x[6]; output z[12] */

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -428,6 +428,7 @@ extern void bignum_mul (uint64_t k, uint64_t *z, uint64_t m, uint64_t *x, uint64
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 extern void bignum_mul_4_8 (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+extern void bignum_mul_4_8_alt (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
 
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
@@ -560,6 +561,7 @@ extern void bignum_sqr (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
 // Square, z := x^2
 // Input x[4]; output z[8]
 extern void bignum_sqr_4_8 (uint64_t z[static 8], uint64_t x[static 4]);
+extern void bignum_sqr_4_8_alt (uint64_t z[static 8], uint64_t x[static 4]);
 
 // Square, z := x^2
 // Input x[6]; output z[12]

--- a/tests/test.c
+++ b/tests/test.c
@@ -166,6 +166,7 @@ enum {
        TEST_BIGNUM_MONTSQR_P521,
        TEST_BIGNUM_MUL,
        TEST_BIGNUM_MUL_4_8,
+       TEST_BIGNUM_MUL_4_8_ALT,
        TEST_BIGNUM_MUL_6_12,
        TEST_BIGNUM_MUL_8_16,
        TEST_BIGNUM_MUL_P256K1,
@@ -199,6 +200,7 @@ enum {
        TEST_BIGNUM_SHR_SMALL,
        TEST_BIGNUM_SQR,
        TEST_BIGNUM_SQR_4_8,
+       TEST_BIGNUM_SQR_4_8_ALT,
        TEST_BIGNUM_SQR_6_12,
        TEST_BIGNUM_SQR_8_16,
        TEST_BIGNUM_SQR_P256K1,
@@ -4104,6 +4106,10 @@ int test_bignum_mul_4_8(void)
 { return test_bignum_mul_specific(8,4,4,"bignum_mul_4_8",bignum_mul_4_8);
 }
 
+int test_bignum_mul_4_8_alt(void)
+{ return test_bignum_mul_specific(8,4,4,"bignum_mul_4_8_alt",bignum_mul_4_8_alt);
+}
+
 int test_bignum_mul_6_12(void)
 { return test_bignum_mul_specific(12,6,6,"bignum_mul_6_12",bignum_mul_6_12);
 }
@@ -5137,6 +5143,10 @@ int test_bignum_sqr_4_8(void)
 { return test_bignum_sqr_specific(8,4,"bignum_sqr_4_8",bignum_sqr_4_8);
 }
 
+int test_bignum_sqr_4_8_alt(void)
+{ return test_bignum_sqr_specific(8,4,"bignum_sqr_4_8_alt",bignum_sqr_4_8_alt);
+}
+
 int test_bignum_sqr_6_12(void)
 { return test_bignum_sqr_specific(12,6,"bignum_sqr_6_12",bignum_sqr_6_12);
 }
@@ -6047,6 +6057,7 @@ int test_all(void)
   dotest(test_bignum_montsqr_p521);
   dotest(test_bignum_mul);
   dotest(test_bignum_mul_4_8);
+  dotest(test_bignum_mul_4_8_alt);
   dotest(test_bignum_mul_6_12);
   dotest(test_bignum_mul_8_16);
   dotest(test_bignum_mul_p256k1);
@@ -6080,6 +6091,7 @@ int test_all(void)
   dotest(test_bignum_shr_small);
   dotest(test_bignum_sqr);
   dotest(test_bignum_sqr_4_8);
+  dotest(test_bignum_sqr_4_8_alt);
   dotest(test_bignum_sqr_6_12);
   dotest(test_bignum_sqr_8_16);
   dotest(test_bignum_sqr_p256k1);
@@ -6208,6 +6220,7 @@ int test_allnonbmi()
   dotest(test_bignum_montredc);
   dotest(test_bignum_montsqr);
   dotest(test_bignum_mul);
+  dotest(test_bignum_mul_4_8_alt);
   dotest(test_bignum_muladd10);
   dotest(test_bignum_mux);
   dotest(test_bignum_mux_4);
@@ -6236,6 +6249,7 @@ int test_allnonbmi()
   dotest(test_bignum_shl_small);
   dotest(test_bignum_shr_small);
   dotest(test_bignum_sqr);
+  dotest(test_bignum_sqr_4_8_alt);
   dotest(test_bignum_sub);
   dotest(test_bignum_sub_p256);
   dotest(test_bignum_sub_p256k1);
@@ -6428,6 +6442,7 @@ int main(int argc, char *argv[])
      case TEST_BIGNUM_MONTSQR_P521:    return test_bignum_montsqr_p521();
      case TEST_BIGNUM_MUL:             return test_bignum_mul();
      case TEST_BIGNUM_MUL_4_8:         return test_bignum_mul_4_8();
+     case TEST_BIGNUM_MUL_4_8_ALT:     return test_bignum_mul_4_8_alt();
      case TEST_BIGNUM_MUL_6_12:        return test_bignum_mul_6_12();
      case TEST_BIGNUM_MUL_8_16:        return test_bignum_mul_8_16();
      case TEST_BIGNUM_MUL_P256K1:      return test_bignum_mul_p256k1();
@@ -6461,6 +6476,7 @@ int main(int argc, char *argv[])
      case TEST_BIGNUM_SHR_SMALL:       return test_bignum_shr_small();
      case TEST_BIGNUM_SQR:             return test_bignum_sqr();
      case TEST_BIGNUM_SQR_4_8:         return test_bignum_sqr_4_8();
+     case TEST_BIGNUM_SQR_4_8_ALT:     return test_bignum_sqr_4_8_alt();
      case TEST_BIGNUM_SQR_6_12:        return test_bignum_sqr_6_12();
      case TEST_BIGNUM_SQR_8_16:        return test_bignum_sqr_8_16();
      case TEST_BIGNUM_SQR_P256K1:      return test_bignum_sqr_p256k1();

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -71,9 +71,11 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       fastmul/bignum_ksqr_16_32.o \
       fastmul/bignum_ksqr_32_64.o \
       fastmul/bignum_mul_4_8.o \
+      fastmul/bignum_mul_4_8_alt.o \
       fastmul/bignum_mul_6_12.o \
       fastmul/bignum_mul_8_16.o \
       fastmul/bignum_sqr_4_8.o \
+      fastmul/bignum_sqr_4_8_alt.o \
       fastmul/bignum_sqr_6_12.o \
       fastmul/bignum_sqr_8_16.o \
       generic/bignum_add.o \

--- a/x86/fastmul/Makefile
+++ b/x86/fastmul/Makefile
@@ -21,9 +21,11 @@ OBJ = bignum_emontredc_8n.o \
       bignum_ksqr_16_32.o \
       bignum_ksqr_32_64.o \
       bignum_mul_4_8.o \
+      bignum_mul_4_8_alt.o \
       bignum_mul_6_12.o \
       bignum_mul_8_16.o \
       bignum_sqr_4_8.o \
+      bignum_sqr_4_8_alt.o \
       bignum_sqr_6_12.o \
       bignum_sqr_8_16.o
 

--- a/x86/fastmul/bignum_mul_4_8_alt.S
+++ b/x86/fastmul/bignum_mul_4_8_alt.S
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply z := x * y
+// Inputs x[4], y[4]; output z[8]
+//
+//    extern void bignum_mul_4_8_alt
+//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+        .intel_syntax noprefix
+        .globl  bignum_mul_4_8_alt
+        .text
+
+// These are actually right
+
+#define z rdi
+#define x rsi
+
+// This is moved from rdx to free it for muls
+
+#define y rcx
+
+// Other variables used as a rotating 3-word window to add terms to
+
+#define t0 r8
+#define t1 r9
+#define t2 r10
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,I,J)                      \
+        mov     rax, [x+8*I];                   \
+        mul     QWORD PTR [y+8*J];              \
+        add     l, rax;                         \
+        adc     h, rdx;                         \
+        adc     c, 0
+
+// A minutely shorter form for the very first term where c = 0 initially
+
+#define combadz(c,h,l,I,J)                      \
+        mov     rax, [x+8*I];                   \
+        mul     QWORD PTR [y+8*J];              \
+        add     l, rax;                         \
+        adc     h, rdx;                         \
+        adc     c, c
+
+// A short form for the very last term where we don't expect a top carry
+
+#define combads(c,h,l,I,J)                      \
+        mov     rax, [x+8*I];                   \
+        mul     QWORD PTR [y+8*J];              \
+        add     l, rax;                         \
+        adc     h, rdx
+
+// Stash the result
+
+#define stash(c,h,l,I)                          \
+        mov     [z+8*I],l
+
+bignum_mul_4_8_alt:
+
+// Copy y into a safe register to start with
+
+        mov     y, rdx
+
+// Result term 0
+
+        mov     rax, [x]
+        mul     QWORD PTR [y]
+
+        mov     [z], rax
+        mov     t0, rdx
+        xor     t1, t1
+
+// Result term 1
+
+       xor     t2, t2
+       combadz(t2,t1,t0,0,1)
+       combadd(t2,t1,t0,1,0)
+       stash(t2,t1,t0,1)
+
+// Result term 2
+
+        xor     t0, t0
+        combadd(t0,t2,t1,0,2)
+        combadd(t0,t2,t1,1,1)
+        combadd(t0,t2,t1,2,0)
+        stash(t0,t2,t1,2)
+
+// Result term 3
+
+        xor     t1, t1
+        combadd(t1,t0,t2,0,3)
+        combadd(t1,t0,t2,1,2)
+        combadd(t1,t0,t2,2,1)
+        combadd(t1,t0,t2,3,0)
+        stash(t1,t0,t2,3)
+
+// Result term 4
+
+        xor     t2, t2
+        combadd(t2,t1,t0,1,3)
+        combadd(t2,t1,t0,2,2)
+        combadd(t2,t1,t0,3,1)
+        stash(t2,t1,t0,4)
+
+// Result term 5
+
+        xor     t0, t0
+        combadd(t0,t2,t1,2,3)
+        combadd(t0,t2,t1,3,2)
+        stash(t0,t2,t1,5)
+
+// Result term 6
+
+        xor     t1, t1
+        combads(t1,t0,t2,3,3)
+        stash(t1,t0,t2,6)
+
+// Result term 7
+
+        stash(t2,t1,t0,7)
+
+// Return
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86/fastmul/bignum_sqr_4_8_alt.S
+++ b/x86/fastmul/bignum_sqr_4_8_alt.S
@@ -1,0 +1,135 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square, z := x^2
+// Input x[4]; output z[8]
+//
+//    extern void bignum_sqr_4_8_alt
+//     (uint64_t z[static 8], uint64_t x[static 4]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+        .intel_syntax noprefix
+        .globl  bignum_sqr_4_8_alt
+        .text
+
+// Input arguments
+
+#define z rdi
+#define x rsi
+
+// Other variables used as a rotating 3-word window to add terms to
+
+#define t0 rcx
+#define t1 r8
+#define t2 r9
+
+// Macro for the key "multiply and add to (c,h,l)" step, for square term
+
+#define combadd1(c,h,l,I)                       \
+        mov     rax, [x+8*I];                   \
+        mul     rax;                            \
+        add     l, rax;                         \
+        adc     h, rdx;                         \
+        adc     c, 0
+
+// A short form for the very last term where we don't expect a top carry
+
+#define combads(c,h,l,I)                        \
+        mov     rax, [x+8*I];                   \
+        mul     rax;                            \
+        add     l, rax;                         \
+        adc     h, rdx
+
+// A version doubling before adding, for non-square terms
+
+#define combadd2(c,h,l,I,J)                     \
+        mov     rax, [x+8*I];                   \
+        mul     QWORD PTR [x+8*J];              \
+        add     rax, rax;                       \
+        adc     rdx, rdx;                       \
+        adc     c, 0;                           \
+        add     l, rax;                         \
+        adc     h, rdx;                         \
+        adc     c, 0
+
+// Stash the result
+
+#define stash(c,h,l,I)                          \
+        mov     [z+8*I],l
+
+bignum_sqr_4_8_alt:
+
+// Result term 0
+
+        mov     rax, [x]
+        mul     rax
+
+        mov     [z], rax
+        mov     t0, rdx
+        xor     t1, t1
+
+// Result term 1
+
+       xor     t2, t2
+       combadd2(t2,t1,t0,0,1)
+       stash(t2,t1,t0,1)
+
+// Result term 2
+
+        xor     t0, t0
+        combadd1(t0,t2,t1,1)
+        combadd2(t0,t2,t1,0,2)
+        stash(t0,t2,t1,2)
+
+// Result term 3
+
+        xor     t1, t1
+        combadd2(t1,t0,t2,0,3)
+        combadd2(t1,t0,t2,1,2)
+        stash(t1,t0,t2,3)
+
+// Result term 4
+
+        xor     t2, t2
+        combadd2(t2,t1,t0,1,3)
+        combadd1(t2,t1,t0,2)
+        stash(t2,t1,t0,4)
+
+// Result term 5
+
+        xor     t0, t0
+        combadd2(t0,t2,t1,2,3)
+        stash(t0,t2,t1,5)
+
+// Result term 6
+
+        xor     t1, t1
+        combads(t1,t0,t2,3)
+        stash(t1,t0,t2,6)
+
+// Result term 7
+
+        stash(t2,t1,t0,7)
+
+// Return
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86/nonbmi_functions
+++ b/x86/nonbmi_functions
@@ -72,6 +72,7 @@ bignum_montmul
 bignum_montredc
 bignum_montsqr
 bignum_mul
+bignum_mul_4_8_alt
 bignum_muladd10
 bignum_mux
 bignum_mux16
@@ -100,6 +101,7 @@ bignum_pow2
 bignum_shl_small
 bignum_shr_small
 bignum_sqr
+bignum_sqr_4_8_alt
 bignum_sub
 bignum_sub_p256
 bignum_sub_p256k1

--- a/x86/proofs/bignum_mul_4_8_alt.ml
+++ b/x86/proofs/bignum_mul_4_8_alt.ml
@@ -1,0 +1,177 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* 4x4->8 multiplication using traditional x86 mul instructions.             *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "x86/fastmul/bignum_mul_4_8_alt.o";;
+ ****)
+
+let bignum_mul_4_8_alt_mc =
+  define_assert_from_elf "bignum_mul_4_8_alt_mc" "x86/fastmul/bignum_mul_4_8_alt.o"
+[
+  0x48; 0x89; 0xd1;        (* MOV (% rcx) (% rdx) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x21;        (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,0))) *)
+  0x48; 0x89; 0x07;        (* MOV (Memop Quadword (%% (rdi,0))) (% rax) *)
+  0x49; 0x89; 0xd0;        (* MOV (% r8) (% rdx) *)
+  0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
+  0x4d; 0x31; 0xd2;        (* XOR (% r10) (% r10) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x61; 0x08;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,8))) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x4d; 0x11; 0xd2;        (* ADC (% r10) (% r10) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x21;        (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,0))) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x49; 0x83; 0xd2; 0x00;  (* ADC (% r10) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x47; 0x08;  (* MOV (Memop Quadword (%% (rdi,8))) (% r8) *)
+  0x4d; 0x31; 0xc0;        (* XOR (% r8) (% r8) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x61; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,16))) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x61; 0x08;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,8))) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0x21;        (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,0))) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x4f; 0x10;  (* MOV (Memop Quadword (%% (rdi,16))) (% r9) *)
+  0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x61; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,24))) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x61; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,16))) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0x61; 0x08;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,8))) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0x21;        (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,0))) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x57; 0x18;  (* MOV (Memop Quadword (%% (rdi,24))) (% r10) *)
+  0x4d; 0x31; 0xd2;        (* XOR (% r10) (% r10) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x61; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,24))) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x49; 0x83; 0xd2; 0x00;  (* ADC (% r10) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0x61; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,16))) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x49; 0x83; 0xd2; 0x00;  (* ADC (% r10) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0x61; 0x08;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,8))) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x49; 0x83; 0xd2; 0x00;  (* ADC (% r10) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x47; 0x20;  (* MOV (Memop Quadword (%% (rdi,32))) (% r8) *)
+  0x4d; 0x31; 0xc0;        (* XOR (% r8) (% r8) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0x61; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,24))) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0x61; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,16))) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x4f; 0x28;  (* MOV (Memop Quadword (%% (rdi,40))) (% r9) *)
+  0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0x61; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rcx,24))) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x4c; 0x89; 0x57; 0x30;  (* MOV (Memop Quadword (%% (rdi,48))) (% r10) *)
+  0x4c; 0x89; 0x47; 0x38;  (* MOV (Memop Quadword (%% (rdi,56))) (% r8) *)
+  0xc3                     (* RET *)
+];;
+
+let BIGNUM_MUL_4_8_ALT_EXEC = X86_MK_EXEC_RULE bignum_mul_4_8_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_MUL_4_8_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+     ALL (nonoverlapping (z,8 * 8))
+         [(word pc,0x144); (x,8 * 4); (y,8 * 4)]
+     ==> ensures x86
+          (\s. bytes_loaded s (word pc) bignum_mul_4_8_alt_mc /\
+               read RIP s = word pc /\
+               C_ARGUMENTS [z; x; y] s /\
+               bignum_from_memory (x,4) s = a /\
+               bignum_from_memory (y,4) s = b)
+          (\s. read RIP s = word (pc + 0x143) /\
+               bignum_from_memory (z,8) s = a * b)
+          (MAYCHANGE [RIP; RAX; RCX; RDX; R8; R9; R10] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; ALL; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+  X86_ACCSTEPS_TAC BIGNUM_MUL_4_8_ALT_EXEC (1--93) (1--93) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  MAP_EVERY EXPAND_TAC ["a"; "b"] THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC);;
+
+let BIGNUM_MUL_4_8_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc stackpointer returnaddress.
+     ALL (nonoverlapping (z,8 * 8))
+         [(word pc,0x144); (x,8 * 4); (y,8 * 4); (stackpointer,8)]
+     ==> ensures x86
+          (\s. bytes_loaded s (word pc) bignum_mul_4_8_alt_mc /\
+               read RIP s = word pc /\
+               read RSP s = stackpointer /\
+               read (memory :> bytes64 stackpointer) s = returnaddress /\
+               C_ARGUMENTS [z; x; y] s /\
+               bignum_from_memory (x,4) s = a /\
+               bignum_from_memory (y,4) s = b)
+          (\s. read RIP s = returnaddress /\
+               read RSP s = word_add stackpointer (word 8) /\
+               bignum_from_memory (z,8) s = a * b)
+          (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9; R10] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_NOSTACK_TAC BIGNUM_MUL_4_8_ALT_EXEC
+     BIGNUM_MUL_4_8_ALT_CORRECT);;

--- a/x86/proofs/bignum_sqr_4_8_alt.ml
+++ b/x86/proofs/bignum_sqr_4_8_alt.ml
@@ -1,0 +1,158 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* 4x4->8 squaring using traditional x86 mul instructions.                   *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "x86/fastmul/bignum_sqr_4_8_alt.o";;
+ ****)
+
+let bignum_sqr_4_8_alt_mc =
+  define_assert_from_elf "bignum_sqr_4_8_alt_mc" "x86/fastmul/bignum_sqr_4_8_alt.o"
+[
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x48; 0x89; 0x07;        (* MOV (Memop Quadword (%% (rdi,0))) (% rax) *)
+  0x48; 0x89; 0xd1;        (* MOV (% rcx) (% rdx) *)
+  0x4d; 0x31; 0xc0;        (* XOR (% r8) (% r8) *)
+  0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x66; 0x08;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x01; 0xc1;        (* ADD (% rcx) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x89; 0x4f; 0x08;  (* MOV (Memop Quadword (%% (rdi,8))) (% rcx) *)
+  0x48; 0x31; 0xc9;        (* XOR (% rcx) (% rcx) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x48; 0x83; 0xd1; 0x00;  (* ADC (% rcx) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x66; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x48; 0x83; 0xd1; 0x00;  (* ADC (% rcx) (Imm8 (word 0)) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x48; 0x83; 0xd1; 0x00;  (* ADC (% rcx) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x47; 0x10;  (* MOV (Memop Quadword (%% (rdi,16))) (% r8) *)
+  0x4d; 0x31; 0xc0;        (* XOR (% r8) (% r8) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0x66; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x48; 0x11; 0xd1;        (* ADC (% rcx) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x66; 0x10;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x48; 0x11; 0xd1;        (* ADC (% rcx) (% rdx) *)
+  0x49; 0x83; 0xd0; 0x00;  (* ADC (% r8) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x4f; 0x18;  (* MOV (Memop Quadword (%% (rdi,24))) (% r9) *)
+  0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0x66; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x01; 0xc1;        (* ADD (% rcx) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x48; 0x01; 0xc1;        (* ADD (% rcx) (% rax) *)
+  0x49; 0x11; 0xd0;        (* ADC (% r8) (% rdx) *)
+  0x49; 0x83; 0xd1; 0x00;  (* ADC (% r9) (Imm8 (word 0)) *)
+  0x48; 0x89; 0x4f; 0x20;  (* MOV (Memop Quadword (%% (rdi,32))) (% rcx) *)
+  0x48; 0x31; 0xc9;        (* XOR (% rcx) (% rcx) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0x66; 0x18;  (* MUL2 (% rdx,% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0x01; 0xc0;        (* ADD (% rax) (% rax) *)
+  0x48; 0x11; 0xd2;        (* ADC (% rdx) (% rdx) *)
+  0x48; 0x83; 0xd1; 0x00;  (* ADC (% rcx) (Imm8 (word 0)) *)
+  0x49; 0x01; 0xc0;        (* ADD (% r8) (% rax) *)
+  0x49; 0x11; 0xd1;        (* ADC (% r9) (% rdx) *)
+  0x48; 0x83; 0xd1; 0x00;  (* ADC (% rcx) (Imm8 (word 0)) *)
+  0x4c; 0x89; 0x47; 0x28;  (* MOV (Memop Quadword (%% (rdi,40))) (% r8) *)
+  0x4d; 0x31; 0xc0;        (* XOR (% r8) (% r8) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x48; 0x11; 0xd1;        (* ADC (% rcx) (% rdx) *)
+  0x4c; 0x89; 0x4f; 0x30;  (* MOV (Memop Quadword (%% (rdi,48))) (% r9) *)
+  0x48; 0x89; 0x4f; 0x38;  (* MOV (Memop Quadword (%% (rdi,56))) (% rcx) *)
+  0xc3                     (* RET *)
+];;
+
+let BIGNUM_SQR_4_8_ALT_EXEC = X86_MK_EXEC_RULE bignum_sqr_4_8_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_SQR_4_8_ALT_CORRECT = time prove
+ (`!z x a pc.
+     ALL (nonoverlapping (z,8 * 8)) [(word pc,0x112); (x,8 * 4)]
+     ==> ensures x86
+          (\s. bytes_loaded s (word pc) bignum_sqr_4_8_alt_mc /\
+               read RIP s = word pc /\
+               C_ARGUMENTS [z; x] s /\
+               bignum_from_memory (x,4) s = a)
+          (\s. read RIP s = word (pc + 0x111) /\
+               bignum_from_memory (z,8) s = a EXP 2)
+          (MAYCHANGE [RIP; RAX; RCX; RDX; R8; R9] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; ALL; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  X86_ACCSTEPS_TAC BIGNUM_SQR_4_8_ALT_EXEC (1--80) (1--80) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  EXPAND_TAC "a" THEN REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC);;
+
+let BIGNUM_SQR_4_8_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc stackpointer returnaddress.
+     ALL (nonoverlapping (z,8 * 8))
+         [(word pc,0x112); (x,8 * 4); (stackpointer,8)]
+     ==> ensures x86
+          (\s. bytes_loaded s (word pc) bignum_sqr_4_8_alt_mc /\
+               read RIP s = word pc /\
+               read RSP s = stackpointer /\
+               read (memory :> bytes64 stackpointer) s = returnaddress /\
+               C_ARGUMENTS [z; x] s /\
+               bignum_from_memory (x,4) s = a)
+          (\s. read RIP s = returnaddress /\
+               read RSP s = word_add stackpointer (word 8) /\
+               bignum_from_memory (z,8) s = a EXP 2)
+          (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9] ,,
+           MAYCHANGE [memory :> bytes(z,8 * 8)] ,,
+           MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_NOSTACK_TAC BIGNUM_SQR_4_8_ALT_EXEC
+    BIGNUM_SQR_4_8_ALT_CORRECT);;

--- a/x86_att/Makefile
+++ b/x86_att/Makefile
@@ -21,9 +21,11 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       fastmul/bignum_ksqr_16_32.o \
       fastmul/bignum_ksqr_32_64.o \
       fastmul/bignum_mul_4_8.o \
+      fastmul/bignum_mul_4_8_alt.o \
       fastmul/bignum_mul_6_12.o \
       fastmul/bignum_mul_8_16.o \
       fastmul/bignum_sqr_4_8.o \
+      fastmul/bignum_sqr_4_8_alt.o \
       fastmul/bignum_sqr_6_12.o \
       fastmul/bignum_sqr_8_16.o \
       generic/bignum_add.o \

--- a/x86_att/fastmul/bignum_mul_4_8_alt.S
+++ b/x86_att/fastmul/bignum_mul_4_8_alt.S
@@ -1,0 +1,146 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Multiply z := x * y
+// Inputs x[4], y[4]; output z[8]
+//
+//    extern void bignum_mul_4_8_alt
+//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_mul_4_8_alt
+        .text
+
+// These are actually right
+
+#define z %rdi
+#define x %rsi
+
+// This is moved from %rdx to free it for muls
+
+#define y %rcx
+
+// Other variables used as a rotating 3-word window to add terms to
+
+#define t0 %r8
+#define t1 %r9
+#define t2 %r10
+
+// Macro for the key "multiply and add to (c,h,l)" step
+
+#define combadd(c,h,l,I,J)                      \
+        movq    8*I(x), %rax ;                   \
+        mulq     8*J(y);              \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A minutely shorter form for the very first term where c = 0 initially
+
+#define combadz(c,h,l,I,J)                      \
+        movq    8*I(x), %rax ;                   \
+        mulq     8*J(y);              \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    c, c
+
+// A short form for the very last term where we don't expect a top carry
+
+#define combads(c,h,l,I,J)                      \
+        movq    8*I(x), %rax ;                   \
+        mulq     8*J(y);              \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+// Stash the result
+
+#define stash(c,h,l,I)                          \
+        movq    l, 8*I(z)
+
+bignum_mul_4_8_alt:
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Result term 0
+
+        movq    (x), %rax
+        mulq     (y)
+
+        movq    %rax, (z)
+        movq    %rdx, t0
+        xorq    t1, t1
+
+// Result term 1
+
+       xorq    t2, t2
+       combadz(t2,t1,t0,0,1)
+       combadd(t2,t1,t0,1,0)
+       stash(t2,t1,t0,1)
+
+// Result term 2
+
+        xorq    t0, t0
+        combadd(t0,t2,t1,0,2)
+        combadd(t0,t2,t1,1,1)
+        combadd(t0,t2,t1,2,0)
+        stash(t0,t2,t1,2)
+
+// Result term 3
+
+        xorq    t1, t1
+        combadd(t1,t0,t2,0,3)
+        combadd(t1,t0,t2,1,2)
+        combadd(t1,t0,t2,2,1)
+        combadd(t1,t0,t2,3,0)
+        stash(t1,t0,t2,3)
+
+// Result term 4
+
+        xorq    t2, t2
+        combadd(t2,t1,t0,1,3)
+        combadd(t2,t1,t0,2,2)
+        combadd(t2,t1,t0,3,1)
+        stash(t2,t1,t0,4)
+
+// Result term 5
+
+        xorq    t0, t0
+        combadd(t0,t2,t1,2,3)
+        combadd(t0,t2,t1,3,2)
+        stash(t0,t2,t1,5)
+
+// Result term 6
+
+        xorq    t1, t1
+        combads(t1,t0,t2,3,3)
+        stash(t1,t0,t2,6)
+
+// Result term 7
+
+        stash(t2,t1,t0,7)
+
+// Return
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86_att/fastmul/bignum_sqr_4_8_alt.S
+++ b/x86_att/fastmul/bignum_sqr_4_8_alt.S
@@ -1,0 +1,135 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Square, z := x^2
+// Input x[4]; output z[8]
+//
+//    extern void bignum_sqr_4_8_alt
+//     (uint64_t z[static 8], uint64_t x[static 4]);
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_sqr_4_8_alt
+        .text
+
+// Input arguments
+
+#define z %rdi
+#define x %rsi
+
+// Other variables used as a rotating 3-word window to add terms to
+
+#define t0 %rcx
+#define t1 %r8
+#define t2 %r9
+
+// Macro for the key "multiply and add to (c,h,l)" step, for square term
+
+#define combadd1(c,h,l,I)                       \
+        movq    8*I(x), %rax ;                   \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// A short form for the very last term where we don't expect a top carry
+
+#define combads(c,h,l,I)                        \
+        movq    8*I(x), %rax ;                   \
+        mulq    %rax;                            \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h
+
+// A version doubling before adding, for non-square terms
+
+#define combadd2(c,h,l,I,J)                     \
+        movq    8*I(x), %rax ;                   \
+        mulq     8*J(x);              \
+        addq    %rax, %rax ;                       \
+        adcq    %rdx, %rdx ;                       \
+        adcq    $0, c ;                           \
+        addq    %rax, l ;                         \
+        adcq    %rdx, h ;                         \
+        adcq    $0, c
+
+// Stash the result
+
+#define stash(c,h,l,I)                          \
+        movq    l, 8*I(z)
+
+bignum_sqr_4_8_alt:
+
+// Result term 0
+
+        movq    (x), %rax
+        mulq    %rax
+
+        movq    %rax, (z)
+        movq    %rdx, t0
+        xorq    t1, t1
+
+// Result term 1
+
+       xorq    t2, t2
+       combadd2(t2,t1,t0,0,1)
+       stash(t2,t1,t0,1)
+
+// Result term 2
+
+        xorq    t0, t0
+        combadd1(t0,t2,t1,1)
+        combadd2(t0,t2,t1,0,2)
+        stash(t0,t2,t1,2)
+
+// Result term 3
+
+        xorq    t1, t1
+        combadd2(t1,t0,t2,0,3)
+        combadd2(t1,t0,t2,1,2)
+        stash(t1,t0,t2,3)
+
+// Result term 4
+
+        xorq    t2, t2
+        combadd2(t2,t1,t0,1,3)
+        combadd1(t2,t1,t0,2)
+        stash(t2,t1,t0,4)
+
+// Result term 5
+
+        xorq    t0, t0
+        combadd2(t0,t2,t1,2,3)
+        stash(t0,t2,t1,5)
+
+// Result term 6
+
+        xorq    t1, t1
+        combads(t1,t0,t2,3)
+        stash(t1,t0,t2,6)
+
+// Result term 7
+
+        stash(t2,t1,t0,7)
+
+// Return
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
The new functions "bignum_mul_4_8_alt" and "bignum_sqr_4_8_alt"
are equivalent in arithmetic functionality to their non-"alt" forms.
But they are better suited to some other microarchitectures:

  - On x86, the "alt" ones can be used on any x86_64 machine, even
    if it does not support BMI or ADX instructions. The original
    non-"alt" ones are usually faster when these extensions are
    present, however.

  - On ARM, the "alt" forms suit microarchitectures with
    higher multiplier throughput, while the originals are
    optimized under the assumption that throughput, especially
    of umulh, is low.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
