### PR TITLE
Add alternative variants of P-256 Montgomery operations

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -166,7 +166,9 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       p256/bignum_mod_p256.o \
       p256/bignum_mod_p256_4.o \
       p256/bignum_montmul_p256.o \
+      p256/bignum_montmul_p256_alt.o \
       p256/bignum_montsqr_p256.o \
+      p256/bignum_montsqr_p256_alt.o \
       p256/bignum_mux_4.o \
       p256/bignum_neg_p256.o \
       p256/bignum_nonzero_4.o \

--- a/arm/p256/Makefile
+++ b/arm/p256/Makefile
@@ -44,7 +44,9 @@ OBJ = bignum_add_p256.o \
       bignum_mod_p256.o \
       bignum_mod_p256_4.o \
       bignum_montmul_p256.o \
+      bignum_montmul_p256_alt.o \
       bignum_montsqr_p256.o \
+      bignum_montsqr_p256_alt.o \
       bignum_mux_4.o \
       bignum_neg_p256.o \
       bignum_nonzero_4.o \

--- a/arm/p256/bignum_montmul_p256_alt.S
+++ b/arm/p256/bignum_montmul_p256_alt.S
@@ -1,0 +1,228 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^256) mod p_256
+// Inputs x[4], y[4]; output z[4]
+//
+//    extern void bignum_montmul_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
+// satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in
+// the "usual" case x < p_256 and y < p_256).
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montmul_p256_alt
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d3;d2;d1;d0] and returns result in [d4;d3;d2;d1], adding to the
+// existing contents of [d3;d2;d1] and generating d4 from zero, re-using
+// d0 as a temporary internally together with t0, t1 and t2.
+// It is fine for d4 to be the same register as d0, and it often is.
+// ---------------------------------------------------------------------------
+
+#define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
+/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
+/* First let [t2;t1] = 2^32 * w                                          */ \
+/* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
+                lsl     t1, d0, #32;                                        \
+                subs    t0, d0, t1;                                         \
+                lsr     t2, d0, #32;                                        \
+                sbc     d0, d0, t2;                                         \
+/* Hence [d4;..;d1] := [d3;d2;d1;0] + (2^256 - 2^224 + 2^192 + 2^96) * w */ \
+                adds    d1, d1, t1;                                         \
+                adcs    d2, d2, t2;                                         \
+                adcs    d3, d3, t0;                                         \
+                adc     d4, d0, xzr
+
+#define z x0
+#define x x1
+#define y x2
+
+#define a0 x3
+#define a1 x4
+#define a2 x5
+#define a3 x6
+#define b0 x7
+#define b1 x8
+#define b2 x9
+#define b3 x10
+
+#define h x11
+#define l x12
+
+#define u0 x13
+#define u1 x14
+#define u2 x15
+#define u3 x16
+
+// These alias to the input arguments when no longer needed
+
+#define u4 a0
+#define u5 a1
+#define u6 a2
+#define u7 a3
+
+bignum_montmul_p256_alt:
+
+// Load operands and set up row 0 = [u4;...;u0] = a0 * [b3;...;b0]
+
+                ldp     a0, a1, [x]
+                ldp     b0, b1, [y]
+
+                mul     u0, a0, b0
+                umulh   u1, a0, b0
+                mul     l, a0, b1
+                umulh   u2, a0, b1
+                adds    u1, u1, l
+
+                ldp     b2, b3, [y, #16]
+
+                mul     l, a0, b2
+                umulh   u3, a0, b2
+                adcs    u2, u2, l
+
+                mul     l, a0, b3
+                umulh   u4, a0, b3
+                adcs    u3, u3, l
+                adc     u4, u4, xzr
+
+                ldp     a2, a3, [x, #16]
+
+// Row 1 = [u5;...;u0] = [a1;a0] * [b3;...;b0]
+
+                mul     l, a1, b0
+                umulh   h, a1, b0
+                adds    u1, u1, l
+
+                adcs    u2, u2, h
+                mul     l, a1, b1
+                umulh   h, a1, b1
+                adc     h, h, xzr
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a1, b2
+                umulh   h, a1, b2
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a1, b3
+                umulh   h, a1, b3
+                adc     h, h, xzr
+                adds    u4, u4, l
+                adc     u5, h, xzr
+
+// Row 2 = [u6;...;u0] = [a2;a1;a0] * [b3;...;b0]
+
+                mul     l, a2, b0
+                umulh   h, a2, b0
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a2, b1
+                umulh   h, a2, b1
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a2, b2
+                umulh   h, a2, b2
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                mul     l, a2, b3
+                umulh   h, a2, b3
+                adc     h, h, xzr
+                adds    u5, u5, l
+                adc     u6, h, xzr
+
+// Row 3 = [u7;...;u0] = [a3;...a0] * [b3;...;b0]
+
+                mul     l, a3, b0
+                umulh   h, a3, b0
+                adds    u3, u3, l
+
+                adcs    u4, u4, h
+                mul     l, a3, b1
+                umulh   h, a3, b1
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                mul     l, a3, b2
+                umulh   h, a3, b2
+                adc     h, h, xzr
+                adds    u5, u5, l
+
+                adcs    u6, u6, h
+                mul     l, a3, b3
+                umulh   h, a3, b3
+                adc     h, h, xzr
+                adds    u6, u6, l
+                adc     u7, h, xzr
+
+// Perform 4 Montgomery steps to rotate the lower half
+
+                montreds(u0,u3,u2,u1,u0, h,l,y)
+                montreds(u1,u0,u3,u2,u1, h,l,y)
+                montreds(u2,u1,u0,u3,u2, h,l,y)
+                montreds(u3,u2,u1,u0,u3, h,l,y)
+
+// Add high and low parts, catching carry in y
+
+                adds    u0, u0, u4
+                adcs    u1, u1, u5
+                adcs    u2, u2, u6
+                adcs    u3, u3, u7
+                cset    y, cs
+
+// Set [h;0;l;-1] = p_256 and form [u7,u6,u5,u4] = [y;u3;u2;u1;u0] - p_256
+
+                mov     l, #0x00000000ffffffff
+                mov     h, #0xffffffff00000001
+
+                subs    u4, u0, #-1
+                sbcs    u5, u1, l
+                sbcs    u6, u2, xzr
+                sbcs    u7, u3, h
+                sbcs    xzr, y, xzr
+
+// Now CF is clear if the comparison carried so the original was fine
+// Otherwise take the form with p_256 subtracted.
+
+                csel    u0, u0, u4, cc
+                csel    u1, u1, u5, cc
+                csel    u2, u2, u6, cc
+                csel    u3, u3, u7, cc
+
+// Store back final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arm/p256/bignum_montsqr_p256_alt.S
+++ b/arm/p256/bignum_montsqr_p256_alt.S
@@ -1,0 +1,186 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^256) mod p_256
+// Input x[4]; output z[4]
+//
+//    extern void bignum_montsqr_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4]);
+//
+// Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
+// guaranteed in particular if x < p_256 initially (the "intended" case).
+//
+// Standard ARM ABI: X0 = z, X1 = x
+// ----------------------------------------------------------------------------
+
+        .globl  bignum_montsqr_p256_alt
+        .text
+        .balign 4
+
+// ---------------------------------------------------------------------------
+// Core one-step "short" Montgomery reduction macro. Takes input in
+// [d3;d2;d1;d0] and returns result in [d4;d3;d2;d1], adding to the
+// existing contents of [d3;d2;d1] and generating d4 from zero, re-using
+// d0 as a temporary internally together with t0 and t1.
+// It is fine for d4 to be the same register as d0, and it often is.
+// ---------------------------------------------------------------------------
+
+#define montreds(d4,d3,d2,d1,d0, t1,t0)                                     \
+                adds    d1, d1, d0, lsl #32;                                \
+                lsr     t1, d0, #32;                                        \
+                adcs    d2, d2, t1;                                         \
+                mov     t1, #0xFFFFFFFF00000001;                            \
+                mul     t0, d0, t1;                                         \
+                umulh   d4, d0, t1;                                         \
+                adcs    d3, d3, t0;                                         \
+                adc     d4, d4, xzr
+
+#define z x0
+#define x x1
+
+#define a0 x2
+#define a1 x3
+#define a2 x4
+#define a3 x5
+
+#define l x6
+#define h x7
+
+#define u0 x8
+#define u1 x9
+#define u2 x10
+#define u3 x11
+#define u4 x12
+#define u5 x13
+#define u6 x14
+
+// This one is the same as h, which is safe with this computation sequence
+
+#define u7 h
+
+bignum_montsqr_p256_alt:
+
+// Load all the elements, set up an initial window [u6;...u1] = [23;03;01]
+// and chain in the addition of 02 + 12 + 13 (no carry-out is possible).
+// This gives all the "heterogeneous" terms of the squaring ready to double
+
+                ldp     a0, a1, [x]
+
+                mul     u1, a0, a1
+                umulh   u2, a0, a1
+
+                ldp     a2, a3, [x, #16]
+
+                mul     u3, a0, a3
+                umulh   u4, a0, a3
+
+                mul     l, a0, a2
+                umulh   h, a0, a2
+                adds    u2, u2, l
+
+                adcs    u3, u3, h
+                mul     l, a1, a2
+                umulh   h, a1, a2
+                adc     h, h, xzr
+                adds    u3, u3, l
+
+                mul     u5, a2, a3
+                umulh   u6, a2, a3
+
+                adcs    u4, u4, h
+                mul     l, a1, a3
+                umulh   h, a1, a3
+                adc     h, h, xzr
+                adds    u4, u4, l
+
+                adcs    u5, u5, h
+                adc     u6, u6, xzr
+
+// Now just double it; this simple approach seems to work better than extr
+
+                adds    u1, u1, u1
+                adcs    u2, u2, u2
+                adcs    u3, u3, u3
+                adcs    u4, u4, u4
+                adcs    u5, u5, u5
+                adcs    u6, u6, u6
+                cset    u7, cs
+
+// Add the homogeneous terms 00 + 11 + 22 + 33
+
+                umulh   l, a0, a0
+                mul     u0, a0, a0
+                adds    u1, u1, l
+
+                mul     l, a1, a1
+                adcs    u2, u2, l
+                umulh   l, a1, a1
+                adcs    u3, u3, l
+
+                mul     l, a2, a2
+                adcs    u4, u4, l
+                umulh   l, a2, a2
+                adcs    u5, u5, l
+
+                mul     l, a3, a3
+                adcs    u6, u6, l
+                umulh   l, a3, a3
+                adc     u7, u7, l
+
+// Squaring complete. Perform 4 Montgomery steps to rotate the lower half
+
+                montreds(u0,u3,u2,u1,u0, a1,a0)
+                montreds(u1,u0,u3,u2,u1, a1,a0)
+                montreds(u2,u1,u0,u3,u2, a1,a0)
+                montreds(u3,u2,u1,u0,u3, a1,a0)
+
+// Add high and low parts, catching carry in a0
+
+                adds    u0, u0, u4
+                adcs    u1, u1, u5
+                adcs    u2, u2, u6
+                adcs    u3, u3, u7
+                cset    a0, cs
+
+// Set [a3;0;a1;-1] = p_256 and form [u7,u6,u5,u4] = [a0;u3;u2;u1;u0] - p_256
+
+                mov     a1, #0x00000000ffffffff
+                mov     a3, #0xffffffff00000001
+
+                subs    u4, u0, #-1
+                sbcs    u5, u1, a1
+                sbcs    u6, u2, xzr
+                sbcs    u7, u3, a3
+                sbcs    xzr, a0, xzr
+
+// Now CF is clear if the comparison carried so the original was fine
+// Otherwise take the form with p_256 subtracted.
+
+                csel    u0, u0, u4, cc
+                csel    u1, u1, u5, cc
+                csel    u2, u2, u6, cc
+                csel    u3, u3, u7, cc
+
+// Store back final result
+
+                stp     u0, u1, [z]
+                stp     u2, u3, [z, #16]
+
+                ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/arm/proofs/bignum_montmul_p256_alt.ml
+++ b/arm/proofs/bignum_montmul_p256_alt.ml
@@ -1,0 +1,398 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* Montgomery multiplication modulo p_256.                                   *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "arm/p256/bignum_montmul_p256_alt.o";;
+ ****)
+
+let bignum_montmul_p256_alt_mc =
+  define_assert_from_elf "bignum_montmul_p256_alt_mc" "arm/p256/bignum_montmul_p256_alt.o"
+[
+  0xa9401023;       (* arm_LDP X3 X4 X1 (Immediate_Offset (iword (&0))) *)
+  0xa9402047;       (* arm_LDP X7 X8 X2 (Immediate_Offset (iword (&0))) *)
+  0x9b077c6d;       (* arm_MUL X13 X3 X7 *)
+  0x9bc77c6e;       (* arm_UMULH X14 X3 X7 *)
+  0x9b087c6c;       (* arm_MUL X12 X3 X8 *)
+  0x9bc87c6f;       (* arm_UMULH X15 X3 X8 *)
+  0xab0c01ce;       (* arm_ADDS X14 X14 X12 *)
+  0xa9412849;       (* arm_LDP X9 X10 X2 (Immediate_Offset (iword (&16))) *)
+  0x9b097c6c;       (* arm_MUL X12 X3 X9 *)
+  0x9bc97c70;       (* arm_UMULH X16 X3 X9 *)
+  0xba0c01ef;       (* arm_ADCS X15 X15 X12 *)
+  0x9b0a7c6c;       (* arm_MUL X12 X3 X10 *)
+  0x9bca7c63;       (* arm_UMULH X3 X3 X10 *)
+  0xba0c0210;       (* arm_ADCS X16 X16 X12 *)
+  0x9a1f0063;       (* arm_ADC X3 X3 XZR *)
+  0xa9411825;       (* arm_LDP X5 X6 X1 (Immediate_Offset (iword (&16))) *)
+  0x9b077c8c;       (* arm_MUL X12 X4 X7 *)
+  0x9bc77c8b;       (* arm_UMULH X11 X4 X7 *)
+  0xab0c01ce;       (* arm_ADDS X14 X14 X12 *)
+  0xba0b01ef;       (* arm_ADCS X15 X15 X11 *)
+  0x9b087c8c;       (* arm_MUL X12 X4 X8 *)
+  0x9bc87c8b;       (* arm_UMULH X11 X4 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c01ef;       (* arm_ADDS X15 X15 X12 *)
+  0xba0b0210;       (* arm_ADCS X16 X16 X11 *)
+  0x9b097c8c;       (* arm_MUL X12 X4 X9 *)
+  0x9bc97c8b;       (* arm_UMULH X11 X4 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b0a7c8c;       (* arm_MUL X12 X4 X10 *)
+  0x9bca7c8b;       (* arm_UMULH X11 X4 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0x9a1f0164;       (* arm_ADC X4 X11 XZR *)
+  0x9b077cac;       (* arm_MUL X12 X5 X7 *)
+  0x9bc77cab;       (* arm_UMULH X11 X5 X7 *)
+  0xab0c01ef;       (* arm_ADDS X15 X15 X12 *)
+  0xba0b0210;       (* arm_ADCS X16 X16 X11 *)
+  0x9b087cac;       (* arm_MUL X12 X5 X8 *)
+  0x9bc87cab;       (* arm_UMULH X11 X5 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b097cac;       (* arm_MUL X12 X5 X9 *)
+  0x9bc97cab;       (* arm_UMULH X11 X5 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0xba0b0084;       (* arm_ADCS X4 X4 X11 *)
+  0x9b0a7cac;       (* arm_MUL X12 X5 X10 *)
+  0x9bca7cab;       (* arm_UMULH X11 X5 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0084;       (* arm_ADDS X4 X4 X12 *)
+  0x9a1f0165;       (* arm_ADC X5 X11 XZR *)
+  0x9b077ccc;       (* arm_MUL X12 X6 X7 *)
+  0x9bc77ccb;       (* arm_UMULH X11 X6 X7 *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b0063;       (* arm_ADCS X3 X3 X11 *)
+  0x9b087ccc;       (* arm_MUL X12 X6 X8 *)
+  0x9bc87ccb;       (* arm_UMULH X11 X6 X8 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0063;       (* arm_ADDS X3 X3 X12 *)
+  0xba0b0084;       (* arm_ADCS X4 X4 X11 *)
+  0x9b097ccc;       (* arm_MUL X12 X6 X9 *)
+  0x9bc97ccb;       (* arm_UMULH X11 X6 X9 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0084;       (* arm_ADDS X4 X4 X12 *)
+  0xba0b00a5;       (* arm_ADCS X5 X5 X11 *)
+  0x9b0a7ccc;       (* arm_MUL X12 X6 X10 *)
+  0x9bca7ccb;       (* arm_UMULH X11 X6 X10 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c00a5;       (* arm_ADDS X5 X5 X12 *)
+  0x9a1f0166;       (* arm_ADC X6 X11 XZR *)
+  0xd3607dac;       (* arm_LSL X12 X13 32 *)
+  0xeb0c01a2;       (* arm_SUBS X2 X13 X12 *)
+  0xd360fdab;       (* arm_LSR X11 X13 32 *)
+  0xda0b01ad;       (* arm_SBC X13 X13 X11 *)
+  0xab0c01ce;       (* arm_ADDS X14 X14 X12 *)
+  0xba0b01ef;       (* arm_ADCS X15 X15 X11 *)
+  0xba020210;       (* arm_ADCS X16 X16 X2 *)
+  0x9a1f01ad;       (* arm_ADC X13 X13 XZR *)
+  0xd3607dcc;       (* arm_LSL X12 X14 32 *)
+  0xeb0c01c2;       (* arm_SUBS X2 X14 X12 *)
+  0xd360fdcb;       (* arm_LSR X11 X14 32 *)
+  0xda0b01ce;       (* arm_SBC X14 X14 X11 *)
+  0xab0c01ef;       (* arm_ADDS X15 X15 X12 *)
+  0xba0b0210;       (* arm_ADCS X16 X16 X11 *)
+  0xba0201ad;       (* arm_ADCS X13 X13 X2 *)
+  0x9a1f01ce;       (* arm_ADC X14 X14 XZR *)
+  0xd3607dec;       (* arm_LSL X12 X15 32 *)
+  0xeb0c01e2;       (* arm_SUBS X2 X15 X12 *)
+  0xd360fdeb;       (* arm_LSR X11 X15 32 *)
+  0xda0b01ef;       (* arm_SBC X15 X15 X11 *)
+  0xab0c0210;       (* arm_ADDS X16 X16 X12 *)
+  0xba0b01ad;       (* arm_ADCS X13 X13 X11 *)
+  0xba0201ce;       (* arm_ADCS X14 X14 X2 *)
+  0x9a1f01ef;       (* arm_ADC X15 X15 XZR *)
+  0xd3607e0c;       (* arm_LSL X12 X16 32 *)
+  0xeb0c0202;       (* arm_SUBS X2 X16 X12 *)
+  0xd360fe0b;       (* arm_LSR X11 X16 32 *)
+  0xda0b0210;       (* arm_SBC X16 X16 X11 *)
+  0xab0c01ad;       (* arm_ADDS X13 X13 X12 *)
+  0xba0b01ce;       (* arm_ADCS X14 X14 X11 *)
+  0xba0201ef;       (* arm_ADCS X15 X15 X2 *)
+  0x9a1f0210;       (* arm_ADC X16 X16 XZR *)
+  0xab0301ad;       (* arm_ADDS X13 X13 X3 *)
+  0xba0401ce;       (* arm_ADCS X14 X14 X4 *)
+  0xba0501ef;       (* arm_ADCS X15 X15 X5 *)
+  0xba060210;       (* arm_ADCS X16 X16 X6 *)
+  0x9a9f37e2;       (* arm_CSET X2 Condition_CS *)
+  0xb2407fec;       (* arm_MOV X12 (rvalue (word 4294967295)) *)
+  0xb26083eb;       (* arm_MOV X11 (rvalue (word 18446744069414584321)) *)
+  0xb10005a3;       (* arm_ADDS X3 X13 (rvalue (word 1)) *)
+  0xfa0c01c4;       (* arm_SBCS X4 X14 X12 *)
+  0xfa1f01e5;       (* arm_SBCS X5 X15 XZR *)
+  0xfa0b0206;       (* arm_SBCS X6 X16 X11 *)
+  0xfa1f005f;       (* arm_SBCS XZR X2 XZR *)
+  0x9a8331ad;       (* arm_CSEL X13 X13 X3 Condition_CC *)
+  0x9a8431ce;       (* arm_CSEL X14 X14 X4 Condition_CC *)
+  0x9a8531ef;       (* arm_CSEL X15 X15 X5 Condition_CC *)
+  0x9a863210;       (* arm_CSEL X16 X16 X6 Condition_CC *)
+  0xa900380d;       (* arm_STP X13 X14 X0 (Immediate_Offset (iword (&0))) *)
+  0xa901400f;       (* arm_STP X15 X16 X0 (Immediate_Offset (iword (&16))) *)
+  0xd65f03c0        (* arm_RET X30 *)
+];;
+
+let BIGNUM_MONTMUL_P256_ALT_EXEC = ARM_MK_EXEC_RULE bignum_montmul_p256_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let p_256 = new_definition `p_256 = 115792089210356248762697446949407573530086143415290314195533631308867097853951`;;
+
+let BIGNUM_MONTMUL_P256_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+        nonoverlapping (word pc,0x1f0) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read PC s = word pc /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read PC s = word (pc + 0x1ec) /\
+                  (a * b <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a * b) MOD p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14; X15; X16] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (*** Globalize the a * b <= 2 EXP 256 * p_256  assumption ***)
+
+  ASM_CASES_TAC `a * b <= 2 EXP 256 * p_256` THENL
+   [ASM_REWRITE_TAC[]; ARM_SIM_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (1--123)] THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+
+  (*** Simulate the core pre-reduced result accumulation ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (1--110) (1--110) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[WORD_UNMASK_64]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s106; sum_s107; sum_s108; sum_s109;
+           word(bitval carry_s109)]` THEN
+  SUBGOAL_THEN
+   `t < 2 * p_256 /\ (2 EXP 256 * t == a * b) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (ARITH_RULE
+        `ab <= 2 EXP 256 * p
+         ==> 2 EXP 256 * t < ab + 2 EXP 256 * p ==> t < 2 * p`)) THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (113--117) (111--123) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE
+   [GSYM WORD_BITVAL; COND_SWAP; REAL_BITVAL_NOT]) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  TRANS_TAC EQ_TRANS `t MOD p_256` THEN CONJ_TAC THENL
+   [ALL_TAC;
+    REWRITE_TAC[GSYM CONG] THEN FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == a * b) (mod p)
+        ==> (e * i == 1) (mod p) ==> (t == i * a * b) (mod p)`)) THEN
+    REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+    REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV] THEN
+  CONV_TAC SYM_CONV THEN MATCH_MP_TAC EQUAL_FROM_CONGRUENT_MOD_MOD THEN
+  MAP_EVERY EXISTS_TAC
+   [`256`; `if t < p_256 then &t:real else &t - &p_256`] THEN
+  REPEAT CONJ_TAC THENL
+   [REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    ALL_TAC;
+    ASM_SIMP_TAC[MOD_CASES] THEN
+    GEN_REWRITE_TAC LAND_CONV [COND_RAND] THEN
+    SIMP_TAC[REAL_OF_NUM_SUB; GSYM NOT_LT]] THEN
+  SUBGOAL_THEN `carry_s117 <=> t < p_256` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LT THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN REWRITE_TAC[VAL_WORD_BITVAL] THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN EXPAND_TAC "t" THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist; p_256] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  ASM_REWRITE_TAC[BITVAL_CLAUSES; VAL_WORD_BITVAL] THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_MONTMUL_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc returnaddress.
+        nonoverlapping (word pc,0x1f0) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read PC s = word pc /\
+                  read X30 s = returnaddress /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read PC s = returnaddress /\
+                  (a * b <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a * b) MOD p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14; X15; X16] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_MONTMUL_P256_ALT_EXEC
+    BIGNUM_MONTMUL_P256_ALT_CORRECT);;
+
+(* ------------------------------------------------------------------------- *)
+(* Show that it also works as "almost-Montgomery" if desired. That is, even  *)
+(* without the further range assumption on inputs we still get a congruence. *)
+(* But the output, still 256 bits, may then not be fully reduced mod p_256.  *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_AMONTMUL_P256_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+        nonoverlapping (word pc,0x1f0) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read PC s = word pc /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read PC s = word (pc + 0x1ec) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a * b) (mod p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14; X15; X16] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+
+ (*** Simulate the core pre-reduced result accumulation ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (1--110) (1--110) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[WORD_UNMASK_64]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s106; sum_s107; sum_s108; sum_s109;
+           word(bitval carry_s109)]` THEN
+  SUBGOAL_THEN
+   `t < 2 EXP 256 + p_256 /\ (2 EXP 256 * t == a * b) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [MATCH_MP_TAC(ARITH_RULE
+       `2 EXP 256 * t <= (2 EXP 256 - 1) EXP 2 + (2 EXP 256 - 1) * p
+        ==> t < 2 EXP 256 + p`) THEN
+      REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (113--117) (111--123) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE
+   [GSYM WORD_BITVAL; COND_SWAP; REAL_BITVAL_NOT]) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == ab) (mod p)
+        ==> (e * i == 1) (mod p) /\ (s == t) (mod p)
+            ==> (s == i * ab) (mod p)`)) THEN
+  REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+  CONJ_TAC THENL
+   [REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV; ALL_TAC] THEN
+  SUBGOAL_THEN `carry_s117 <=> t < p_256` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LT THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN REWRITE_TAC[VAL_WORD_BITVAL] THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  MATCH_MP_TAC(NUMBER_RULE `!b:num. x + b * p = y ==> (x == y) (mod p)`) THEN
+  EXISTS_TAC `bitval(p_256 <= t)` THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN REWRITE_TAC[REAL_OF_NUM_LE] THEN
+  ONCE_REWRITE_TAC[REAL_ARITH `a + b:real = c <=> c - b = a`] THEN
+  MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
+  MAP_EVERY EXISTS_TAC [`256`; `&0:real`] THEN CONJ_TAC THENL
+   [UNDISCH_TAC `t < 2 EXP 256 + p_256` THEN
+    REWRITE_TAC[bitval; p_256; GSYM REAL_OF_NUM_CLAUSES] THEN REAL_ARITH_TAC;
+    REWRITE_TAC[INTEGER_CLOSED]] THEN
+  CONJ_TAC THENL
+   [CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+    REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+  REWRITE_TAC[bitval; GSYM NOT_LT; COND_SWAP] THEN COND_CASES_TAC THEN
+  EXPAND_TAC "t" THEN REWRITE_TAC[bignum_of_wordlist] THEN
+  ASM_REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST (MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
+  REWRITE_TAC[BITVAL_CLAUSES; p_256] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_AMONTMUL_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc returnaddress.
+        nonoverlapping (word pc,0x1f0) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read PC s = word pc /\
+                  read X30 s = returnaddress /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read PC s = returnaddress /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a * b) (mod p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14; X15; X16] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_MONTMUL_P256_ALT_EXEC
+    BIGNUM_AMONTMUL_P256_ALT_CORRECT);;

--- a/arm/proofs/bignum_montsqr_p256_alt.ml
+++ b/arm/proofs/bignum_montsqr_p256_alt.ml
@@ -1,0 +1,361 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* Montgomery squaring modulo p_256.                                         *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "arm/p256/bignum_montsqr_p256_alt.o";;
+ ****)
+
+let bignum_montsqr_p256_alt_mc =
+  define_assert_from_elf "bignum_montsqr_p256_alt_mc" "arm/p256/bignum_montsqr_p256_alt.o"
+[
+  0xa9400c22;       (* arm_LDP X2 X3 X1 (Immediate_Offset (iword (&0))) *)
+  0x9b037c49;       (* arm_MUL X9 X2 X3 *)
+  0x9bc37c4a;       (* arm_UMULH X10 X2 X3 *)
+  0xa9411424;       (* arm_LDP X4 X5 X1 (Immediate_Offset (iword (&16))) *)
+  0x9b057c4b;       (* arm_MUL X11 X2 X5 *)
+  0x9bc57c4c;       (* arm_UMULH X12 X2 X5 *)
+  0x9b047c46;       (* arm_MUL X6 X2 X4 *)
+  0x9bc47c47;       (* arm_UMULH X7 X2 X4 *)
+  0xab06014a;       (* arm_ADDS X10 X10 X6 *)
+  0xba07016b;       (* arm_ADCS X11 X11 X7 *)
+  0x9b047c66;       (* arm_MUL X6 X3 X4 *)
+  0x9bc47c67;       (* arm_UMULH X7 X3 X4 *)
+  0x9a1f00e7;       (* arm_ADC X7 X7 XZR *)
+  0xab06016b;       (* arm_ADDS X11 X11 X6 *)
+  0x9b057c8d;       (* arm_MUL X13 X4 X5 *)
+  0x9bc57c8e;       (* arm_UMULH X14 X4 X5 *)
+  0xba07018c;       (* arm_ADCS X12 X12 X7 *)
+  0x9b057c66;       (* arm_MUL X6 X3 X5 *)
+  0x9bc57c67;       (* arm_UMULH X7 X3 X5 *)
+  0x9a1f00e7;       (* arm_ADC X7 X7 XZR *)
+  0xab06018c;       (* arm_ADDS X12 X12 X6 *)
+  0xba0701ad;       (* arm_ADCS X13 X13 X7 *)
+  0x9a1f01ce;       (* arm_ADC X14 X14 XZR *)
+  0xab090129;       (* arm_ADDS X9 X9 X9 *)
+  0xba0a014a;       (* arm_ADCS X10 X10 X10 *)
+  0xba0b016b;       (* arm_ADCS X11 X11 X11 *)
+  0xba0c018c;       (* arm_ADCS X12 X12 X12 *)
+  0xba0d01ad;       (* arm_ADCS X13 X13 X13 *)
+  0xba0e01ce;       (* arm_ADCS X14 X14 X14 *)
+  0x9a9f37e7;       (* arm_CSET X7 Condition_CS *)
+  0x9bc27c46;       (* arm_UMULH X6 X2 X2 *)
+  0x9b027c48;       (* arm_MUL X8 X2 X2 *)
+  0xab060129;       (* arm_ADDS X9 X9 X6 *)
+  0x9b037c66;       (* arm_MUL X6 X3 X3 *)
+  0xba06014a;       (* arm_ADCS X10 X10 X6 *)
+  0x9bc37c66;       (* arm_UMULH X6 X3 X3 *)
+  0xba06016b;       (* arm_ADCS X11 X11 X6 *)
+  0x9b047c86;       (* arm_MUL X6 X4 X4 *)
+  0xba06018c;       (* arm_ADCS X12 X12 X6 *)
+  0x9bc47c86;       (* arm_UMULH X6 X4 X4 *)
+  0xba0601ad;       (* arm_ADCS X13 X13 X6 *)
+  0x9b057ca6;       (* arm_MUL X6 X5 X5 *)
+  0xba0601ce;       (* arm_ADCS X14 X14 X6 *)
+  0x9bc57ca6;       (* arm_UMULH X6 X5 X5 *)
+  0x9a0600e7;       (* arm_ADC X7 X7 X6 *)
+  0xab088129;       (* arm_ADDS X9 X9 (Shiftedreg X8 LSL 32) *)
+  0xd360fd03;       (* arm_LSR X3 X8 32 *)
+  0xba03014a;       (* arm_ADCS X10 X10 X3 *)
+  0xb26083e3;       (* arm_MOV X3 (rvalue (word 18446744069414584321)) *)
+  0x9b037d02;       (* arm_MUL X2 X8 X3 *)
+  0x9bc37d08;       (* arm_UMULH X8 X8 X3 *)
+  0xba02016b;       (* arm_ADCS X11 X11 X2 *)
+  0x9a1f0108;       (* arm_ADC X8 X8 XZR *)
+  0xab09814a;       (* arm_ADDS X10 X10 (Shiftedreg X9 LSL 32) *)
+  0xd360fd23;       (* arm_LSR X3 X9 32 *)
+  0xba03016b;       (* arm_ADCS X11 X11 X3 *)
+  0xb26083e3;       (* arm_MOV X3 (rvalue (word 18446744069414584321)) *)
+  0x9b037d22;       (* arm_MUL X2 X9 X3 *)
+  0x9bc37d29;       (* arm_UMULH X9 X9 X3 *)
+  0xba020108;       (* arm_ADCS X8 X8 X2 *)
+  0x9a1f0129;       (* arm_ADC X9 X9 XZR *)
+  0xab0a816b;       (* arm_ADDS X11 X11 (Shiftedreg X10 LSL 32) *)
+  0xd360fd43;       (* arm_LSR X3 X10 32 *)
+  0xba030108;       (* arm_ADCS X8 X8 X3 *)
+  0xb26083e3;       (* arm_MOV X3 (rvalue (word 18446744069414584321)) *)
+  0x9b037d42;       (* arm_MUL X2 X10 X3 *)
+  0x9bc37d4a;       (* arm_UMULH X10 X10 X3 *)
+  0xba020129;       (* arm_ADCS X9 X9 X2 *)
+  0x9a1f014a;       (* arm_ADC X10 X10 XZR *)
+  0xab0b8108;       (* arm_ADDS X8 X8 (Shiftedreg X11 LSL 32) *)
+  0xd360fd63;       (* arm_LSR X3 X11 32 *)
+  0xba030129;       (* arm_ADCS X9 X9 X3 *)
+  0xb26083e3;       (* arm_MOV X3 (rvalue (word 18446744069414584321)) *)
+  0x9b037d62;       (* arm_MUL X2 X11 X3 *)
+  0x9bc37d6b;       (* arm_UMULH X11 X11 X3 *)
+  0xba02014a;       (* arm_ADCS X10 X10 X2 *)
+  0x9a1f016b;       (* arm_ADC X11 X11 XZR *)
+  0xab0c0108;       (* arm_ADDS X8 X8 X12 *)
+  0xba0d0129;       (* arm_ADCS X9 X9 X13 *)
+  0xba0e014a;       (* arm_ADCS X10 X10 X14 *)
+  0xba07016b;       (* arm_ADCS X11 X11 X7 *)
+  0x9a9f37e2;       (* arm_CSET X2 Condition_CS *)
+  0xb2407fe3;       (* arm_MOV X3 (rvalue (word 4294967295)) *)
+  0xb26083e5;       (* arm_MOV X5 (rvalue (word 18446744069414584321)) *)
+  0xb100050c;       (* arm_ADDS X12 X8 (rvalue (word 1)) *)
+  0xfa03012d;       (* arm_SBCS X13 X9 X3 *)
+  0xfa1f014e;       (* arm_SBCS X14 X10 XZR *)
+  0xfa050167;       (* arm_SBCS X7 X11 X5 *)
+  0xfa1f005f;       (* arm_SBCS XZR X2 XZR *)
+  0x9a8c3108;       (* arm_CSEL X8 X8 X12 Condition_CC *)
+  0x9a8d3129;       (* arm_CSEL X9 X9 X13 Condition_CC *)
+  0x9a8e314a;       (* arm_CSEL X10 X10 X14 Condition_CC *)
+  0x9a87316b;       (* arm_CSEL X11 X11 X7 Condition_CC *)
+  0xa9002408;       (* arm_STP X8 X9 X0 (Immediate_Offset (iword (&0))) *)
+  0xa9012c0a;       (* arm_STP X10 X11 X0 (Immediate_Offset (iword (&16))) *)
+  0xd65f03c0        (* arm_RET X30 *)
+];;
+
+let BIGNUM_MONTSQR_P256_ALT_EXEC = ARM_MK_EXEC_RULE bignum_montsqr_p256_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let p_256 = new_definition `p_256 = 115792089210356248762697446949407573530086143415290314195533631308867097853951`;;
+
+let BIGNUM_MONTSQR_P256_ALT_CORRECT = time prove
+ (`!z x a pc.
+        nonoverlapping (word pc,0x180) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read PC s = word pc /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read PC s = word (pc + 0x17c) /\
+                  (a EXP 2 <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a EXP 2) MOD p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (*** Globalize the a EXP 2 <= 2 EXP 256 * p_256  assumption ***)
+
+  ASM_CASES_TAC `a EXP 2 <= 2 EXP 256 * p_256` THENL
+   [ASM_REWRITE_TAC[]; ARM_SIM_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (1--95)] THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+
+  (*** Simulate the core pre-reduced result accumulation ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (1--82) (1--82) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[COND_SWAP; GSYM WORD_BITVAL]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s78; sum_s79; sum_s80; sum_s81; word(bitval carry_s81)]` THEN
+  SUBGOAL_THEN
+   `t < 2 * p_256 /\ (2 EXP 256 * t == a EXP 2) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (ARITH_RULE
+        `ab <= 2 EXP 256 * p
+         ==> 2 EXP 256 * t < ab + 2 EXP 256 * p ==> t < 2 * p`)) THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (85--89) (83--95) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE
+   [GSYM WORD_BITVAL; COND_SWAP; REAL_BITVAL_NOT]) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  TRANS_TAC EQ_TRANS `t MOD p_256` THEN CONJ_TAC THENL
+   [ALL_TAC;
+    REWRITE_TAC[GSYM CONG] THEN FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == a EXP 2) (mod p)
+        ==> (e * i == 1) (mod p) ==> (t == i * a EXP 2) (mod p)`)) THEN
+    REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+    REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV] THEN
+  CONV_TAC SYM_CONV THEN MATCH_MP_TAC EQUAL_FROM_CONGRUENT_MOD_MOD THEN
+  MAP_EVERY EXISTS_TAC
+   [`256`; `if t < p_256 then &t:real else &t - &p_256`] THEN
+  REPEAT CONJ_TAC THENL
+   [REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    ALL_TAC;
+    ASM_SIMP_TAC[MOD_CASES] THEN
+    GEN_REWRITE_TAC LAND_CONV [COND_RAND] THEN
+    SIMP_TAC[REAL_OF_NUM_SUB; GSYM NOT_LT]] THEN
+  SUBGOAL_THEN `carry_s89 <=> t < p_256` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LT THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN REWRITE_TAC[VAL_WORD_BITVAL] THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN EXPAND_TAC "t" THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist; p_256] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  ASM_REWRITE_TAC[BITVAL_CLAUSES; VAL_WORD_BITVAL] THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_MONTSQR_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc returnaddress.
+        nonoverlapping (word pc,0x180) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read PC s = word pc /\
+                  read X30 s = returnaddress /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read PC s = returnaddress /\
+                  (a EXP 2 <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a EXP 2) MOD p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_MONTSQR_P256_ALT_EXEC
+    BIGNUM_MONTSQR_P256_ALT_CORRECT);;
+
+(* ------------------------------------------------------------------------- *)
+(* Show that it also works as "almost-Montgomery" if desired. That is, even  *)
+(* without the further range assumption on inputs we still get a congruence. *)
+(* But the output, still 256 bits, may then not be fully reduced mod p_256.  *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_AMONTSQR_P256_ALT_CORRECT = time prove
+ (`!z x a pc.
+        nonoverlapping (word pc,0x180) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read PC s = word pc /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read PC s = word (pc + 0x17c) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a EXP 2) (mod p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+
+ (*** Simulate the core pre-reduced result accumulation ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (1--82) (1--82) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[COND_SWAP; GSYM WORD_BITVAL]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s78; sum_s79; sum_s80; sum_s81;
+           word(bitval carry_s81)]` THEN
+  SUBGOAL_THEN
+   `t < 2 EXP 256 + p_256 /\ (2 EXP 256 * t == a EXP 2) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [MATCH_MP_TAC(ARITH_RULE
+       `2 EXP 256 * t <= (2 EXP 256 - 1) EXP 2 + (2 EXP 256 - 1) * p
+        ==> t < 2 EXP 256 + p`) THEN
+      REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[VAL_WORD_BITVAL] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  ARM_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (85--89) (83--95) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE
+   [GSYM WORD_BITVAL; COND_SWAP; REAL_BITVAL_NOT]) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == ab) (mod p)
+        ==> (e * i == 1) (mod p) /\ (s == t) (mod p)
+            ==> (s == i * ab) (mod p)`)) THEN
+  REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+  CONJ_TAC THENL
+   [REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV; ALL_TAC] THEN
+  SUBGOAL_THEN `carry_s89 <=> t < p_256` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LT THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN REWRITE_TAC[VAL_WORD_BITVAL] THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  MATCH_MP_TAC(NUMBER_RULE `!b:num. x + b * p = y ==> (x == y) (mod p)`) THEN
+  EXISTS_TAC `bitval(p_256 <= t)` THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN REWRITE_TAC[REAL_OF_NUM_LE] THEN
+  ONCE_REWRITE_TAC[REAL_ARITH `a + b:real = c <=> c - b = a`] THEN
+  MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
+  MAP_EVERY EXISTS_TAC [`256`; `&0:real`] THEN CONJ_TAC THENL
+   [UNDISCH_TAC `t < 2 EXP 256 + p_256` THEN
+    REWRITE_TAC[bitval; p_256; GSYM REAL_OF_NUM_CLAUSES] THEN REAL_ARITH_TAC;
+    REWRITE_TAC[INTEGER_CLOSED]] THEN
+  CONJ_TAC THENL
+   [CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+    REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+  REWRITE_TAC[bitval; GSYM NOT_LT; COND_SWAP] THEN COND_CASES_TAC THEN
+  EXPAND_TAC "t" THEN REWRITE_TAC[bignum_of_wordlist] THEN
+  ASM_REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST (MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
+  REWRITE_TAC[BITVAL_CLAUSES; p_256] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_AMONTSQR_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc returnaddress.
+        nonoverlapping (word pc,0x180) (z,8 * 4)
+        ==> ensures arm
+             (\s. aligned_bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read PC s = word pc /\
+                  read X30 s = returnaddress /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read PC s = returnaddress /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a EXP 2) (mod p_256))
+             (MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
+                         X13; X14] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  ARM_ADD_RETURN_NOSTACK_TAC BIGNUM_MONTSQR_P256_ALT_EXEC
+    BIGNUM_AMONTSQR_P256_ALT_CORRECT);;

--- a/benchmarks/benchmark.c
+++ b/benchmarks/benchmark.c
@@ -281,6 +281,8 @@ void call_bignum_triple_p521(void) repeat(bignum_triple_p521(b0,b1))
 
 void call_bignum_montmul_p256(void) repeat(bignum_montmul_p256(b0,b1,b2))
 
+void call_bignum_montmul_p256_alt(void) repeat(bignum_montmul_p256_alt(b0,b1,b2))
+
 void call_bignum_montmul_p256k1(void) repeat(bignum_montmul_p256k1(b0,b1,b2))
 
 void call_bignum_montmul_p256k1_alt(void) repeat(bignum_montmul_p256k1_alt(b0,b1,b2))
@@ -290,6 +292,8 @@ void call_bignum_montmul_p384(void) repeat(bignum_montmul_p384(b0,b1,b2))
 void call_bignum_montmul_p521(void) repeat(bignum_montmul_p521(b0,b1,b2))
 
 void call_bignum_montsqr_p256(void) repeat(bignum_montsqr_p256(b0,b1))
+
+void call_bignum_montsqr_p256_alt(void) repeat(bignum_montsqr_p256_alt(b0,b1))
 
 void call_bignum_montsqr_p256k1(void) repeat(bignum_montsqr_p256k1(b0,b1))
 
@@ -711,6 +715,7 @@ int main(void)
   timingtest(all,"bignum_montifier (32)",call_bignum_montifier__32);
   timingtest(all,"bignum_montmul (32x32 -> 32)" ,call_bignum_montmul__32);
   timingtest(bmi,"bignum_montmul_p256",call_bignum_montmul_p256);
+  timingtest(all,"bignum_montmul_p256_alt",call_bignum_montmul_p256_alt);
   timingtest(bmi,"bignum_montmul_p256k1",call_bignum_montmul_p256k1);
   timingtest(all,"bignum_montmul_p256k1_alt",call_bignum_montmul_p256k1_alt);
   timingtest(bmi,"bignum_montmul_p384",call_bignum_montmul_p384);
@@ -718,6 +723,7 @@ int main(void)
   timingtest(all,"bignum_montredc (32/16 -> 16)",call_bignum_montredc__32_16);
   timingtest(all,"bignum_montsqr (32 -> 32)" ,call_bignum_montsqr__32);
   timingtest(bmi,"bignum_montsqr_p256",call_bignum_montsqr_p256);
+  timingtest(all,"bignum_montsqr_p256_alt",call_bignum_montsqr_p256_alt);
   timingtest(bmi,"bignum_montsqr_p256k1",call_bignum_montsqr_p256k1);
   timingtest(all,"bignum_montsqr_p256k1_alt",call_bignum_montsqr_p256k1_alt);
   timingtest(bmi,"bignum_montsqr_p384",call_bignum_montsqr_p384);

--- a/include/s2n-bignum-c89.h
+++ b/include/s2n-bignum-c89.h
@@ -396,6 +396,7 @@ extern void bignum_montmul (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, u
 /*  Montgomery multiply, z := (x * y / 2^256) mod p_256 */
 /*  Inputs x[4], y[4]; output z[4] */
 extern void bignum_montmul_p256 (uint64_t z[4], uint64_t x[4], uint64_t y[4]);
+extern void bignum_montmul_p256_alt (uint64_t z[4], uint64_t x[4], uint64_t y[4]);
 
 /*  Montgomery multiply, z := (x * y / 2^256) mod p_256k1 */
 /*  Inputs x[4], y[4]; output z[4] */
@@ -421,6 +422,7 @@ extern void bignum_montsqr (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
 /*  Montgomery square, z := (x^2 / 2^256) mod p_256 */
 /*  Input x[4]; output z[4] */
 extern void bignum_montsqr_p256 (uint64_t z[4], uint64_t x[4]);
+extern void bignum_montsqr_p256_alt (uint64_t z[4], uint64_t x[4]);
 
 /*  Montgomery square, z := (x^2 / 2^256) mod p_256k1 */
 /*  Input x[4]; output z[4] */

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -395,6 +395,7 @@ extern void bignum_montmul (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, u
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 extern void bignum_montmul_p256 (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+extern void bignum_montmul_p256_alt (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
 
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
@@ -420,6 +421,7 @@ extern void bignum_montsqr (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 extern void bignum_montsqr_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+extern void bignum_montsqr_p256_alt (uint64_t z[static 4], uint64_t x[static 4]);
 
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]

--- a/tests/test.c
+++ b/tests/test.c
@@ -156,6 +156,7 @@ enum {
        TEST_BIGNUM_MONTIFIER,
        TEST_BIGNUM_MONTMUL,
        TEST_BIGNUM_MONTMUL_P256,
+       TEST_BIGNUM_MONTMUL_P256_ALT,
        TEST_BIGNUM_MONTMUL_P256K1,
        TEST_BIGNUM_MONTMUL_P256K1_ALT,
        TEST_BIGNUM_MONTMUL_P384,
@@ -163,6 +164,7 @@ enum {
        TEST_BIGNUM_MONTREDC,
        TEST_BIGNUM_MONTSQR,
        TEST_BIGNUM_MONTSQR_P256,
+       TEST_BIGNUM_MONTSQR_P256_ALT,
        TEST_BIGNUM_MONTSQR_P256K1,
        TEST_BIGNUM_MONTSQR_P256K1_ALT,
        TEST_BIGNUM_MONTSQR_P384,
@@ -3771,6 +3773,38 @@ int test_bignum_montmul_p256(void)
   return 0;
 }
 
+int test_bignum_montmul_p256_alt(void)
+{ uint64_t t;
+  printf("Testing bignum_montmul_p256_alt with %d cases\n",tests);
+
+  int c;
+  for (t = 0; t < tests; ++t)
+   { random_bignum(4,b2);
+     reference_mod(4,b0,b2,p_256);
+     random_bignum(4,b2);
+     reference_mod(4,b1,b2,p_256);
+     bignum_montmul_p256_alt(b4,b0,b1);
+     reference_dmontmul(4,b3,b0,b1,p_256,i_256,b5);
+
+     c = reference_compare(4,b3,4,b4);
+     if (c != 0)
+      { printf("### Disparity: [size %4"PRIu64"] "
+               "2^-256 * ...0x%016"PRIx64" * ...%016"PRIx64"  mod p_256 = "
+               "0x%016"PRIx64"...%016"PRIx64" not 0x%016"PRIx64"...%016"PRIx64"\n",
+               UINT64_C(4),b0[0],b1[0],b4[3],b4[0],b3[3],b3[0]);
+        return 1;
+      }
+     else if (VERBOSE)
+      { printf("OK: [size %4"PRIu64"] "
+               "2^-256 * ...0x%016"PRIx64" * ...%016"PRIx64"  mod p_256 = "
+               "0x%016"PRIx64"...%016"PRIx64"\n",
+               UINT64_C(4),b0[0],b1[0],b4[3],b4[0]);
+      }
+   }
+  printf("All OK\n");
+  return 0;
+}
+
 int test_bignum_montmul_p256k1(void)
 { uint64_t t;
   printf("Testing bignum_montmul_p256k1 with %d cases\n",tests);
@@ -4001,6 +4035,36 @@ int test_bignum_montsqr_p256(void)
    { random_bignum(4,b2);
      reference_mod(4,b0,b2,p_256);
      bignum_montsqr_p256(b4,b0);
+     reference_dmontmul(4,b3,b0,b0,p_256,i_256,b5);
+
+     c = reference_compare(4,b3,4,b4);
+     if (c != 0)
+      { printf("### Disparity: [size %4"PRIu64"] "
+               "2^-256 * ...0x%016"PRIx64"^2 mod p_256 = "
+               "0x%016"PRIx64"...%016"PRIx64" not 0x%016"PRIx64"...%016"PRIx64"\n",
+               UINT64_C(4),b0[0],b4[3],b4[0],b3[3],b3[0]);
+        return 1;
+      }
+     else if (VERBOSE)
+      { printf("OK: [size %4"PRIu64"] "
+               "2^-256 * ...0x%016"PRIx64"^2 mod p_256 = "
+               "0x%016"PRIx64"...%016"PRIx64"\n",
+               UINT64_C(4),b0[0],b4[3],b4[0]);
+      }
+   }
+  printf("All OK\n");
+  return 0;
+}
+
+int test_bignum_montsqr_p256_alt(void)
+{ uint64_t t;
+  printf("Testing bignum_montsqr_p256_alt with %d cases\n",tests);
+
+  int c;
+  for (t = 0; t < tests; ++t)
+   { random_bignum(4,b2);
+     reference_mod(4,b0,b2,p_256);
+     bignum_montsqr_p256_alt(b4,b0);
      reference_dmontmul(4,b3,b0,b0,p_256,i_256,b5);
 
      c = reference_compare(4,b3,4,b4);
@@ -6284,6 +6348,7 @@ int test_all(void)
   dotest(test_bignum_montifier);
   dotest(test_bignum_montmul);
   dotest(test_bignum_montmul_p256);
+  dotest(test_bignum_montmul_p256_alt);
   dotest(test_bignum_montmul_p256k1);
   dotest(test_bignum_montmul_p256k1_alt);
   dotest(test_bignum_montmul_p384);
@@ -6291,6 +6356,7 @@ int test_all(void)
   dotest(test_bignum_montredc);
   dotest(test_bignum_montsqr);
   dotest(test_bignum_montsqr_p256);
+  dotest(test_bignum_montsqr_p256_alt);
   dotest(test_bignum_montsqr_p256k1);
   dotest(test_bignum_montsqr_p256k1_alt);
   dotest(test_bignum_montsqr_p384);
@@ -6462,9 +6528,11 @@ int test_allnonbmi()
   dotest(test_bignum_modsub);
   dotest(test_bignum_montifier);
   dotest(test_bignum_montmul);
+  dotest(test_bignum_montmul_p256_alt);
   dotest(test_bignum_montmul_p256k1_alt);
   dotest(test_bignum_montredc);
   dotest(test_bignum_montsqr);
+  dotest(test_bignum_montsqr_p256_alt);
   dotest(test_bignum_montsqr_p256k1_alt);
   dotest(test_bignum_mul);
   dotest(test_bignum_mul_4_8_alt);
@@ -6683,6 +6751,7 @@ int main(int argc, char *argv[])
      case TEST_BIGNUM_MONTIFIER:          return test_bignum_montifier();
      case TEST_BIGNUM_MONTMUL:            return test_bignum_montmul();
      case TEST_BIGNUM_MONTMUL_P256:       return test_bignum_montmul_p256();
+     case TEST_BIGNUM_MONTMUL_P256_ALT:   return test_bignum_montmul_p256_alt();
      case TEST_BIGNUM_MONTMUL_P256K1:     return test_bignum_montmul_p256k1();
      case TEST_BIGNUM_MONTMUL_P256K1_ALT: return test_bignum_montmul_p256k1_alt();
      case TEST_BIGNUM_MONTMUL_P384:       return test_bignum_montmul_p384();
@@ -6690,6 +6759,7 @@ int main(int argc, char *argv[])
      case TEST_BIGNUM_MONTREDC:           return test_bignum_montredc();
      case TEST_BIGNUM_MONTSQR:            return test_bignum_montsqr();
      case TEST_BIGNUM_MONTSQR_P256:       return test_bignum_montsqr_p256();
+     case TEST_BIGNUM_MONTSQR_P256_ALT:   return test_bignum_montsqr_p256_alt();
      case TEST_BIGNUM_MONTSQR_P256K1:     return test_bignum_montsqr_p256k1();
      case TEST_BIGNUM_MONTSQR_P256K1_ALT: return test_bignum_montsqr_p256k1_alt();
      case TEST_BIGNUM_MONTSQR_P384:       return test_bignum_montsqr_p384();

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -158,7 +158,9 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       p256/bignum_mod_p256.o \
       p256/bignum_mod_p256_4.o \
       p256/bignum_montmul_p256.o \
+      p256/bignum_montmul_p256_alt.o \
       p256/bignum_montsqr_p256.o \
+      p256/bignum_montsqr_p256_alt.o \
       p256/bignum_mux_4.o \
       p256/bignum_neg_p256.o \
       p256/bignum_nonzero_4.o \

--- a/x86/p256/Makefile
+++ b/x86/p256/Makefile
@@ -28,7 +28,9 @@ OBJ = bignum_add_p256.o \
       bignum_mod_p256.o \
       bignum_mod_p256_4.o \
       bignum_montmul_p256.o \
+      bignum_montmul_p256_alt.o \
       bignum_montsqr_p256.o \
+      bignum_montsqr_p256_alt.o \
       bignum_mux_4.o \
       bignum_neg_p256.o \
       bignum_nonzero_4.o \

--- a/x86/p256/bignum_montmul_p256_alt.S
+++ b/x86/p256/bignum_montmul_p256_alt.S
@@ -1,0 +1,209 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^256) mod p_256
+// Inputs x[4], y[4]; output z[4]
+//
+//    extern void bignum_montmul_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
+// satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in
+// the "usual" case x < p_256 and y < p_256).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+        .intel_syntax noprefix
+        .globl  bignum_montmul_p256_alt
+        .text
+
+#define z rdi
+#define x rsi
+
+// We move the y argument here so we can use rdx for multipliers
+
+#define y rcx
+
+// Add rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using rax and rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        sub     rdx, carry;             \
+        add     low, rax;               \
+        adc     high, rdx;              \
+        sbb     carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        add     low, rax;               \
+        adc     high, rdx;              \
+        sbb     carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        sub     rdx, carry;             \
+        add     low, rax;               \
+        adc     high, rdx
+
+bignum_montmul_p256_alt:
+
+// Save more registers to play with
+
+        push    rbx
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+// Copy y into a safe register to start with
+
+        mov     y, rdx
+
+// Do row 0 computation, which is a bit different:
+// set up initial window [r12,r11,r10,r9,r8] = y[0] * x
+// Unlike later, we only need a single carry chain
+
+        mov     rbx, [y]
+        mov     rax, [x]
+        mul     rbx
+        mov     r8, rax
+        mov     r9, rdx
+
+        mov     rax, [x+8]
+        mul     rbx
+        xor     r10d, r10d
+        add     r9, rax
+        adc     r10, rdx
+
+        mov     rax, [x+16]
+        mul     rbx
+        xor     r11d, r11d
+        add     r10, rax
+        adc     r11, rdx
+
+        mov     rax, [x+24]
+        mul     rbx
+        xor     r12d, r12d
+        add     r11, rax
+        adc     r12, rdx
+
+// Add row 1
+
+        mov     rbx, [y+8]
+        xor     r13d, r13d
+        mulpadi(r14,r10,r9,[x])
+        mulpadd(r14,r11,r10,[x+8])
+        mulpadd(r14,r12,r11,[x+16])
+        mulpade(r14,r13,r12,[x+24])
+
+// Montgomery reduce windows 0 and 1 together
+
+        xor     r14d, r14d
+        mov     rbx, 0x0000000100000000
+        mulpadi(r15,r10,r9,r8)
+        mulpadd(r15,r11,r10,r9)
+        not     rbx
+        lea     rbx, [rbx+2]
+        mulpadd(r15,r12,r11,r8)
+        mulpade(r15,r13,r12,r9)
+        adc     r14, r14
+
+// Add row 2
+
+        mov     rbx, [y+16]
+        xor     r15d, r15d
+        mulpadi(r8,r11,r10,[x])
+        mulpadd(r8,r12,r11,[x+8])
+        mulpadd(r8,r13,r12,[x+16])
+        mulpade(r8,r14,r13,[x+24])
+        adc     r15, r15
+
+// Add row 3
+
+        mov     rbx, [y+24]
+        xor     r8d, r8d
+        mulpadi(r9,r12,r11,[x])
+        mulpadd(r9,r13,r12,[x+8])
+        mulpadd(r9,r14,r13,[x+16])
+        mulpade(r9,r15,r14,[x+24])
+        adc     r8, r8
+
+// Montgomery reduce windows 2 and 3 together
+
+        xor     r9d, r9d
+        mov     rbx, 0x0000000100000000
+        mulpadi(rcx,r12,r11,r10)
+        mulpadd(rcx,r13,r12,r11)
+        not     rbx
+        lea     rbx, [rbx+2]
+        mulpadd(rcx,r14,r13,r10)
+        mulpade(rcx,r15,r14,r11)
+        adc     r8, r9
+
+// We now have a pre-reduced 5-word form [r8; r15;r14;r13;r12]
+// Load [rax;r11;rbx;rdx;rcx] = 2^320 - p_256, re-using earlier numbers a bit
+// Do [rax;r11;rbx;rdx;rcx] = [r8;r15;r14;r13;r12] + (2^320 - p_256)
+
+        mov     ecx, 1
+        add     rcx, r12
+        dec     rbx
+        adc     rbx, r13
+        dec     r9
+        mov     rax, r9
+        adc     r9, r14
+        mov     r11d, 0x00000000fffffffe
+        adc     r11, r15
+        adc     rax, r8
+
+// Now carry is set if r + (2^320 - p_256) >= 2^320, i.e. r >= p_256
+// where r is the pre-reduced form. So conditionally select the
+// output accordingly.
+
+        cmovc   r12, rcx
+        cmovc   r13, rbx
+        cmovc   r14, r9
+        cmovc   r15, r11
+
+// Write back reduced value
+
+        mov     [z], r12
+        mov     [z+8], r13
+        mov     [z+16], r14
+        mov     [z+24], r15
+
+// Restore registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86/p256/bignum_montsqr_p256_alt.S
+++ b/x86/p256/bignum_montsqr_p256_alt.S
@@ -1,0 +1,208 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^256) mod p_256
+// Input x[4]; output z[4]
+//
+//    extern void bignum_montsqr_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4]);
+//
+// Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
+// guaranteed in particular if x < p_256 initially (the "intended" case).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+        .intel_syntax noprefix
+        .globl  bignum_montsqr_p256_alt
+        .text
+
+#define z rdi
+#define x rsi
+
+// Add rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using rax and rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        sub     rdx, carry;             \
+        add     low, rax;               \
+        adc     high, rdx;              \
+        sbb     carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        add     low, rax;               \
+        adc     high, rdx;              \
+        sbb     carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        mov     rax, m;                 \
+        mul     rbx;                    \
+        sub     rdx, carry;             \
+        add     low, rax;               \
+        adc     high, rdx
+
+bignum_montsqr_p256_alt:
+
+// Save more registers to play with
+
+        push    rbx
+        push    r12
+        push    r13
+        push    r14
+        push    r15
+
+// Compute [r15;r8] = [00] which we use later, but mainly
+// set up an initial window [r14;...;r9] = [23;03;01]
+
+        mov     rax, [x]
+        mov     rbx, rax
+        mul     rax
+        mov     r8, rax
+        mov     r15, rdx
+        mov     rax, [x+8]
+        mul     rbx
+        mov     r9, rax
+        mov     r10, rdx
+        mov     rax, [x+24]
+        mov     r13, rax
+        mul     rbx
+        mov     r11, rax
+        mov     r12, rdx
+        mov     rax, [x+16]
+        mov     rbx, rax
+        mul     r13
+        mov     r13, rax
+        mov     r14, rdx
+
+// Chain in the addition of 02 + 12 + 13 to that window (no carry-out possible)
+// This gives all the "heterogeneous" terms of the squaring ready to double
+
+        mulpadi(rcx,r11,r10,[x])
+        mulpadd(rcx,r12,r11,[x+8])
+        mov     rbx, [x+24]
+        mulpade(rcx,r13,r12,[x+8])
+        adc     r14, 0
+
+// Double the window [r14;...;r9], catching top carry in rcx
+
+        xor     ecx, ecx
+        add     r9, r9
+        adc     r10, r10
+        adc     r11, r11
+        adc     r12, r12
+        adc     r13, r13
+        adc     r14, r14
+        adc     rcx, rcx
+
+// Add to the 00 + 11 + 22 + 33 terms
+
+        mov     rax, [x+8]
+        mul     rax
+        add     r9, r15
+        adc     r10, rax
+        adc     r11, rdx
+        sbb     r15, r15
+        mov     rax, [x+16]
+        mul     rax
+        neg     r15
+        adc     r12, rax
+        adc     r13, rdx
+        sbb     r15, r15
+        mov     rax, [x+24]
+        mul     rax
+        neg     r15
+        adc     r14, rax
+        adc     rdx, rcx
+        mov     r15, rdx
+
+// First two waves of Montgomery reduction, now re-using r8 for top carry
+
+        mov     rbx, 0x0000000100000000
+        mulpadi(rcx,r10,r9,r8)
+        mulpadd(rcx,r11,r10,r9)
+        not     rbx
+        lea     rbx, [rbx+2]
+        mulpadd(rcx,r12,r11,r8)
+        xor     r8d, r8d
+        mulpade(rcx,r13,r12,r9)
+        adc     r14, r8
+        adc     r15, r8
+        adc     r8, r8
+
+// Now two more steps of Montgomery reduction, again with r8 = top carry
+
+        mov     rbx, 0x0000000100000000
+        mulpadi(rcx,r12,r11,r10)
+        mulpadd(rcx,r13,r12,r11)
+        not     rbx
+        lea     rbx, [rbx+2]
+        mulpadd(rcx,r14,r13,r10)
+        xor     r9d, r9d
+        mulpade(rcx,r15,r14,r11)
+        adc     r8, r9
+
+// Load [rax;r11;r9;rbx;rcx] = 2^320 - p_256, re-using earlier numbers a bit
+// Do [rax;r11;r9;rbx;rcx] = [r8;r15;r14;r13;r12] + (2^320 - p_256)
+
+        mov     ecx, 1
+        add     rcx, r12
+        lea     rbx, [rbx-1]
+        adc     rbx, r13
+        lea     r9, [r9-1]
+        mov     rax, r9
+        adc     r9, r14
+        mov     r11d,  0x00000000fffffffe
+        adc     r11, r15
+        adc     rax, r8
+
+// Now carry is set if r + (2^320 - p_256) >= 2^320, i.e. r >= p_256
+// where r is the pre-reduced form. So conditionally select the
+// output accordingly.
+
+        cmovc   r12, rcx
+        cmovc   r13, rbx
+        cmovc   r14, r9
+        cmovc   r15, r11
+
+// Write back reduced value
+
+        mov     [z], r12
+        mov     [z+8], r13
+        mov     [z+16], r14
+        mov     [z+24], r15
+
+// Restore saved registers and return
+
+        pop     r15
+        pop     r14
+        pop     r13
+        pop     r12
+        pop     rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86/proofs/bignum_montmul_p256_alt.ml
+++ b/x86/proofs/bignum_montmul_p256_alt.ml
@@ -1,0 +1,472 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* Montgomery multiplication modulo p_256 using using traditional x86 muls.  *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "x86/p256/bignum_montmul_p256_alt.o";;
+ ****)
+
+let bignum_montmul_p256_alt_mc =
+  define_assert_from_elf "bignum_montmul_p256_alt_mc" "x86/p256/bignum_montmul_p256_alt.o"
+[
+  0x53;                    (* PUSH (% rbx) *)
+  0x41; 0x54;              (* PUSH (% r12) *)
+  0x41; 0x55;              (* PUSH (% r13) *)
+  0x41; 0x56;              (* PUSH (% r14) *)
+  0x41; 0x57;              (* PUSH (% r15) *)
+  0x48; 0x89; 0xd1;        (* MOV (% rcx) (% rdx) *)
+  0x48; 0x8b; 0x19;        (* MOV (% rbx) (Memop Quadword (%% (rcx,0))) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x89; 0xc0;        (* MOV (% r8) (% rax) *)
+  0x49; 0x89; 0xd1;        (* MOV (% r9) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x45; 0x31; 0xd2;        (* XOR (% r10d) (% r10d) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x45; 0x31; 0xdb;        (* XOR (% r11d) (% r11d) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x45; 0x31; 0xe4;        (* XOR (% r12d) (% r12d) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x48; 0x8b; 0x59; 0x08;  (* MOV (% rbx) (Memop Quadword (%% (rcx,8))) *)
+  0x45; 0x31; 0xed;        (* XOR (% r13d) (% r13d) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x4d; 0x19; 0xf6;        (* SBB (% r14) (% r14) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xf2;        (* SUB (% rdx) (% r14) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x4d; 0x19; 0xf6;        (* SBB (% r14) (% r14) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xf2;        (* SUB (% rdx) (% r14) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x4d; 0x19; 0xf6;        (* SBB (% r14) (% r14) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xf2;        (* SUB (% rdx) (% r14) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x45; 0x31; 0xf6;        (* XOR (% r14d) (% r14d) *)
+  0x48; 0xbb; 0x00; 0x00; 0x00; 0x00; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm64 (word 4294967296)) *)
+  0x4c; 0x89; 0xc0;        (* MOV (% rax) (% r8) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x4d; 0x19; 0xff;        (* SBB (% r15) (% r15) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xfa;        (* SUB (% rdx) (% r15) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x4d; 0x19; 0xff;        (* SBB (% r15) (% r15) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0x8d; 0x5b; 0x02;  (* LEA (% rbx) (%% (rbx,2)) *)
+  0x4c; 0x89; 0xc0;        (* MOV (% rax) (% r8) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xfa;        (* SUB (% rdx) (% r15) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x4d; 0x19; 0xff;        (* SBB (% r15) (% r15) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xfa;        (* SUB (% rdx) (% r15) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x4d; 0x11; 0xf6;        (* ADC (% r14) (% r14) *)
+  0x48; 0x8b; 0x59; 0x10;  (* MOV (% rbx) (Memop Quadword (%% (rcx,16))) *)
+  0x45; 0x31; 0xff;        (* XOR (% r15d) (% r15d) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x4d; 0x19; 0xc0;        (* SBB (% r8) (% r8) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xc2;        (* SUB (% rdx) (% r8) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x4d; 0x19; 0xc0;        (* SBB (% r8) (% r8) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xc2;        (* SUB (% rdx) (% r8) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x4d; 0x19; 0xc0;        (* SBB (% r8) (% r8) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xc2;        (* SUB (% rdx) (% r8) *)
+  0x49; 0x01; 0xc5;        (* ADD (% r13) (% rax) *)
+  0x49; 0x11; 0xd6;        (* ADC (% r14) (% rdx) *)
+  0x4d; 0x11; 0xff;        (* ADC (% r15) (% r15) *)
+  0x48; 0x8b; 0x59; 0x18;  (* MOV (% rbx) (Memop Quadword (%% (rcx,24))) *)
+  0x45; 0x31; 0xc0;        (* XOR (% r8d) (% r8d) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x4d; 0x19; 0xc9;        (* SBB (% r9) (% r9) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xca;        (* SUB (% rdx) (% r9) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x4d; 0x19; 0xc9;        (* SBB (% r9) (% r9) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xca;        (* SUB (% rdx) (% r9) *)
+  0x49; 0x01; 0xc5;        (* ADD (% r13) (% rax) *)
+  0x49; 0x11; 0xd6;        (* ADC (% r14) (% rdx) *)
+  0x4d; 0x19; 0xc9;        (* SBB (% r9) (% r9) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x4c; 0x29; 0xca;        (* SUB (% rdx) (% r9) *)
+  0x49; 0x01; 0xc6;        (* ADD (% r14) (% rax) *)
+  0x49; 0x11; 0xd7;        (* ADC (% r15) (% rdx) *)
+  0x4d; 0x11; 0xc0;        (* ADC (% r8) (% r8) *)
+  0x45; 0x31; 0xc9;        (* XOR (% r9d) (% r9d) *)
+  0x48; 0xbb; 0x00; 0x00; 0x00; 0x00; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm64 (word 4294967296)) *)
+  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0x8d; 0x5b; 0x02;  (* LEA (% rbx) (%% (rbx,2)) *)
+  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc5;        (* ADD (% r13) (% rax) *)
+  0x49; 0x11; 0xd6;        (* ADC (% r14) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc6;        (* ADD (% r14) (% rax) *)
+  0x49; 0x11; 0xd7;        (* ADC (% r15) (% rdx) *)
+  0x4d; 0x11; 0xc8;        (* ADC (% r8) (% r9) *)
+  0xb9; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% ecx) (Imm32 (word 1)) *)
+  0x4c; 0x01; 0xe1;        (* ADD (% rcx) (% r12) *)
+  0x48; 0xff; 0xcb;        (* DEC (% rbx) *)
+  0x4c; 0x11; 0xeb;        (* ADC (% rbx) (% r13) *)
+  0x49; 0xff; 0xc9;        (* DEC (% r9) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x4d; 0x11; 0xf1;        (* ADC (% r9) (% r14) *)
+  0x41; 0xbb; 0xfe; 0xff; 0xff; 0xff;
+                           (* MOV (% r11d) (Imm32 (word 4294967294)) *)
+  0x4d; 0x11; 0xfb;        (* ADC (% r11) (% r15) *)
+  0x4c; 0x11; 0xc0;        (* ADC (% rax) (% r8) *)
+  0x4c; 0x0f; 0x42; 0xe1;  (* CMOVB (% r12) (% rcx) *)
+  0x4c; 0x0f; 0x42; 0xeb;  (* CMOVB (% r13) (% rbx) *)
+  0x4d; 0x0f; 0x42; 0xf1;  (* CMOVB (% r14) (% r9) *)
+  0x4d; 0x0f; 0x42; 0xfb;  (* CMOVB (% r15) (% r11) *)
+  0x4c; 0x89; 0x27;        (* MOV (Memop Quadword (%% (rdi,0))) (% r12) *)
+  0x4c; 0x89; 0x6f; 0x08;  (* MOV (Memop Quadword (%% (rdi,8))) (% r13) *)
+  0x4c; 0x89; 0x77; 0x10;  (* MOV (Memop Quadword (%% (rdi,16))) (% r14) *)
+  0x4c; 0x89; 0x7f; 0x18;  (* MOV (Memop Quadword (%% (rdi,24))) (% r15) *)
+  0x41; 0x5f;              (* POP (% r15) *)
+  0x41; 0x5e;              (* POP (% r14) *)
+  0x41; 0x5d;              (* POP (% r13) *)
+  0x41; 0x5c;              (* POP (% r12) *)
+  0x5b;                    (* POP (% rbx) *)
+  0xc3                     (* RET *)
+];;
+
+let BIGNUM_MONTMUL_P256_ALT_EXEC = X86_MK_EXEC_RULE bignum_montmul_p256_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let p_256 = new_definition `p_256 = 115792089210356248762697446949407573530086143415290314195533631308867097853951`;;
+
+let BIGNUM_MONTMUL_P256_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+        nonoverlapping (word pc,0x233) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read RIP s = word(pc + 0x09) /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read RIP s = word (pc + 0x229) /\
+                  (a * b <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a * b) MOD p_256))
+             (MAYCHANGE [RIP; RAX; RBX; RCX; RDX;
+                         R8; R9; R10; R11; R12; R13; R14; R15] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (*** Globalize the a * b <= 2 EXP 256 * p_256  assumption ***)
+
+  ASM_CASES_TAC `a * b <= 2 EXP 256 * p_256` THENL
+   [ASM_REWRITE_TAC[]; X86_SIM_TAC BIGNUM_MONTMUL_P256_ALT_EXEC (1--167)] THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+
+  (*** Simulate the core pre-reduced result accumulation ***)
+
+  MAP_EVERY (fun n ->
+    X86_STEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC [n] THEN
+    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
+    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
+   (1--149) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s133; sum_s141; sum_s147; sum_s148; sum_s149]` THEN
+  SUBGOAL_THEN
+   `t < 2 * p_256 /\ (2 EXP 256 * t == a * b) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (ARITH_RULE
+        `ab <= 2 EXP 256 * p
+         ==> 2 EXP 256 * t < ab + 2 EXP 256 * p ==> t < 2 * p`)) THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  X86_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC
+   [151;153;156;158;159] (150--167) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  TRANS_TAC EQ_TRANS `t MOD p_256` THEN CONJ_TAC THENL
+   [ALL_TAC;
+    REWRITE_TAC[GSYM CONG] THEN FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == a * b) (mod p)
+        ==> (e * i == 1) (mod p) ==> (t == i * a * b) (mod p)`)) THEN
+    REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+    REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV] THEN
+  CONV_TAC SYM_CONV THEN MATCH_MP_TAC EQUAL_FROM_CONGRUENT_MOD_MOD THEN
+  MAP_EVERY EXISTS_TAC
+   [`256`; `if t < p_256 then &t:real else &t - &p_256`] THEN
+  REPEAT CONJ_TAC THENL
+   [REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    ALL_TAC;
+    ASM_SIMP_TAC[MOD_CASES] THEN
+    GEN_REWRITE_TAC LAND_CONV [COND_RAND] THEN
+    SIMP_TAC[REAL_OF_NUM_SUB; GSYM NOT_LT]] THEN
+  SUBGOAL_THEN `carry_s159 <=> p_256 <= t` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LE THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    REWRITE_TAC[GSYM NOT_LT; COND_SWAP]] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN EXPAND_TAC "t" THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist; p_256] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  ASM_REWRITE_TAC[BITVAL_CLAUSES; VAL_WORD_BITVAL] THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_MONTMUL_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc stackpointer returnaddress.
+        nonoverlapping (z,8 * 4) (word_sub stackpointer (word 40),48) /\
+        ALL (nonoverlapping (word_sub stackpointer (word 40),40))
+            [(word pc,0x233); (x,8 * 4); (y,8 * 4)] /\
+        nonoverlapping (word pc,0x233) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read RIP s = word pc /\
+                  read RSP s = stackpointer /\
+                  read (memory :> bytes64 stackpointer) s = returnaddress /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read RIP s = returnaddress /\
+                  read RSP s = word_add stackpointer (word 8) /\
+                  (a * b <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a * b) MOD p_256))
+             (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9; R10; R11] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4);
+                         memory :> bytes(word_sub stackpointer (word 40),40)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_STACK_TAC
+   BIGNUM_MONTMUL_P256_ALT_EXEC BIGNUM_MONTMUL_P256_ALT_CORRECT
+   `[RBX; R12; R13; R14; R15]` 40);;
+
+(* ------------------------------------------------------------------------- *)
+(* Show that it also works as "almost-Montgomery" if desired. That is, even  *)
+(* without the further range assumption on inputs we still get a congruence. *)
+(* But the output, still 256 bits, may then not be fully reduced mod p_256.  *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_AMONTMUL_P256_ALT_CORRECT = time prove
+ (`!z x y a b pc.
+        nonoverlapping (word pc,0x233) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read RIP s = word(pc + 0x09) /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read RIP s = word (pc + 0x229) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a * b) (mod p_256))
+             (MAYCHANGE [RIP; RAX; RBX; RCX; RDX;
+                         R8; R9; R10; R11; R12; R13; R14; R15] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC
+   [`z:int64`; `x:int64`; `y:int64`; `a:num`; `b:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+  BIGNUM_DIGITIZE_TAC "y_" `bignum_from_memory (y,4) s0` THEN
+
+  (*** Simulate the core pre-reduced result accumulation ***)
+
+  MAP_EVERY (fun n ->
+    X86_STEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC [n] THEN
+    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
+    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
+   (1--149) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s133; sum_s141; sum_s147; sum_s148; sum_s149]` THEN
+  SUBGOAL_THEN
+   `t < 2 EXP 256 + p_256 /\ (2 EXP 256 * t == a * b) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [MATCH_MP_TAC(ARITH_RULE
+       `2 EXP 256 * t <= (2 EXP 256 - 1) EXP 2 + (2 EXP 256 - 1) * p
+        ==> t < 2 EXP 256 + p`) THEN
+      REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "b"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  X86_ACCSTEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC
+   [151;153;156;158;159] (150--167) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == ab) (mod p)
+        ==> (e * i == 1) (mod p) /\ (s == t) (mod p)
+            ==> (s == i * ab) (mod p)`)) THEN
+  REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+  CONJ_TAC THENL
+   [REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV; ALL_TAC] THEN
+  SUBGOAL_THEN `carry_s159 <=> p_256 <= t` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LE THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    REWRITE_TAC[GSYM NOT_LT; COND_SWAP]] THEN
+  MATCH_MP_TAC(NUMBER_RULE `!b:num. x + b * p = y ==> (x == y) (mod p)`) THEN
+  EXISTS_TAC `bitval(p_256 <= t)` THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN REWRITE_TAC[REAL_OF_NUM_LE] THEN
+  ONCE_REWRITE_TAC[REAL_ARITH `a + b:real = c <=> c - b = a`] THEN
+  MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
+  MAP_EVERY EXISTS_TAC [`256`; `&0:real`] THEN CONJ_TAC THENL
+   [UNDISCH_TAC `t < 2 EXP 256 + p_256` THEN
+    REWRITE_TAC[bitval; p_256; GSYM REAL_OF_NUM_CLAUSES] THEN REAL_ARITH_TAC;
+    REWRITE_TAC[INTEGER_CLOSED]] THEN
+  CONJ_TAC THENL
+   [CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+    REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+  REWRITE_TAC[bitval] THEN COND_CASES_TAC THEN
+  EXPAND_TAC "t" THEN REWRITE_TAC[bignum_of_wordlist] THEN
+  ASM_REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST (MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
+  REWRITE_TAC[BITVAL_CLAUSES; p_256] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_AMONTMUL_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x y a b pc stackpointer returnaddress.
+        nonoverlapping (z,8 * 4) (word_sub stackpointer (word 40),48) /\
+        ALL (nonoverlapping (word_sub stackpointer (word 40),40))
+            [(word pc,0x233); (x,8 * 4); (y,8 * 4)] /\
+        nonoverlapping (word pc,0x233) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montmul_p256_alt_mc /\
+                  read RIP s = word pc /\
+                  read RSP s = stackpointer /\
+                  read (memory :> bytes64 stackpointer) s = returnaddress /\
+                  C_ARGUMENTS [z; x; y] s /\
+                  bignum_from_memory (x,4) s = a /\
+                  bignum_from_memory (y,4) s = b)
+             (\s. read RIP s = returnaddress /\
+                  read RSP s = word_add stackpointer (word 8) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a * b) (mod p_256))
+             (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9; R10; R11] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4);
+                         memory :> bytes(word_sub stackpointer (word 40),40)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_STACK_TAC
+   BIGNUM_MONTMUL_P256_ALT_EXEC BIGNUM_AMONTMUL_P256_ALT_CORRECT
+   `[RBX; R12; R13; R14; R15]` 40);;

--- a/x86/proofs/bignum_montsqr_p256_alt.ml
+++ b/x86/proofs/bignum_montsqr_p256_alt.ml
@@ -1,0 +1,434 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *)
+
+(* ========================================================================= *)
+(* Montgomery squaring modulo p_256 using traditional x86 multiplications.   *)
+(* ========================================================================= *)
+
+(**** print_literal_from_elf "x86/p256/bignum_montsqr_p256_alt.o";;
+ ****)
+
+let bignum_montsqr_p256_alt_mc =
+  define_assert_from_elf "bignum_montsqr_p256_alt_mc" "x86/p256/bignum_montsqr_p256_alt.o"
+[
+  0x53;                    (* PUSH (% rbx) *)
+  0x41; 0x54;              (* PUSH (% r12) *)
+  0x41; 0x55;              (* PUSH (% r13) *)
+  0x41; 0x56;              (* PUSH (% r14) *)
+  0x41; 0x57;              (* PUSH (% r15) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0x89; 0xc3;        (* MOV (% rbx) (% rax) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x49; 0x89; 0xc0;        (* MOV (% r8) (% rax) *)
+  0x49; 0x89; 0xd7;        (* MOV (% r15) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x89; 0xc1;        (* MOV (% r9) (% rax) *)
+  0x49; 0x89; 0xd2;        (* MOV (% r10) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x49; 0x89; 0xc5;        (* MOV (% r13) (% rax) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x89; 0xc3;        (* MOV (% r11) (% rax) *)
+  0x49; 0x89; 0xd4;        (* MOV (% r12) (% rdx) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0x89; 0xc3;        (* MOV (% rbx) (% rax) *)
+  0x49; 0xf7; 0xe5;        (* MUL2 (% rdx,% rax) (% r13) *)
+  0x49; 0x89; 0xc5;        (* MOV (% r13) (% rax) *)
+  0x49; 0x89; 0xd6;        (* MOV (% r14) (% rdx) *)
+  0x48; 0x8b; 0x06;        (* MOV (% rax) (Memop Quadword (%% (rsi,0))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x48; 0x8b; 0x5e; 0x18;  (* MOV (% rbx) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x49; 0x83; 0xd6; 0x00;  (* ADC (% r14) (Imm8 (word 0)) *)
+  0x31; 0xc9;              (* XOR (% ecx) (% ecx) *)
+  0x4d; 0x01; 0xc9;        (* ADD (% r9) (% r9) *)
+  0x4d; 0x11; 0xd2;        (* ADC (% r10) (% r10) *)
+  0x4d; 0x11; 0xdb;        (* ADC (% r11) (% r11) *)
+  0x4d; 0x11; 0xe4;        (* ADC (% r12) (% r12) *)
+  0x4d; 0x11; 0xed;        (* ADC (% r13) (% r13) *)
+  0x4d; 0x11; 0xf6;        (* ADC (% r14) (% r14) *)
+  0x48; 0x11; 0xc9;        (* ADC (% rcx) (% rcx) *)
+  0x48; 0x8b; 0x46; 0x08;  (* MOV (% rax) (Memop Quadword (%% (rsi,8))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x4d; 0x01; 0xf9;        (* ADD (% r9) (% r15) *)
+  0x49; 0x11; 0xc2;        (* ADC (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x4d; 0x19; 0xff;        (* SBB (% r15) (% r15) *)
+  0x48; 0x8b; 0x46; 0x10;  (* MOV (% rax) (Memop Quadword (%% (rsi,16))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x49; 0xf7; 0xdf;        (* NEG (% r15) *)
+  0x49; 0x11; 0xc4;        (* ADC (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x4d; 0x19; 0xff;        (* SBB (% r15) (% r15) *)
+  0x48; 0x8b; 0x46; 0x18;  (* MOV (% rax) (Memop Quadword (%% (rsi,24))) *)
+  0x48; 0xf7; 0xe0;        (* MUL2 (% rdx,% rax) (% rax) *)
+  0x49; 0xf7; 0xdf;        (* NEG (% r15) *)
+  0x49; 0x11; 0xc6;        (* ADC (% r14) (% rax) *)
+  0x48; 0x11; 0xca;        (* ADC (% rdx) (% rcx) *)
+  0x49; 0x89; 0xd7;        (* MOV (% r15) (% rdx) *)
+  0x48; 0xbb; 0x00; 0x00; 0x00; 0x00; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm64 (word 4294967296)) *)
+  0x4c; 0x89; 0xc0;        (* MOV (% rax) (% r8) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc1;        (* ADD (% r9) (% rax) *)
+  0x49; 0x11; 0xd2;        (* ADC (% r10) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
+  0x49; 0x11; 0xd3;        (* ADC (% r11) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0x8d; 0x5b; 0x02;  (* LEA (% rbx) (%% (rbx,2)) *)
+  0x4c; 0x89; 0xc0;        (* MOV (% rax) (% r8) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x45; 0x31; 0xc0;        (* XOR (% r8d) (% r8d) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x4d; 0x11; 0xc6;        (* ADC (% r14) (% r8) *)
+  0x4d; 0x11; 0xc7;        (* ADC (% r15) (% r8) *)
+  0x4d; 0x11; 0xc0;        (* ADC (% r8) (% r8) *)
+  0x48; 0xbb; 0x00; 0x00; 0x00; 0x00; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm64 (word 4294967296)) *)
+  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x11; 0xd4;        (* ADC (% r12) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc4;        (* ADD (% r12) (% rax) *)
+  0x49; 0x11; 0xd5;        (* ADC (% r13) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0x8d; 0x5b; 0x02;  (* LEA (% rbx) (%% (rbx,2)) *)
+  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc5;        (* ADD (% r13) (% rax) *)
+  0x49; 0x11; 0xd6;        (* ADC (% r14) (% rdx) *)
+  0x48; 0x19; 0xc9;        (* SBB (% rcx) (% rcx) *)
+  0x45; 0x31; 0xc9;        (* XOR (% r9d) (% r9d) *)
+  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
+  0x48; 0xf7; 0xe3;        (* MUL2 (% rdx,% rax) (% rbx) *)
+  0x48; 0x29; 0xca;        (* SUB (% rdx) (% rcx) *)
+  0x49; 0x01; 0xc6;        (* ADD (% r14) (% rax) *)
+  0x49; 0x11; 0xd7;        (* ADC (% r15) (% rdx) *)
+  0x4d; 0x11; 0xc8;        (* ADC (% r8) (% r9) *)
+  0xb9; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% ecx) (Imm32 (word 1)) *)
+  0x4c; 0x01; 0xe1;        (* ADD (% rcx) (% r12) *)
+  0x48; 0x8d; 0x5b; 0xff;  (* LEA (% rbx) (%% (rbx,18446744073709551615)) *)
+  0x4c; 0x11; 0xeb;        (* ADC (% rbx) (% r13) *)
+  0x4d; 0x8d; 0x49; 0xff;  (* LEA (% r9) (%% (r9,18446744073709551615)) *)
+  0x4c; 0x89; 0xc8;        (* MOV (% rax) (% r9) *)
+  0x4d; 0x11; 0xf1;        (* ADC (% r9) (% r14) *)
+  0x41; 0xbb; 0xfe; 0xff; 0xff; 0xff;
+                           (* MOV (% r11d) (Imm32 (word 4294967294)) *)
+  0x4d; 0x11; 0xfb;        (* ADC (% r11) (% r15) *)
+  0x4c; 0x11; 0xc0;        (* ADC (% rax) (% r8) *)
+  0x4c; 0x0f; 0x42; 0xe1;  (* CMOVB (% r12) (% rcx) *)
+  0x4c; 0x0f; 0x42; 0xeb;  (* CMOVB (% r13) (% rbx) *)
+  0x4d; 0x0f; 0x42; 0xf1;  (* CMOVB (% r14) (% r9) *)
+  0x4d; 0x0f; 0x42; 0xfb;  (* CMOVB (% r15) (% r11) *)
+  0x4c; 0x89; 0x27;        (* MOV (Memop Quadword (%% (rdi,0))) (% r12) *)
+  0x4c; 0x89; 0x6f; 0x08;  (* MOV (Memop Quadword (%% (rdi,8))) (% r13) *)
+  0x4c; 0x89; 0x77; 0x10;  (* MOV (Memop Quadword (%% (rdi,16))) (% r14) *)
+  0x4c; 0x89; 0x7f; 0x18;  (* MOV (Memop Quadword (%% (rdi,24))) (% r15) *)
+  0x41; 0x5f;              (* POP (% r15) *)
+  0x41; 0x5e;              (* POP (% r14) *)
+  0x41; 0x5d;              (* POP (% r13) *)
+  0x41; 0x5c;              (* POP (% r12) *)
+  0x5b;                    (* POP (% rbx) *)
+  0xc3                     (* RET *)
+];;
+
+let BIGNUM_MONTSQR_P256_ALT_EXEC = X86_MK_EXEC_RULE bignum_montsqr_p256_alt_mc;;
+
+(* ------------------------------------------------------------------------- *)
+(* Proof.                                                                    *)
+(* ------------------------------------------------------------------------- *)
+
+let p_256 = new_definition `p_256 = 115792089210356248762697446949407573530086143415290314195533631308867097853951`;;
+
+let BIGNUM_MONTSQR_P256_ALT_CORRECT = time prove
+ (`!z x a pc.
+        nonoverlapping (word pc,0x1d5) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read RIP s = word(pc + 0x09) /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read RIP s = word (pc + 0x1cb) /\
+                  (a EXP 2 <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a EXP 2) MOD p_256))
+             (MAYCHANGE [RIP; RAX; RBX; RCX; RDX;
+                         R8; R9; R10; R11; R12; R13; R14; R15] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+
+  (*** Globalize the a EXP 2 <= 2 EXP 256 * p_256  assumption ***)
+
+  ASM_CASES_TAC `a EXP 2 <= 2 EXP 256 * p_256` THENL
+   [ASM_REWRITE_TAC[]; X86_SIM_TAC BIGNUM_MONTSQR_P256_ALT_EXEC (1--137)] THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+
+  MAP_EVERY (fun n ->
+    X86_STEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC [n] THEN
+    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
+    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
+   (1--119) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[WORD_NEG_EQ_0; WORD_BITVAL_EQ_0]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s102; sum_s110; sum_s117; sum_s118; sum_s119]` THEN
+  SUBGOAL_THEN
+   `t < 2 * p_256 /\ (2 EXP 256 * t == a EXP 2) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [RULE_ASSUM_TAC(REWRITE_RULE[VAL_WORD_BITVAL]) THEN
+    ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP (ARITH_RULE
+        `ab <= 2 EXP 256 * p
+         ==> 2 EXP 256 * t < ab + 2 EXP 256 * p ==> t < 2 * p`)) THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  X86_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC
+    [121;123;126;128;129] (120--137) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(LAND_CONV BIGNUM_EXPAND_CONV) THEN ASM_REWRITE_TAC[] THEN
+  TRANS_TAC EQ_TRANS `t MOD p_256` THEN CONJ_TAC THENL
+   [ALL_TAC;
+    REWRITE_TAC[GSYM CONG] THEN FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == a EXP 2) (mod p)
+        ==> (e * i == 1) (mod p) ==> (t == i * a EXP 2) (mod p)`)) THEN
+    REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+    REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV] THEN
+  CONV_TAC SYM_CONV THEN MATCH_MP_TAC EQUAL_FROM_CONGRUENT_MOD_MOD THEN
+  MAP_EVERY EXISTS_TAC
+   [`256`; `if t < p_256 then &t:real else &t - &p_256`] THEN
+  REPEAT CONJ_TAC THENL
+   [REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    REWRITE_TAC[p_256] THEN ARITH_TAC;
+    ALL_TAC;
+    ASM_SIMP_TAC[MOD_CASES] THEN
+    GEN_REWRITE_TAC LAND_CONV [COND_RAND] THEN
+    SIMP_TAC[REAL_OF_NUM_SUB; GSYM NOT_LT]] THEN
+  SUBGOAL_THEN `carry_s129 <=> p_256 <= t` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LE THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    REWRITE_TAC[GSYM NOT_LT; COND_SWAP]] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN EXPAND_TAC "t" THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist; p_256] THEN
+  ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  ASM_REWRITE_TAC[BITVAL_CLAUSES; VAL_WORD_BITVAL] THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_MONTSQR_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc stackpointer returnaddress.
+        nonoverlapping (z,8 * 4) (word_sub stackpointer (word 40),48) /\
+        ALL (nonoverlapping (word_sub stackpointer (word 40),40))
+            [(word pc,0x1d5); (x,8 * 4)] /\
+        nonoverlapping (word pc,0x1d5) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read RIP s = word pc /\
+                  read RSP s = stackpointer /\
+                  read (memory :> bytes64 stackpointer) s = returnaddress /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read RIP s = returnaddress /\
+                  read RSP s = word_add stackpointer (word 8) /\
+                  (a EXP 2 <= 2 EXP 256 * p_256
+                   ==> bignum_from_memory (z,4) s =
+                       (inverse_mod p_256 (2 EXP 256) * a EXP 2) MOD p_256))
+             (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9; R10; R11] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4);
+                       memory :> bytes(word_sub stackpointer (word 40),40)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_STACK_TAC
+   BIGNUM_MONTSQR_P256_ALT_EXEC BIGNUM_MONTSQR_P256_ALT_CORRECT
+   `[RBX; R12; R13; R14; R15]` 40);;
+
+(* ------------------------------------------------------------------------- *)
+(* Show that it also works as "almost-Montgomery" if desired. That is, even  *)
+(* without the further range assumption on inputs we still get a congruence. *)
+(* But the output, still 256 bits, may then not be fully reduced mod p_256.  *)
+(* ------------------------------------------------------------------------- *)
+
+let BIGNUM_AMONTSQR_P256_ALT_CORRECT = time prove
+ (`!z x a pc.
+        nonoverlapping (word pc,0x1d5) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read RIP s = word(pc + 0x09) /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read RIP s = word (pc + 0x1cb) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a EXP 2) (mod p_256))
+             (MAYCHANGE [RIP; RAX; RBX; RCX; RDX;
+                         R8; R9; R10; R11; R12; R13; R14; R15] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  MAP_EVERY X_GEN_TAC [`z:int64`; `x:int64`; `a:num`; `pc:num`] THEN
+  REWRITE_TAC[C_ARGUMENTS; C_RETURN; SOME_FLAGS; NONOVERLAPPING_CLAUSES] THEN
+  DISCH_THEN(REPEAT_TCL CONJUNCTS_THEN ASSUME_TAC) THEN
+  ENSURES_INIT_TAC "s0" THEN
+  BIGNUM_DIGITIZE_TAC "x_" `bignum_from_memory (x,4) s0` THEN
+
+  MAP_EVERY (fun n ->
+    X86_STEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC [n] THEN
+    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
+    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
+   (1--119) THEN
+  RULE_ASSUM_TAC(REWRITE_RULE[WORD_NEG_EQ_0; WORD_BITVAL_EQ_0]) THEN
+  ABBREV_TAC
+   `t = bignum_of_wordlist
+          [sum_s102; sum_s110; sum_s117; sum_s118; sum_s119]` THEN
+  SUBGOAL_THEN
+   `t < 2 EXP 256 + p_256 /\ (2 EXP 256 * t == a EXP 2) (mod p_256)`
+  STRIP_ASSUME_TAC THENL
+   [RULE_ASSUM_TAC(REWRITE_RULE[VAL_WORD_BITVAL]) THEN
+    ACCUMULATOR_POP_ASSUM_LIST
+     (STRIP_ASSUME_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    CONJ_TAC THENL
+     [MATCH_MP_TAC(ARITH_RULE
+       `2 EXP 256 * t <= (2 EXP 256 - 1) EXP 2 + (2 EXP 256 - 1) * p
+        ==> t < 2 EXP 256 + p`) THEN
+      REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      REWRITE_TAC[p_256; REAL_ARITH `a:real < b + c <=> a - b < c`] THEN
+      ASM_REWRITE_TAC[] THEN BOUNDER_TAC[];
+      REWRITE_TAC[REAL_CONGRUENCE; p_256] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      MAP_EVERY EXPAND_TAC ["a"; "t"] THEN
+      REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES; bignum_of_wordlist] THEN
+      ASM_REWRITE_TAC[] THEN REAL_INTEGER_TAC];
+    ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
+
+  (*** Final correction stage ***)
+
+  X86_ACCSTEPS_TAC BIGNUM_MONTSQR_P256_ALT_EXEC
+   [121;123;126;128;129] (120--137) THEN
+  ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+  FIRST_X_ASSUM(MATCH_MP_TAC o MATCH_MP
+     (NUMBER_RULE
+       `(e * t == ab) (mod p)
+        ==> (e * i == 1) (mod p) /\ (s == t) (mod p)
+            ==> (s == i * ab) (mod p)`)) THEN
+  REWRITE_TAC[INVERSE_MOD_RMUL_EQ; COPRIME_REXP; COPRIME_2] THEN
+  CONJ_TAC THENL
+   [REWRITE_TAC[p_256] THEN CONV_TAC NUM_REDUCE_CONV; ALL_TAC] THEN
+  SUBGOAL_THEN `carry_s129 <=> p_256 <= t` SUBST_ALL_TAC THENL
+   [MATCH_MP_TAC FLAG_FROM_CARRY_LE THEN EXISTS_TAC `320` THEN
+    EXPAND_TAC "t" THEN
+    REWRITE_TAC[p_256; bignum_of_wordlist; GSYM REAL_OF_NUM_CLAUSES] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN
+    ACCUMULATOR_POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o DECARRY_RULE) THEN
+    DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN BOUNDER_TAC[];
+    REWRITE_TAC[GSYM NOT_LT; COND_SWAP]] THEN
+  MATCH_MP_TAC(NUMBER_RULE `!b:num. x + b * p = y ==> (x == y) (mod p)`) THEN
+  EXISTS_TAC `bitval(p_256 <= t)` THEN
+  REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN REWRITE_TAC[REAL_OF_NUM_LE] THEN
+  ONCE_REWRITE_TAC[REAL_ARITH `a + b:real = c <=> c - b = a`] THEN
+  MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
+  MAP_EVERY EXISTS_TAC [`256`; `&0:real`] THEN CONJ_TAC THENL
+   [UNDISCH_TAC `t < 2 EXP 256 + p_256` THEN
+    REWRITE_TAC[bitval; p_256; GSYM REAL_OF_NUM_CLAUSES] THEN REAL_ARITH_TAC;
+    REWRITE_TAC[INTEGER_CLOSED]] THEN
+  CONJ_TAC THENL
+   [CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+    REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN BOUNDER_TAC[];
+    ALL_TAC] THEN
+  CONV_TAC(ONCE_DEPTH_CONV BIGNUM_EXPAND_CONV) THEN
+  REWRITE_TAC[bitval] THEN COND_CASES_TAC THEN
+  EXPAND_TAC "t" THEN REWRITE_TAC[bignum_of_wordlist] THEN
+  ASM_REWRITE_TAC[GSYM REAL_OF_NUM_CLAUSES] THEN
+  ACCUMULATOR_POP_ASSUM_LIST (MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
+  DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
+  REWRITE_TAC[BITVAL_CLAUSES; p_256] THEN
+  CONV_TAC WORD_REDUCE_CONV THEN REAL_INTEGER_TAC);;
+
+let BIGNUM_AMONTSQR_P256_ALT_SUBROUTINE_CORRECT = time prove
+ (`!z x a pc stackpointer returnaddress.
+        nonoverlapping (z,8 * 4) (word_sub stackpointer (word 40),48) /\
+        ALL (nonoverlapping (word_sub stackpointer (word 40),40))
+            [(word pc,0x1d5); (x,8 * 4)] /\
+        nonoverlapping (word pc,0x1d5) (z,8 * 4)
+        ==> ensures x86
+             (\s. bytes_loaded s (word pc) bignum_montsqr_p256_alt_mc /\
+                  read RIP s = word pc /\
+                  read RSP s = stackpointer /\
+                  read (memory :> bytes64 stackpointer) s = returnaddress /\
+                  C_ARGUMENTS [z; x] s /\
+                  bignum_from_memory (x,4) s = a)
+             (\s. read RIP s = returnaddress /\
+                  read RSP s = word_add stackpointer (word 8) /\
+                  (bignum_from_memory (z,4) s ==
+                   inverse_mod p_256 (2 EXP 256) * a EXP 2) (mod p_256))
+             (MAYCHANGE [RIP; RSP; RAX; RCX; RDX; R8; R9; R10; R11] ,,
+              MAYCHANGE [memory :> bytes(z,8 * 4);
+                       memory :> bytes(word_sub stackpointer (word 40),40)] ,,
+              MAYCHANGE SOME_FLAGS)`,
+  X86_ADD_RETURN_STACK_TAC
+   BIGNUM_MONTSQR_P256_ALT_EXEC BIGNUM_AMONTSQR_P256_ALT_CORRECT
+   `[RBX; R12; R13; R14; R15]` 40);;

--- a/x86_att/Makefile
+++ b/x86_att/Makefile
@@ -108,7 +108,9 @@ OBJ = fastmul/bignum_emontredc_8n.o \
       p256/bignum_mod_p256.o \
       p256/bignum_mod_p256_4.o \
       p256/bignum_montmul_p256.o \
+      p256/bignum_montmul_p256_alt.o \
       p256/bignum_montsqr_p256.o \
+      p256/bignum_montsqr_p256_alt.o \
       p256/bignum_mux_4.o \
       p256/bignum_neg_p256.o \
       p256/bignum_nonzero_4.o \

--- a/x86_att/p256/bignum_montmul_p256_alt.S
+++ b/x86_att/p256/bignum_montmul_p256_alt.S
@@ -1,0 +1,209 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery multiply, z := (x * y / 2^256) mod p_256
+// Inputs x[4], y[4]; output z[4]
+//
+//    extern void bignum_montmul_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//
+// Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
+// satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in
+// the "usual" case x < p_256 and y < p_256).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montmul_p256_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// We move the y argument here so we can use %rdx for multipliers
+
+#define y %rcx
+
+// Add %rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using %rax and %rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high
+
+bignum_montmul_p256_alt:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Copy y into a safe register to start with
+
+        movq    %rdx, y
+
+// Do row 0 computation, which is a bit different:
+// set up initial window [%r12,%r11,%r10,%r9,%r8] = y[0] * x
+// Unlike later, we only need a single carry chain
+
+        movq    (y), %rbx
+        movq    (x), %rax
+        mulq    %rbx
+        movq    %rax, %r8
+        movq    %rdx, %r9
+
+        movq    8(x), %rax
+        mulq    %rbx
+        xorl    %r10d, %r10d
+        addq    %rax, %r9
+        adcq    %rdx, %r10
+
+        movq    16(x), %rax
+        mulq    %rbx
+        xorl    %r11d, %r11d
+        addq    %rax, %r10
+        adcq    %rdx, %r11
+
+        movq    24(x), %rax
+        mulq    %rbx
+        xorl    %r12d, %r12d
+        addq    %rax, %r11
+        adcq    %rdx, %r12
+
+// Add row 1
+
+        movq    8(y), %rbx
+        xorl    %r13d, %r13d
+        mulpadi(%r14,%r10,%r9,(x))
+        mulpadd(%r14,%r11,%r10,8(x))
+        mulpadd(%r14,%r12,%r11,16(x))
+        mulpade(%r14,%r13,%r12,24(x))
+
+// Montgomery reduce windows 0 and 1 together
+
+        xorl    %r14d, %r14d
+        movq    $0x0000000100000000, %rbx
+        mulpadi(%r15,%r10,%r9,%r8)
+        mulpadd(%r15,%r11,%r10,%r9)
+        notq    %rbx
+        leaq    2(%rbx), %rbx
+        mulpadd(%r15,%r12,%r11,%r8)
+        mulpade(%r15,%r13,%r12,%r9)
+        adcq    %r14, %r14
+
+// Add row 2
+
+        movq    16(y), %rbx
+        xorl    %r15d, %r15d
+        mulpadi(%r8,%r11,%r10,(x))
+        mulpadd(%r8,%r12,%r11,8(x))
+        mulpadd(%r8,%r13,%r12,16(x))
+        mulpade(%r8,%r14,%r13,24(x))
+        adcq    %r15, %r15
+
+// Add row 3
+
+        movq    24(y), %rbx
+        xorl    %r8d, %r8d
+        mulpadi(%r9,%r12,%r11,(x))
+        mulpadd(%r9,%r13,%r12,8(x))
+        mulpadd(%r9,%r14,%r13,16(x))
+        mulpade(%r9,%r15,%r14,24(x))
+        adcq    %r8, %r8
+
+// Montgomery reduce windows 2 and 3 together
+
+        xorl    %r9d, %r9d
+        movq    $0x0000000100000000, %rbx
+        mulpadi(%rcx,%r12,%r11,%r10)
+        mulpadd(%rcx,%r13,%r12,%r11)
+        notq    %rbx
+        leaq    2(%rbx), %rbx
+        mulpadd(%rcx,%r14,%r13,%r10)
+        mulpade(%rcx,%r15,%r14,%r11)
+        adcq    %r9, %r8
+
+// We now have a pre-reduced 5-word form [%r8; %r15;%r14;%r13;%r12]
+// Load [%rax;%r11;%rbx;%rdx;%rcx] = 2^320 - p_256, re-using earlier numbers a bit
+// Do [%rax;%r11;%rbx;%rdx;%rcx] = [%r8;%r15;%r14;%r13;%r12] + (2^320 - p_256)
+
+        movl    $1, %ecx
+        addq    %r12, %rcx
+        decq    %rbx
+        adcq    %r13, %rbx
+        decq    %r9
+        movq    %r9, %rax
+        adcq    %r14, %r9
+        movl    $0x00000000fffffffe, %r11d
+        adcq    %r15, %r11
+        adcq    %r8, %rax
+
+// Now carry is set if r + (2^320 - p_256) >= 2^320, i.e. r >= p_256
+// where r is the pre-reduced form. So conditionally select the
+// output accordingly.
+
+        cmovcq  %rcx, %r12
+        cmovcq  %rbx, %r13
+        cmovcq  %r9, %r14
+        cmovcq  %r11, %r15
+
+// Write back reduced value
+
+        movq    %r12, (z)
+        movq    %r13, 8(z)
+        movq    %r14, 16(z)
+        movq    %r15, 24(z)
+
+// Restore registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif

--- a/x86_att/p256/bignum_montsqr_p256_alt.S
+++ b/x86_att/p256/bignum_montsqr_p256_alt.S
@@ -1,0 +1,208 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "LICENSE" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+// ----------------------------------------------------------------------------
+// Montgomery square, z := (x^2 / 2^256) mod p_256
+// Input x[4]; output z[4]
+//
+//    extern void bignum_montsqr_p256_alt
+//     (uint64_t z[static 4], uint64_t x[static 4]);
+//
+// Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
+// guaranteed in particular if x < p_256 initially (the "intended" case).
+//
+// Standard x86-64 ABI: RDI = z, RSI = x
+// ----------------------------------------------------------------------------
+
+
+        .globl  bignum_montsqr_p256_alt
+        .text
+
+#define z %rdi
+#define x %rsi
+
+// Add %rbx * m into a register-pair (high,low) maintaining consistent
+// carry-catching with carry (negated, as bitmask) and using %rax and %rdx
+// as temporaries
+
+#define mulpadd(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// Initial version assuming no carry-in
+
+#define mulpadi(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        addq    %rax, low ;               \
+        adcq    %rdx, high ;              \
+        sbbq    carry, carry
+
+// End version not catching the top carry-out
+
+#define mulpade(carry,high,low,m)       \
+        movq    m, %rax ;                 \
+        mulq    %rbx;                    \
+        subq    carry, %rdx ;             \
+        addq    %rax, low ;               \
+        adcq    %rdx, high
+
+bignum_montsqr_p256_alt:
+
+// Save more registers to play with
+
+        pushq   %rbx
+        pushq   %r12
+        pushq   %r13
+        pushq   %r14
+        pushq   %r15
+
+// Compute [%r15;%r8] = [00] which we use later, but mainly
+// set up an initial window [%r14;...;%r9] = [23;03;01]
+
+        movq    (x), %rax
+        movq    %rax, %rbx
+        mulq    %rax
+        movq    %rax, %r8
+        movq    %rdx, %r15
+        movq    8(x), %rax
+        mulq    %rbx
+        movq    %rax, %r9
+        movq    %rdx, %r10
+        movq    24(x), %rax
+        movq    %rax, %r13
+        mulq    %rbx
+        movq    %rax, %r11
+        movq    %rdx, %r12
+        movq    16(x), %rax
+        movq    %rax, %rbx
+        mulq    %r13
+        movq    %rax, %r13
+        movq    %rdx, %r14
+
+// Chain in the addition of 02 + 12 + 13 to that window (no carry-out possible)
+// This gives all the "heterogeneous" terms of the squaring ready to double
+
+        mulpadi(%rcx,%r11,%r10,(x))
+        mulpadd(%rcx,%r12,%r11,8(x))
+        movq    24(x), %rbx
+        mulpade(%rcx,%r13,%r12,8(x))
+        adcq    $0, %r14
+
+// Double the window [%r14;...;%r9], catching top carry in %rcx
+
+        xorl    %ecx, %ecx
+        addq    %r9, %r9
+        adcq    %r10, %r10
+        adcq    %r11, %r11
+        adcq    %r12, %r12
+        adcq    %r13, %r13
+        adcq    %r14, %r14
+        adcq    %rcx, %rcx
+
+// Add to the 00 + 11 + 22 + 33 terms
+
+        movq    8(x), %rax
+        mulq    %rax
+        addq    %r15, %r9
+        adcq    %rax, %r10
+        adcq    %rdx, %r11
+        sbbq    %r15, %r15
+        movq    16(x), %rax
+        mulq    %rax
+        negq    %r15
+        adcq    %rax, %r12
+        adcq    %rdx, %r13
+        sbbq    %r15, %r15
+        movq    24(x), %rax
+        mulq    %rax
+        negq    %r15
+        adcq    %rax, %r14
+        adcq    %rcx, %rdx
+        movq    %rdx, %r15
+
+// First two waves of Montgomery reduction, now re-using %r8 for top carry
+
+        movq    $0x0000000100000000, %rbx
+        mulpadi(%rcx,%r10,%r9,%r8)
+        mulpadd(%rcx,%r11,%r10,%r9)
+        notq    %rbx
+        leaq    2(%rbx), %rbx
+        mulpadd(%rcx,%r12,%r11,%r8)
+        xorl    %r8d, %r8d
+        mulpade(%rcx,%r13,%r12,%r9)
+        adcq    %r8, %r14
+        adcq    %r8, %r15
+        adcq    %r8, %r8
+
+// Now two more steps of Montgomery reduction, again with %r8 = top carry
+
+        movq    $0x0000000100000000, %rbx
+        mulpadi(%rcx,%r12,%r11,%r10)
+        mulpadd(%rcx,%r13,%r12,%r11)
+        notq    %rbx
+        leaq    2(%rbx), %rbx
+        mulpadd(%rcx,%r14,%r13,%r10)
+        xorl    %r9d, %r9d
+        mulpade(%rcx,%r15,%r14,%r11)
+        adcq    %r9, %r8
+
+// Load [%rax;%r11;%r9;%rbx;%rcx] = 2^320 - p_256, re-using earlier numbers a bit
+// Do [%rax;%r11;%r9;%rbx;%rcx] = [%r8;%r15;%r14;%r13;%r12] + (2^320 - p_256)
+
+        movl    $1, %ecx
+        addq    %r12, %rcx
+        leaq    -1(%rbx), %rbx
+        adcq    %r13, %rbx
+        leaq    -1(%r9), %r9
+        movq    %r9, %rax
+        adcq    %r14, %r9
+        movl    $0x00000000fffffffe, %r11d
+        adcq    %r15, %r11
+        adcq    %r8, %rax
+
+// Now carry is set if r + (2^320 - p_256) >= 2^320, i.e. r >= p_256
+// where r is the pre-reduced form. So conditionally select the
+// output accordingly.
+
+        cmovcq  %rcx, %r12
+        cmovcq  %rbx, %r13
+        cmovcq  %r9, %r14
+        cmovcq  %r11, %r15
+
+// Write back reduced value
+
+        movq    %r12, (z)
+        movq    %r13, 8(z)
+        movq    %r14, 16(z)
+        movq    %r15, 24(z)
+
+// Restore saved registers and return
+
+        popq    %r15
+        popq    %r14
+        popq    %r13
+        popq    %r12
+        popq    %rbx
+
+        ret
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Continuing the addition of alternative microarchitecture versions, faster on some ARM machines, more portable to older x86 machines. This covers the Montgomery operations (multiplication and squaring) for NIST P-256.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
