### PR TITLE
Optimize modular inverse inner loop

### DIFF
--- a/arm/generic/bignum_coprime.S
+++ b/arm/generic/bignum_coprime.S
@@ -261,66 +261,64 @@ toploop:
 
                 mov     i, #CHUNKSIZE
 
-innerloop:
-
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                and     t1, m_lo, #1
-                mov     t2, #2
-                subs    xzr, m_hi, n_hi
-                sbcs    xzr, t2, t1
-
-// Precalculate these, since a swap makes no difference to their sum
-
-                add     c1, m_m, n_m
-                add     c2, m_n, n_n
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                mov     t1, m_hi
-                csel    m_hi, n_hi, m_hi, eq
-                csel    n_hi, t1, n_hi, eq
-                mov     t1, m_lo
-                csel    m_lo, n_lo, m_lo, eq
-                csel    n_lo, t1, n_lo, eq
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                mov     t1, m_m
-                csel    m_m, n_m, m_m, eq
-                csel    n_m, t1, n_m, eq
-                mov     t1, m_n
-                csel    m_n, n_n, m_n, eq
-                csel    n_n, t1, n_n, eq
-
-// b = (m_lo & 1ull);
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed. It also maintains the invariant ~ZF <=> odd(m_lo),
+// since it seems to reduce the dependent latency. Set that up first.
 
                 ands    xzr, m_lo, #1
 
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
+innerloop:
 
-                sub     t1, m_hi, n_hi
-                csel    m_hi, t1, m_hi, ne
-                sub     t1, m_lo, n_lo
-                csel    m_lo, t1, m_lo, ne
+// At the start of the loop ~ZF <=> m_lo is odd; mask values accordingly
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                csel    t1, n_hi, xzr, ne
+                csel    t2, n_lo, xzr, ne
+                csel    c1, n_m, xzr, ne
+                csel    c2, n_n, xzr, ne
 
-                csel    m_m, c1, m_m, ne
-                csel    m_n, c2, m_n, ne
+// Compute subtractive updates, which are trivial in the case even(m_lo).
+// Set the flags with the m_hi := m_hi - n_hi so we know to flip things
 
-// m_hi >>= 1; m_lo >>= 1;
-// n_m <<= 1; n_n <<= 1;
+                subs    t1, m_hi, t1
+                sub     t2, m_lo, t2
 
-                lsr     m_hi, m_hi, #1
-                lsr     m_lo, m_lo, #1
+// If the subtraction borrows, swap things appropriately, negating where
+// we've already subtracted so things are as if we actually swapped first.
+
+                cneg    t1, t1, cc
+                cneg    t2, t2, cc
+                csel    n_hi, n_hi, m_hi, cs
+                csel    n_lo, n_lo, m_lo, cs
+                csel    n_m, n_m, m_m, cs
+                csel    n_n, n_n, m_n, cs
+
+// Update and shift while setting oddness flag for next iteration
+
+                ands    xzr, t2, #2
+                add     m_m, m_m, c1
+                add     m_n, m_n, c2
+                lsr     m_hi, t1, #1
+                lsr     m_lo, t2, #1
                 add     n_m, n_m, n_m
                 add     n_n, n_n, n_n
 
-// Next iteration
+// Next iteration; don't disturb the flags since they are used at entry
 
-                subs    i, i, #1
-                bne     innerloop
+                sub     i, i, #1
+                cbnz    i, innerloop
 
 // Now actually compute the updates to m and n corresponding to that matrix,
 // and correct the signs if they have gone negative. First we compute the

--- a/arm/generic/bignum_modinv.S
+++ b/arm/generic/bignum_modinv.S
@@ -244,66 +244,64 @@ toploop:
 
                 mov     i, #CHUNKSIZE
 
-innerloop:
-
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                and     t1, m_lo, #1
-                mov     t2, #2
-                subs    xzr, m_hi, n_hi
-                sbcs    xzr, t2, t1
-
-// Precalculate these, since a swap makes no difference to their sum
-
-                add     c1, m_m, n_m
-                add     c2, m_n, n_n
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                mov     t1, m_hi
-                csel    m_hi, n_hi, m_hi, eq
-                csel    n_hi, t1, n_hi, eq
-                mov     t1, m_lo
-                csel    m_lo, n_lo, m_lo, eq
-                csel    n_lo, t1, n_lo, eq
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                mov     t1, m_m
-                csel    m_m, n_m, m_m, eq
-                csel    n_m, t1, n_m, eq
-                mov     t1, m_n
-                csel    m_n, n_n, m_n, eq
-                csel    n_n, t1, n_n, eq
-
-// b = (m_lo & 1ull);
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed. It also maintains the invariant ~ZF <=> odd(m_lo),
+// since it seems to reduce the dependent latency. Set that up first.
 
                 ands    xzr, m_lo, #1
 
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
+innerloop:
 
-                sub     t1, m_hi, n_hi
-                csel    m_hi, t1, m_hi, ne
-                sub     t1, m_lo, n_lo
-                csel    m_lo, t1, m_lo, ne
+// At the start of the loop ~ZF <=> m_lo is odd; mask values accordingly
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                csel    t1, n_hi, xzr, ne
+                csel    t2, n_lo, xzr, ne
+                csel    c1, n_m, xzr, ne
+                csel    c2, n_n, xzr, ne
 
-                csel    m_m, c1, m_m, ne
-                csel    m_n, c2, m_n, ne
+// Compute subtractive updates, which are trivial in the case even(m_lo).
+// Set the flags with the m_hi := m_hi - n_hi so we know to flip things
 
-// m_hi >>= 1; m_lo >>= 1;
-// n_m <<= 1; n_n <<= 1;
+                subs    t1, m_hi, t1
+                sub     t2, m_lo, t2
 
-                lsr     m_hi, m_hi, #1
-                lsr     m_lo, m_lo, #1
+// If the subtraction borrows, swap things appropriately, negating where
+// we've already subtracted so things are as if we actually swapped first.
+
+                cneg    t1, t1, cc
+                cneg    t2, t2, cc
+                csel    n_hi, n_hi, m_hi, cs
+                csel    n_lo, n_lo, m_lo, cs
+                csel    n_m, n_m, m_m, cs
+                csel    n_n, n_n, m_n, cs
+
+// Update and shift while setting oddness flag for next iteration
+
+                ands    xzr, t2, #2
+                add     m_m, m_m, c1
+                add     m_n, m_n, c2
+                lsr     m_hi, t1, #1
+                lsr     m_lo, t2, #1
                 add     n_m, n_m, n_m
                 add     n_n, n_n, n_n
 
-// Next iteration
+// Next iteration; don't disturb the flags since they are used at entry
 
-                subs    i, i, #1
-                bne     innerloop
+                sub     i, i, #1
+                cbnz    i, innerloop
 
 // Apply the update to w and z, using addition in this case, and also take
 // the chance to shift an additional 6 = 64-CHUNKSIZE bits to be ready for a

--- a/arm/proofs/bignum_coprime.ml
+++ b/arm/proofs/bignum_coprime.ml
@@ -26,8 +26,8 @@ let bignum_coprime_mc =
   0xa9bf53f3;       (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   0xeb02001f;       (* arm_CMP X0 X2 *)
   0x9a803049;       (* arm_CSEL X9 X2 X0 Condition_CC *)
-  0xb40019c9;       (* arm_CBZ X9 (word 824) *)
-  0xd37df12a;       (* arm_LSL X10 X9 (rvalue (word 3)) *)
+  0xb40018a9;       (* arm_CBZ X9 (word 788) *)
+  0xd37df12a;       (* arm_LSL X10 X9 3 *)
   0x8b0a0085;       (* arm_ADD X5 X4 X10 *)
   0xaa1f03ea;       (* arm_MOV X10 XZR *)
   0xb4000100;       (* arm_CBZ X0 (word 32) *)
@@ -56,7 +56,7 @@ let bignum_coprime_mc =
   0xeb09015f;       (* arm_CMP X10 X9 *)
   0x54ffffa3;       (* arm_BCC (word 2097140) *)
   0x8b020002;       (* arm_ADD X2 X0 X2 *)
-  0xd37ae442;       (* arm_LSL X2 X2 (rvalue (word 6)) *)
+  0xd37ae442;       (* arm_LSL X2 X2 6 *)
   0xf9400080;       (* arm_LDR X0 X4 (Immediate_Offset (word 0)) *)
   0xf94000a6;       (* arm_LDR X6 X5 (Immediate_Offset (word 0)) *)
   0xaa060000;       (* arm_ORR X0 X0 X6 *)
@@ -75,7 +75,7 @@ let bignum_coprime_mc =
   0xeb09015f;       (* arm_CMP X10 X9 *)
   0x54fffec3;       (* arm_BCC (word 2097112) *)
   0x9100fc4a;       (* arm_ADD X10 X2 (rvalue (word 63)) *)
-  0xd346fd43;       (* arm_LSR X3 X10 (rvalue (word 6)) *)
+  0xd346fd43;       (* arm_LSR X3 X10 6 *)
   0xeb09007f;       (* arm_CMP X3 X9 *)
   0x9a832123;       (* arm_CSEL X3 X9 X3 Condition_CS *)
   0xaa1f03ed;       (* arm_MOV X13 XZR *)
@@ -101,12 +101,12 @@ let bignum_coprime_mc =
   0xaa0e01ab;       (* arm_ORR X11 X13 X14 *)
   0xdac0116c;       (* arm_CLZ X12 X11 *)
   0xeb0c03f1;       (* arm_NEGS X17 X12 *)
-  0x9acc21ad;       (* arm_LSL X13 X13 X12 *)
+  0x9acc21ad;       (* arm_LSLV X13 X13 X12 *)
   0x9a9f11ef;       (* arm_CSEL X15 X15 XZR Condition_NE *)
-  0x9acc21ce;       (* arm_LSL X14 X14 X12 *)
+  0x9acc21ce;       (* arm_LSLV X14 X14 X12 *)
   0x9a9f1210;       (* arm_CSEL X16 X16 XZR Condition_NE *)
-  0x9ad125ef;       (* arm_LSR X15 X15 X17 *)
-  0x9ad12610;       (* arm_LSR X16 X16 X17 *)
+  0x9ad125ef;       (* arm_LSRV X15 X15 X17 *)
+  0x9ad12610;       (* arm_LSRV X16 X16 X17 *)
   0xaa0f01ad;       (* arm_ORR X13 X13 X15 *)
   0xaa1001ce;       (* arm_ORR X14 X14 X16 *)
   0xf940008f;       (* arm_LDR X15 X4 (Immediate_Offset (word 0)) *)
@@ -116,37 +116,28 @@ let bignum_coprime_mc =
   0xaa1f03e8;       (* arm_MOV X8 XZR *)
   0xd2800021;       (* arm_MOV X1 (rvalue (word 1)) *)
   0xd280074a;       (* arm_MOV X10 (rvalue (word 58)) *)
-  0x924001eb;       (* arm_AND X11 X15 (rvalue (word 1)) *)
-  0xd280004c;       (* arm_MOV X12 (rvalue (word 2)) *)
-  0xeb0e01bf;       (* arm_CMP X13 X14 *)
-  0xfa0b019f;       (* arm_SBCS XZR X12 X11 *)
-  0x8b0800d1;       (* arm_ADD X17 X6 X8 *)
-  0x8b0100f3;       (* arm_ADD X19 X7 X1 *)
-  0xaa0d03eb;       (* arm_MOV X11 X13 *)
-  0x9a8d01cd;       (* arm_CSEL X13 X14 X13 Condition_EQ *)
-  0x9a8e016e;       (* arm_CSEL X14 X11 X14 Condition_EQ *)
-  0xaa0f03eb;       (* arm_MOV X11 X15 *)
-  0x9a8f020f;       (* arm_CSEL X15 X16 X15 Condition_EQ *)
-  0x9a900170;       (* arm_CSEL X16 X11 X16 Condition_EQ *)
-  0xaa0603eb;       (* arm_MOV X11 X6 *)
-  0x9a860106;       (* arm_CSEL X6 X8 X6 Condition_EQ *)
-  0x9a880168;       (* arm_CSEL X8 X11 X8 Condition_EQ *)
-  0xaa0703eb;       (* arm_MOV X11 X7 *)
-  0x9a870027;       (* arm_CSEL X7 X1 X7 Condition_EQ *)
-  0x9a810161;       (* arm_CSEL X1 X11 X1 Condition_EQ *)
   0xf24001ff;       (* arm_TST X15 (rvalue (word 1)) *)
-  0xcb0e01ab;       (* arm_SUB X11 X13 X14 *)
-  0x9a8d116d;       (* arm_CSEL X13 X11 X13 Condition_NE *)
-  0xcb1001eb;       (* arm_SUB X11 X15 X16 *)
-  0x9a8f116f;       (* arm_CSEL X15 X11 X15 Condition_NE *)
-  0x9a861226;       (* arm_CSEL X6 X17 X6 Condition_NE *)
-  0x9a871267;       (* arm_CSEL X7 X19 X7 Condition_NE *)
-  0xd341fdad;       (* arm_LSR X13 X13 (rvalue (word 1)) *)
-  0xd341fdef;       (* arm_LSR X15 X15 (rvalue (word 1)) *)
+  0x9a9f11cb;       (* arm_CSEL X11 X14 XZR Condition_NE *)
+  0x9a9f120c;       (* arm_CSEL X12 X16 XZR Condition_NE *)
+  0x9a9f1111;       (* arm_CSEL X17 X8 XZR Condition_NE *)
+  0x9a9f1033;       (* arm_CSEL X19 X1 XZR Condition_NE *)
+  0xeb0b01ab;       (* arm_SUBS X11 X13 X11 *)
+  0xcb0c01ec;       (* arm_SUB X12 X15 X12 *)
+  0xda8b256b;       (* arm_CNEG X11 X11 Condition_CC *)
+  0xda8c258c;       (* arm_CNEG X12 X12 Condition_CC *)
+  0x9a8d21ce;       (* arm_CSEL X14 X14 X13 Condition_CS *)
+  0x9a8f2210;       (* arm_CSEL X16 X16 X15 Condition_CS *)
+  0x9a862108;       (* arm_CSEL X8 X8 X6 Condition_CS *)
+  0x9a872021;       (* arm_CSEL X1 X1 X7 Condition_CS *)
+  0xf27f019f;       (* arm_TST X12 (rvalue (word 2)) *)
+  0x8b1100c6;       (* arm_ADD X6 X6 X17 *)
+  0x8b1300e7;       (* arm_ADD X7 X7 X19 *)
+  0xd341fd6d;       (* arm_LSR X13 X11 1 *)
+  0xd341fd8f;       (* arm_LSR X15 X12 1 *)
   0x8b080108;       (* arm_ADD X8 X8 X8 *)
   0x8b010021;       (* arm_ADD X1 X1 X1 *)
-  0xf100054a;       (* arm_SUBS X10 X10 (rvalue (word 1)) *)
-  0x54fffc41;       (* arm_BNE (word 2097032) *)
+  0xd100054a;       (* arm_SUB X10 X10 (rvalue (word 1)) *)
+  0xb5fffd8a;       (* arm_CBNZ X10 (word 2097072) *)
   0xaa1f03ed;       (* arm_MOV X13 XZR *)
   0xaa1f03ee;       (* arm_MOV X14 XZR *)
   0xaa1f03f1;       (* arm_MOV X17 XZR *)
@@ -186,7 +177,7 @@ let bignum_coprime_mc =
   0xb4000166;       (* arm_CBZ X6 (word 44) *)
   0x9100214b;       (* arm_ADD X11 X10 (rvalue (word 8)) *)
   0xf86b688c;       (* arm_LDR X12 X4 (Register_Offset X11) *)
-  0x93cfe98f;       (* arm_EXTR X15 X12 X15 (rvalue (word 58)) *)
+  0x93cfe98f;       (* arm_EXTR X15 X12 X15 58 *)
   0xca1101ef;       (* arm_EOR X15 X15 X17 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a688f;       (* arm_STR X15 X4 (Register_Offset X10) *)
@@ -194,7 +185,7 @@ let bignum_coprime_mc =
   0x9100214a;       (* arm_ADD X10 X10 (rvalue (word 8)) *)
   0xd10004c6;       (* arm_SUB X6 X6 (rvalue (word 1)) *)
   0xb5fffee6;       (* arm_CBNZ X6 (word 2097116) *)
-  0x93cfe9af;       (* arm_EXTR X15 X13 X15 (rvalue (word 58)) *)
+  0x93cfe9af;       (* arm_EXTR X15 X13 X15 58 *)
   0xca1101ef;       (* arm_EOR X15 X15 X17 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a688f;       (* arm_STR X15 X4 (Register_Offset X10) *)
@@ -205,7 +196,7 @@ let bignum_coprime_mc =
   0xb4000166;       (* arm_CBZ X6 (word 44) *)
   0x9100214b;       (* arm_ADD X11 X10 (rvalue (word 8)) *)
   0xf86b68ac;       (* arm_LDR X12 X5 (Register_Offset X11) *)
-  0x93cfe98f;       (* arm_EXTR X15 X12 X15 (rvalue (word 58)) *)
+  0x93cfe98f;       (* arm_EXTR X15 X12 X15 58 *)
   0xca1301ef;       (* arm_EOR X15 X15 X19 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a68af;       (* arm_STR X15 X5 (Register_Offset X10) *)
@@ -213,12 +204,12 @@ let bignum_coprime_mc =
   0x9100214a;       (* arm_ADD X10 X10 (rvalue (word 8)) *)
   0xd10004c6;       (* arm_SUB X6 X6 (rvalue (word 1)) *)
   0xb5fffee6;       (* arm_CBNZ X6 (word 2097116) *)
-  0x93cfe9cf;       (* arm_EXTR X15 X14 X15 (rvalue (word 58)) *)
+  0x93cfe9cf;       (* arm_EXTR X15 X14 X15 58 *)
   0xca1301ef;       (* arm_EOR X15 X15 X19 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a68af;       (* arm_STR X15 X5 (Register_Offset X10) *)
   0xf100e842;       (* arm_SUBS X2 X2 (rvalue (word 58)) *)
-  0x54ffee08;       (* arm_BHI (word 2096576) *)
+  0x54ffef28;       (* arm_BHI (word 2096612) *)
   0xf94000ab;       (* arm_LDR X11 X5 (Immediate_Offset (word 0)) *)
   0xd240016b;       (* arm_EOR X11 X11 (rvalue (word 1)) *)
   0xf100053f;       (* arm_CMP X9 (rvalue (word 1)) *)
@@ -259,10 +250,18 @@ let lemma58 = prove
    `m divides e EXP 2 ==> (e * (e * x + y) + z == e * y + z) (mod m)`) THEN
   REWRITE_TAC[EXP_EXP] THEN MATCH_MP_TAC DIVIDES_EXP_LE_IMP THEN ARITH_TAC);;
 
+let lemmabit1 = prove
+ (`!x:int64. val(word_and x (word 2)) = 0 <=> EVEN(val(word_ushr x 1))`,
+  GEN_TAC THEN SUBST1_TAC(SYM(NUM_REDUCE_CONV `2 EXP 1`)) THEN
+  REWRITE_TAC[WORD_AND_POW2; GSYM NOT_ODD; GSYM BIT_LSB] THEN
+  REWRITE_TAC[BIT_WORD_USHR; ADD_CLAUSES; bitval] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(DEPTH_CONV(NUM_RED_CONV ORELSEC WORD_RED_CONV)));;
+
 let BIGNUM_COPRIME_CORRECT = prove
  (`!m x a n y b w pc.
         ALL (nonoverlapping (w,8 * 2 * MAX (val m) (val n)))
-            [(word pc,0x34c); (x,8 * val m); (y,8 * val n)] /\
+            [(word pc,0x328); (x,8 * val m); (y,8 * val n)] /\
         val m < 2 EXP 57 /\ val n < 2 EXP 57
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_coprime_mc /\
@@ -270,7 +269,7 @@ let BIGNUM_COPRIME_CORRECT = prove
                   C_ARGUMENTS [m;x;n;y;w] s /\
                   bignum_from_memory(x,val m) s = a /\
                   bignum_from_memory(y,val n) s = b)
-             (\s. read PC s = word(pc + 0x344) /\
+             (\s. read PC s = word(pc + 0x320) /\
                   C_RETURN s = if coprime(a,b) then word 1 else word 0)
              (MAYCHANGE [PC; X0; X1; X2; X3; X5; X6; X7; X8; X9; X10; X11;
                          X12; X13; X14; X15; X16; X17; X19; X20] ,,
@@ -667,7 +666,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** The setup of the main outer loop, with the final comparison to 1 ***)
 
-  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xcc` `pc + 0x30c`
+  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xcc` `pc + 0x2e8`
     `\i s. (read X0 s = word_or (word(bigdigit a 0)) (word(bigdigit b 0)) /\
             read X4 s = mm /\
             read X5 s = nn /\
@@ -706,7 +705,7 @@ let BIGNUM_COPRIME_CORRECT = prove
     REWRITE_TAC[EXP] THEN GLOBALIZE_PRECONDITION_TAC THEN
     ASM_REWRITE_TAC[] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x338`
+    ENSURES_SEQUENCE_TAC `pc + 0x314`
      `\s. read X0 s = word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
           (read X11 s = word 0 <=> n = 1)` THEN
     CONJ_TAC THENL
@@ -740,7 +739,7 @@ let BIGNUM_COPRIME_CORRECT = prove
           ASM_CASES_TAC `n = 0` THEN ASM_REWRITE_TAC[ODD] THEN
           ASM_CASES_TAC `m = 0` THEN ASM_REWRITE_TAC[GCD_0]]]] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x318`
+    ENSURES_SEQUENCE_TAC `pc + 0x2f4`
      `\s. read X0 s = word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
           read X5 s = nn /\
           read X9 s = word k /\
@@ -776,7 +775,7 @@ let BIGNUM_COPRIME_CORRECT = prove
       RULE_ASSUM_TAC(REWRITE_RULE[MULT_CLAUSES]) THEN ASM_SIMP_TAC[MOD_LT];
       ALL_TAC] THEN
 
-    ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x324` `pc + 0x330`
+    ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x300` `pc + 0x30c`
      `\i s. read X0 s = word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
             read X5 s = nn /\
             read X9 s = word k /\
@@ -1073,64 +1072,64 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** Now set up the somewhat intricate inner loop invariant ***)
 
-  ENSURES_WHILE_PUP_TAC `58` `pc + 0x174` `pc + 0x1ec`
-   `\i s. (read X0 s = evenor /\
-           read X4 s = mm /\
-           read X5 s = nn /\
-           read X9 s = word k /\
-           read X2 s = word t /\
-           read X3 s = word l /\
-           bignum_from_memory (mm,l) s = m /\
-           bignum_from_memory (nn,l) s = n /\
-           bignum_from_memory (mm,k) s = m0 /\
-           bignum_from_memory (nn,k) s = n0 /\
-           read X10 s = word(58 - i) /\
-           val(read X6 s) + val(read X7 s) <= 2 EXP i /\
-           val(read X8 s) + val(read X1 s) <= 2 EXP i /\
-           (ODD a \/ ODD b
-           ==> ODD(val(read X16 s)) /\
-               gcd(&(val(read X6 s)) * &m - &(val(read X7 s)) * &n:int,
-                   &(val(read X8 s)) * &m - &(val(read X1 s)) * &n) =
-               &2 pow i * gcd(&m,&n) /\
-               ?q. (--(&1) pow q *
-                    (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n):int ==
-                    &2 pow i * &(val(read X15 s))) (mod (&2 pow 64)) /\
-                   (--(--(&1) pow q) *
-                    (&(val(read X8 s)) * &m - &(val(read X1 s)) * &n):int ==
-                    &2 pow i * &(val(read X16 s))) (mod (&2 pow 64)) /\
-                   let m' = --(&1) pow q *
-                            (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n)
-                   and n' = --(--(&1) pow q) *
-                            (&(val(read X8 s)) * &m - &(val(read X1 s)) * &n)
-                   and m_hi = val(read X13 s)
-                   and n_hi = val(read X14 s)
-                   and m_lo = val(read X15 s)
-                   and n_lo = val(read X16 s) in
-                   --(lowerr i) <= &m_hi - m' / &2 zpow (base + &i) /\
-                   &m_hi - m' / &2 zpow (base + &i) <= upperr i /\
-                   --(lowerr i) <= &n_hi - n' / &2 zpow (base + &i) /\
-                   &n_hi - n' / &2 zpow (base + &i) <= upperr i /\
-                   (min (&m) (&n) < &2 zpow base * &2 pow 5
-                    ==> abs(m') * abs(n') <= &2 pow i * &m * &n /\
-                        (i <= 57
-                         ==> &0 <= m' /\ &0 <= n' /\
-                             (m_hi < n_hi /\
-                              m_hi < 2 EXP 5 /\
-                              2 EXP 63 <= 2 EXP i * (n_hi + 31) /\
-                              &m_hi <= m' / &2 zpow (base + &i) /\
-                              m' / &2 zpow (base + &i) <= &m_hi + &1 \/
-                              n_hi < m_hi /\
-                              n_hi < 2 EXP 5 /\
-                              2 EXP 63 <= 2 EXP i * (m_hi + 31) /\
-                              n' / &2 zpow (base + &i) <= &n_hi + &1))) /\
-                   (&0 <= m' /\ &0 <= n' /\
-                    min m' n' <= &2 pow i * min (&m) (&n) /\
-                    m' * n' <= &2 pow i * &m * &n \/
-                    m' < &0 /\ &0 <= n' /\ m_hi < 16 /\
-                    &n_hi < min (&m) (&n) / &2 zpow base + &16 \/
-                    n' < &0 /\ &0 <= m' /\ n_hi < 16 /\
-                    &m_hi < min (&m) (&n) / &2 zpow base + &16))) /\
-          (read ZF s <=> i = 58)` THEN
+  ENSURES_WHILE_UP_TAC `58` `pc + 0x178` `pc + 0x1c8`
+   `\i s. read X0 s = evenor /\
+          read X4 s = mm /\
+          read X5 s = nn /\
+          read X9 s = word k /\
+          read X2 s = word t /\
+          read X3 s = word l /\
+          bignum_from_memory (mm,l) s = m /\
+          bignum_from_memory (nn,l) s = n /\
+          bignum_from_memory (mm,k) s = m0 /\
+          bignum_from_memory (nn,k) s = n0 /\
+          read X10 s = word(58 - i) /\
+          val(read X6 s) + val(read X7 s) <= 2 EXP i /\
+          val(read X8 s) + val(read X1 s) <= 2 EXP i /\
+          (read ZF s <=> EVEN(val(read X15 s))) /\
+          (ODD a \/ ODD b
+          ==> ODD(val(read X16 s)) /\
+              gcd(&(val(read X6 s)) * &m - &(val(read X7 s)) * &n:int,
+                  &(val(read X8 s)) * &m - &(val(read X1 s)) * &n) =
+              &2 pow i * gcd(&m,&n) /\
+              ?q. (--(&1) pow q *
+                   (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n):int ==
+                   &2 pow i * &(val(read X15 s))) (mod (&2 pow 64)) /\
+                  (--(--(&1) pow q) *
+                   (&(val(read X8 s)) * &m - &(val(read X1 s)) * &n):int ==
+                   &2 pow i * &(val(read X16 s))) (mod (&2 pow 64)) /\
+                  let m' = --(&1) pow q *
+                           (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n)
+                  and n' = --(--(&1) pow q) *
+                           (&(val(read X8 s)) * &m - &(val(read X1 s)) * &n)
+                  and m_hi = val(read X13 s)
+                  and n_hi = val(read X14 s)
+                  and m_lo = val(read X15 s)
+                  and n_lo = val(read X16 s) in
+                  --(lowerr i) <= &m_hi - m' / &2 zpow (base + &i) /\
+                  &m_hi - m' / &2 zpow (base + &i) <= upperr i /\
+                  --(lowerr i) <= &n_hi - n' / &2 zpow (base + &i) /\
+                  &n_hi - n' / &2 zpow (base + &i) <= upperr i /\
+                  (min (&m) (&n) < &2 zpow base * &2 pow 5
+                   ==> abs(m') * abs(n') <= &2 pow i * &m * &n /\
+                       (i <= 57
+                        ==> &0 <= m' /\ &0 <= n' /\
+                            (m_hi < n_hi /\
+                             m_hi < 2 EXP 5 /\
+                             2 EXP 63 <= 2 EXP i * (n_hi + 31) /\
+                             &m_hi <= m' / &2 zpow (base + &i) /\
+                             m' / &2 zpow (base + &i) <= &m_hi + &1 \/
+                             n_hi < m_hi /\
+                             n_hi < 2 EXP 5 /\
+                             2 EXP 63 <= 2 EXP i * (m_hi + 31) /\
+                             n' / &2 zpow (base + &i) <= &n_hi + &1))) /\
+                  (&0 <= m' /\ &0 <= n' /\
+                   min m' n' <= &2 pow i * min (&m) (&n) /\
+                   m' * n' <= &2 pow i * &m * &n \/
+                   m' < &0 /\ &0 <= n' /\ m_hi < 16 /\
+                   &n_hi < min (&m) (&n) / &2 zpow base + &16 \/
+                   n' < &0 /\ &0 <= m' /\ n_hi < 16 /\
+                   &m_hi < min (&m) (&n) / &2 zpow base + &16))` THEN
   CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN REPEAT CONJ_TAC THENL
    [ARITH_TAC;
 
@@ -1149,11 +1148,16 @@ let BIGNUM_COPRIME_CORRECT = prove
       GEN_REWRITE_TAC (LAND_CONV o BINOP_CONV)
        [BIGNUM_FROM_MEMORY_EQ_HIGHDIGITS] THEN
       ASM_REWRITE_TAC[] THEN STRIP_TAC] THEN
-    ARM_STEPS_TAC BIGNUM_COPRIME_EXEC (1--20) THEN
+    ARM_STEPS_TAC BIGNUM_COPRIME_EXEC (1--21) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     REWRITE_TAC[SUB_0; VAL_WORD_0; VAL_WORD_1] THEN
     REWRITE_TAC[WORD_SUB_LZERO; WORD_NEG_EQ_0; VAL_EQ_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL [ARITH_TAC; ALL_TAC]) THEN
+    CONJ_TAC THENL
+     [REWRITE_TAC[EVEN_VAL_WORD; WORD_AND_1_BITVAL] THEN
+      REWRITE_TAC[WORD_BITVAL_EQ_0; BIT_LSB; NOT_ODD] THEN
+      REWRITE_TAC[VAL_WORD_BIGDIGIT];
+      ALL_TAC] THEN
     SUBGOAL_THEN
      `word (bigdigit m0 0):int64 = word(m MOD 2 EXP 64) /\
       word (bigdigit n0 0):int64 = word(n MOD 2 EXP 64)`
@@ -1457,33 +1461,20 @@ let BIGNUM_COPRIME_CORRECT = prove
      [`m_m:num`; `m_n:num`; `n_m:num`; `n_n:num`;
       `m_hi:num`; `n_hi:num`; `m_lo:num`; `n_lo:num`] THEN
 
-    ARM_STEPS_TAC BIGNUM_COPRIME_EXEC (1--30) THEN
+    ARM_STEPS_TAC BIGNUM_COPRIME_EXEC (1--20) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
-    DISCARD_STATE_TAC "s30" THEN
+    DISCARD_STATE_TAC "s20" THEN
 
     MATCH_MP_TAC(TAUT `p /\ (p ==> q) ==> p /\ q`) THEN CONJ_TAC THENL
      [REWRITE_TAC[ARITH_RULE `n - (i + 1) = n - i - 1`] THEN
       GEN_REWRITE_TAC RAND_CONV [WORD_SUB] THEN
       ASM_SIMP_TAC[ARITH_RULE `i < 58 ==> 1 <= 58 - i`];
       DISCH_THEN SUBST1_TAC] THEN
-    REWRITE_TAC[CONJ_ASSOC] THEN CONJ_TAC THENL
-     [REWRITE_TAC[GSYM CONJ_ASSOC];
-      VAL_INT64_TAC `58 - (i + 1)` THEN
-      ASM_REWRITE_TAC[] THEN SIMPLE_ARITH_TAC] THEN
 
-    SUBGOAL_THEN
-     `val(word_sub (word 2)
-                   (word_add (word_and (word m_lo) (word 1))
-                             (word (bitval (m_hi < n_hi)))):int64) = 0 <=>
-      m_hi < n_hi /\ ODD m_lo`
-    SUBST1_TAC THENL
-     [POP_ASSUM_LIST(K ALL_TAC) THEN
-      REWRITE_TAC[WORD_AND_1; BIT_LSB_WORD; bitval] THEN
-      REPEAT(COND_CASES_TAC THEN ASM_REWRITE_TAC[]) THEN
-      CONV_TAC WORD_REDUCE_CONV THEN CONV_TAC NUM_REDUCE_CONV;
-      ALL_TAC] THEN
-    REWRITE_TAC[WORD_AND_1_BITVAL; VAL_WORD_BITVAL; BITVAL_EQ_0] THEN
+    REWRITE_TAC[lemmabit1; NOT_EVEN] THEN
+    REWRITE_TAC[MESON[VAL_WORD_0; LE_0; NOT_LT]
+     `val(if p then x else word 0) <= a <=> ~(a < val x /\ p)`] THEN
 
     SUBGOAL_THEN
      `val(word(n_m + n_m):int64) = n_m + n_m /\
@@ -1504,9 +1495,9 @@ let BIGNUM_COPRIME_CORRECT = prove
       ALL_TAC] THEN
 
     ASM_CASES_TAC `m_hi < n_hi /\ ODD m_lo` THEN
-    ASM_REWRITE_TAC[BIT_LSB_WORD] THEN
-    COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
-    REWRITE_TAC[VAL_WORD_USHR; EXP_1] THEN
+    ASM_REWRITE_TAC[WORD_NEG_SUB] THEN
+    TRY COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
+    ASM_REWRITE_TAC[VAL_WORD_USHR; EXP_1; ADD_CLAUSES; WORD_SUB_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL
      [REWRITE_TAC[EXP_ADD] THEN MAP_EVERY UNDISCH_TAC
        [`m_m + m_n <= 2 EXP i`; `n_m + n_n <= 2 EXP i`] THEN
@@ -2181,7 +2172,9 @@ let BIGNUM_COPRIME_CORRECT = prove
     RULE_ASSUM_TAC(REWRITE_RULE[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`]) THEN
     REWRITE_TAC[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`] THEN
     ARM_STEPS_TAC BIGNUM_COPRIME_EXEC [1] THEN
-    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[];
+    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+    SIMP_TAC[VAL_WORD_EQ; DIMINDEX_64; ARITH_RULE `58 - i < 2 EXP 64`] THEN
+    ASM_REWRITE_TAC[SUB_EQ_0; NOT_LE];
 
     ALL_TAC] THEN
 
@@ -2203,7 +2196,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x1f0`
+  ENSURES_SEQUENCE_TAC `pc + 0x1cc`
    `\s. read X0 s = evenor /\
         read X4 s = mm /\
         read X5 s = nn /\
@@ -2416,7 +2409,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** The cross-multiplications loop updating m and n ***)
 
-  ENSURES_WHILE_UP_TAC `l:num` `pc + 0x204` `pc + 0x268`
+  ENSURES_WHILE_UP_TAC `l:num` `pc + 0x1e0` `pc + 0x244`
    `\i s. read X0 s = evenor /\
           read X4 s = mm /\
           read X5 s = nn /\
@@ -2533,7 +2526,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   ABBREV_TAC `sgn1 <=> m':int < &0` THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x270`
+  ENSURES_SEQUENCE_TAC `pc + 0x24c`
    `\s. read X0 s = evenor /\
         read X4 s = mm /\
         read X5 s = nn /\
@@ -2600,7 +2593,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** Optional right shift and negation of m, negloop1 ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x2bc`
+  ENSURES_SEQUENCE_TAC `pc + 0x298`
    `\s. read X0 s = evenor /\
         read X4 s = mm /\
         read X5 s = nn /\
@@ -2627,7 +2620,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
     (*** Attempt to make a unified break at negskip1 to handle l = 1 ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2ac`
+    ENSURES_SEQUENCE_TAC `pc + 0x288`
      `\s. read X0 s = evenor /\
           read X4 s = mm /\
           read X5 s = nn /\
@@ -2675,7 +2668,7 @@ let BIGNUM_COPRIME_CORRECT = prove
         REWRITE_TAC[BITVAL_CLAUSES; ADD_CLAUSES];
         ALL_TAC] THEN
 
-      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x284` `pc + 0x2a8`
+      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x260` `pc + 0x284`
        `\i s. read X0 s = evenor /\
               read X4 s = mm /\
               read X5 s = nn /\
@@ -2946,7 +2939,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   ABBREV_TAC `sgn2 <=> n':int < &0` THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x2bc`
+  ENSURES_SEQUENCE_TAC `pc + 0x298`
    `\s. read X0 s = evenor /\
         read X4 s = mm /\
         read X5 s = nn /\
@@ -3010,7 +3003,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** Optional right shift and negation of n, negloop2 ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x308`
+  ENSURES_SEQUENCE_TAC `pc + 0x2e4`
    `\s. read X0 s = evenor /\
         read X4 s = mm /\
         read X5 s = nn /\
@@ -3035,7 +3028,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
     (*** Attempt to make a unified break at negskip2 to handle l = 1 ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2f8`
+    ENSURES_SEQUENCE_TAC `pc + 0x2d4`
      `\s. read X0 s = evenor /\
           read X4 s = mm /\
           read X5 s = nn /\
@@ -3081,7 +3074,7 @@ let BIGNUM_COPRIME_CORRECT = prove
         REWRITE_TAC[BITVAL_CLAUSES; ADD_CLAUSES];
         ALL_TAC] THEN
 
-      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x2d0` `pc + 0x2f4`
+      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x2ac` `pc + 0x2d0`
        `\i s. read X0 s = evenor /\
               read X4 s = mm /\
               read X5 s = nn /\
@@ -3430,13 +3423,13 @@ let BIGNUM_COPRIME_CORRECT = prove
 let BIGNUM_COPRIME_SUBROUTINE_CORRECT = prove
  (`!m x a n y b w pc stackpointer returnaddress.
         aligned 16 stackpointer /\
-        nonoverlapping (word pc,0x34c) (word_sub stackpointer (word 16),16) /\
+        nonoverlapping (word pc,0x328) (word_sub stackpointer (word 16),16) /\
         nonoverlapping (w,8 * 2 * MAX (val m) (val n))
                        (word_sub stackpointer (word 16),16) /\
         ALLPAIRS nonoverlapping
          [(w,8 * 2 * MAX (val m) (val n));
           (word_sub stackpointer (word 16),16)]
-         [(word pc,0x34c); (x,8 * val m); (y,8 * val n)] /\
+         [(word pc,0x328); (x,8 * val m); (y,8 * val n)] /\
         val m < 2 EXP 57 /\ val n < 2 EXP 57
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_coprime_mc /\

--- a/arm/proofs/bignum_modinv.ml
+++ b/arm/proofs/bignum_modinv.ml
@@ -25,8 +25,8 @@ let bignum_modinv_mc =
 [
   0xa9bf53f3;       (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   0xa9bf5bf5;       (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
-  0xb40027c0;       (* arm_CBZ X0 (word 1272) *)
-  0xd37df00a;       (* arm_LSL X10 X0 (rvalue (word 3)) *)
+  0xb40026a0;       (* arm_CBZ X0 (word 1236) *)
+  0xd37df00a;       (* arm_LSL X10 X0 3 *)
   0x8b0a0095;       (* arm_ADD X21 X4 X10 *)
   0x8b0a02b6;       (* arm_ADD X22 X21 X10 *)
   0xaa1f03ea;       (* arm_MOV X10 XZR *)
@@ -42,7 +42,7 @@ let bignum_modinv_mc =
   0xf940008b;       (* arm_LDR X11 X4 (Immediate_Offset (word 0)) *)
   0xd100056c;       (* arm_SUB X12 X11 (rvalue (word 1)) *)
   0xf900008c;       (* arm_STR X12 X4 (Immediate_Offset (word 0)) *)
-  0xd37ef574;       (* arm_LSL X20 X11 (rvalue (word 2)) *)
+  0xd37ef574;       (* arm_LSL X20 X11 2 *)
   0xcb140174;       (* arm_SUB X20 X11 X20 *)
   0xd27f0294;       (* arm_EOR X20 X20 (rvalue (word 2)) *)
   0xd280002c;       (* arm_MOV X12 (rvalue (word 1)) *)
@@ -54,9 +54,9 @@ let bignum_modinv_mc =
   0x9b0c7d8b;       (* arm_MUL X11 X12 X12 *)
   0x9b145194;       (* arm_MADD X20 X12 X20 X20 *)
   0x9b145174;       (* arm_MADD X20 X11 X20 X20 *)
-  0xd379e002;       (* arm_LSL X2 X0 (rvalue (word 7)) *)
+  0xd379e002;       (* arm_LSL X2 X0 7 *)
   0x9100fc4a;       (* arm_ADD X10 X2 (rvalue (word 63)) *)
-  0xd346fd45;       (* arm_LSR X5 X10 (rvalue (word 6)) *)
+  0xd346fd45;       (* arm_LSR X5 X10 6 *)
   0xeb0000bf;       (* arm_CMP X5 X0 *)
   0x9a852005;       (* arm_CSEL X5 X0 X5 Condition_CS *)
   0xaa1f03ed;       (* arm_MOV X13 XZR *)
@@ -82,12 +82,12 @@ let bignum_modinv_mc =
   0xaa0e01ab;       (* arm_ORR X11 X13 X14 *)
   0xdac0116c;       (* arm_CLZ X12 X11 *)
   0xeb0c03f1;       (* arm_NEGS X17 X12 *)
-  0x9acc21ad;       (* arm_LSL X13 X13 X12 *)
+  0x9acc21ad;       (* arm_LSLV X13 X13 X12 *)
   0x9a9f11ef;       (* arm_CSEL X15 X15 XZR Condition_NE *)
-  0x9acc21ce;       (* arm_LSL X14 X14 X12 *)
+  0x9acc21ce;       (* arm_LSLV X14 X14 X12 *)
   0x9a9f1210;       (* arm_CSEL X16 X16 XZR Condition_NE *)
-  0x9ad125ef;       (* arm_LSR X15 X15 X17 *)
-  0x9ad12610;       (* arm_LSR X16 X16 X17 *)
+  0x9ad125ef;       (* arm_LSRV X15 X15 X17 *)
+  0x9ad12610;       (* arm_LSRV X16 X16 X17 *)
   0xaa0f01ad;       (* arm_ORR X13 X13 X15 *)
   0xaa1001ce;       (* arm_ORR X14 X14 X16 *)
   0xf94002af;       (* arm_LDR X15 X21 (Immediate_Offset (word 0)) *)
@@ -97,37 +97,28 @@ let bignum_modinv_mc =
   0xaa1f03e8;       (* arm_MOV X8 XZR *)
   0xd2800029;       (* arm_MOV X9 (rvalue (word 1)) *)
   0xd280074a;       (* arm_MOV X10 (rvalue (word 58)) *)
-  0x924001eb;       (* arm_AND X11 X15 (rvalue (word 1)) *)
-  0xd280004c;       (* arm_MOV X12 (rvalue (word 2)) *)
-  0xeb0e01bf;       (* arm_CMP X13 X14 *)
-  0xfa0b019f;       (* arm_SBCS XZR X12 X11 *)
-  0x8b0800d1;       (* arm_ADD X17 X6 X8 *)
-  0x8b0900f3;       (* arm_ADD X19 X7 X9 *)
-  0xaa0d03eb;       (* arm_MOV X11 X13 *)
-  0x9a8d01cd;       (* arm_CSEL X13 X14 X13 Condition_EQ *)
-  0x9a8e016e;       (* arm_CSEL X14 X11 X14 Condition_EQ *)
-  0xaa0f03eb;       (* arm_MOV X11 X15 *)
-  0x9a8f020f;       (* arm_CSEL X15 X16 X15 Condition_EQ *)
-  0x9a900170;       (* arm_CSEL X16 X11 X16 Condition_EQ *)
-  0xaa0603eb;       (* arm_MOV X11 X6 *)
-  0x9a860106;       (* arm_CSEL X6 X8 X6 Condition_EQ *)
-  0x9a880168;       (* arm_CSEL X8 X11 X8 Condition_EQ *)
-  0xaa0703eb;       (* arm_MOV X11 X7 *)
-  0x9a870127;       (* arm_CSEL X7 X9 X7 Condition_EQ *)
-  0x9a890169;       (* arm_CSEL X9 X11 X9 Condition_EQ *)
   0xf24001ff;       (* arm_TST X15 (rvalue (word 1)) *)
-  0xcb0e01ab;       (* arm_SUB X11 X13 X14 *)
-  0x9a8d116d;       (* arm_CSEL X13 X11 X13 Condition_NE *)
-  0xcb1001eb;       (* arm_SUB X11 X15 X16 *)
-  0x9a8f116f;       (* arm_CSEL X15 X11 X15 Condition_NE *)
-  0x9a861226;       (* arm_CSEL X6 X17 X6 Condition_NE *)
-  0x9a871267;       (* arm_CSEL X7 X19 X7 Condition_NE *)
-  0xd341fdad;       (* arm_LSR X13 X13 (rvalue (word 1)) *)
-  0xd341fdef;       (* arm_LSR X15 X15 (rvalue (word 1)) *)
+  0x9a9f11cb;       (* arm_CSEL X11 X14 XZR Condition_NE *)
+  0x9a9f120c;       (* arm_CSEL X12 X16 XZR Condition_NE *)
+  0x9a9f1111;       (* arm_CSEL X17 X8 XZR Condition_NE *)
+  0x9a9f1133;       (* arm_CSEL X19 X9 XZR Condition_NE *)
+  0xeb0b01ab;       (* arm_SUBS X11 X13 X11 *)
+  0xcb0c01ec;       (* arm_SUB X12 X15 X12 *)
+  0xda8b256b;       (* arm_CNEG X11 X11 Condition_CC *)
+  0xda8c258c;       (* arm_CNEG X12 X12 Condition_CC *)
+  0x9a8d21ce;       (* arm_CSEL X14 X14 X13 Condition_CS *)
+  0x9a8f2210;       (* arm_CSEL X16 X16 X15 Condition_CS *)
+  0x9a862108;       (* arm_CSEL X8 X8 X6 Condition_CS *)
+  0x9a872129;       (* arm_CSEL X9 X9 X7 Condition_CS *)
+  0xf27f019f;       (* arm_TST X12 (rvalue (word 2)) *)
+  0x8b1100c6;       (* arm_ADD X6 X6 X17 *)
+  0x8b1300e7;       (* arm_ADD X7 X7 X19 *)
+  0xd341fd6d;       (* arm_LSR X13 X11 1 *)
+  0xd341fd8f;       (* arm_LSR X15 X12 1 *)
   0x8b080108;       (* arm_ADD X8 X8 X8 *)
   0x8b090129;       (* arm_ADD X9 X9 X9 *)
-  0xf100054a;       (* arm_SUBS X10 X10 (rvalue (word 1)) *)
-  0x54fffc41;       (* arm_BNE (word 2097032) *)
+  0xd100054a;       (* arm_SUB X10 X10 (rvalue (word 1)) *)
+  0xb5fffd8a;       (* arm_CBNZ X10 (word 2097072) *)
   0xaa1f03ed;       (* arm_MOV X13 XZR *)
   0xaa1f03ee;       (* arm_MOV X14 XZR *)
   0xaa1f03f1;       (* arm_MOV X17 XZR *)
@@ -141,7 +132,7 @@ let bignum_modinv_mc =
   0x9bcb7ccd;       (* arm_UMULH X13 X6 X11 *)
   0x9a1f01ad;       (* arm_ADC X13 X13 XZR *)
   0xab1001ef;       (* arm_ADDS X15 X15 X16 *)
-  0x93d1e9f1;       (* arm_EXTR X17 X15 X17 (rvalue (word 58)) *)
+  0x93d1e9f1;       (* arm_EXTR X17 X15 X17 58 *)
   0xf82a7891;       (* arm_STR X17 X4 (Shiftreg_Offset X10 3) *)
   0xaa0f03f1;       (* arm_MOV X17 X15 *)
   0x9bcc7cef;       (* arm_UMULH X15 X7 X12 *)
@@ -152,7 +143,7 @@ let bignum_modinv_mc =
   0x9bcb7d0e;       (* arm_UMULH X14 X8 X11 *)
   0x9a1f01ce;       (* arm_ADC X14 X14 XZR *)
   0xab1001ef;       (* arm_ADDS X15 X15 X16 *)
-  0x93d3e9f3;       (* arm_EXTR X19 X15 X19 (rvalue (word 58)) *)
+  0x93d3e9f3;       (* arm_EXTR X19 X15 X19 58 *)
   0xf82a7833;       (* arm_STR X19 X1 (Shiftreg_Offset X10 3) *)
   0xaa0f03f3;       (* arm_MOV X19 X15 *)
   0x9bcc7d2f;       (* arm_UMULH X15 X9 X12 *)
@@ -160,8 +151,8 @@ let bignum_modinv_mc =
   0x9100054a;       (* arm_ADD X10 X10 (rvalue (word 1)) *)
   0xeb00015f;       (* arm_CMP X10 X0 *)
   0x54fffcc3;       (* arm_BCC (word 2097048) *)
-  0x93d1e9ad;       (* arm_EXTR X13 X13 X17 (rvalue (word 58)) *)
-  0x93d3e9ce;       (* arm_EXTR X14 X14 X19 (rvalue (word 58)) *)
+  0x93d1e9ad;       (* arm_EXTR X13 X13 X17 58 *)
+  0x93d3e9ce;       (* arm_EXTR X14 X14 X19 58 *)
   0xf940008b;       (* arm_LDR X11 X4 (Immediate_Offset (word 0)) *)
   0x9b147d71;       (* arm_MUL X17 X11 X20 *)
   0xf940006c;       (* arm_LDR X12 X3 (Immediate_Offset (word 0)) *)
@@ -287,7 +278,7 @@ let bignum_modinv_mc =
   0xb4000166;       (* arm_CBZ X6 (word 44) *)
   0x9100214b;       (* arm_ADD X11 X10 (rvalue (word 8)) *)
   0xf86b6aac;       (* arm_LDR X12 X21 (Register_Offset X11) *)
-  0x93cfe98f;       (* arm_EXTR X15 X12 X15 (rvalue (word 58)) *)
+  0x93cfe98f;       (* arm_EXTR X15 X12 X15 58 *)
   0xca1101ef;       (* arm_EOR X15 X15 X17 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a6aaf;       (* arm_STR X15 X21 (Register_Offset X10) *)
@@ -295,7 +286,7 @@ let bignum_modinv_mc =
   0x9100214a;       (* arm_ADD X10 X10 (rvalue (word 8)) *)
   0xd10004c6;       (* arm_SUB X6 X6 (rvalue (word 1)) *)
   0xb5fffee6;       (* arm_CBNZ X6 (word 2097116) *)
-  0x93cfe9af;       (* arm_EXTR X15 X13 X15 (rvalue (word 58)) *)
+  0x93cfe9af;       (* arm_EXTR X15 X13 X15 58 *)
   0xca1101ef;       (* arm_EOR X15 X15 X17 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a6aaf;       (* arm_STR X15 X21 (Register_Offset X10) *)
@@ -306,7 +297,7 @@ let bignum_modinv_mc =
   0xb4000166;       (* arm_CBZ X6 (word 44) *)
   0x9100214b;       (* arm_ADD X11 X10 (rvalue (word 8)) *)
   0xf86b6acc;       (* arm_LDR X12 X22 (Register_Offset X11) *)
-  0x93cfe98f;       (* arm_EXTR X15 X12 X15 (rvalue (word 58)) *)
+  0x93cfe98f;       (* arm_EXTR X15 X12 X15 58 *)
   0xca1301ef;       (* arm_EOR X15 X15 X19 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a6acf;       (* arm_STR X15 X22 (Register_Offset X10) *)
@@ -314,7 +305,7 @@ let bignum_modinv_mc =
   0x9100214a;       (* arm_ADD X10 X10 (rvalue (word 8)) *)
   0xd10004c6;       (* arm_SUB X6 X6 (rvalue (word 1)) *)
   0xb5fffee6;       (* arm_CBNZ X6 (word 2097116) *)
-  0x93cfe9cf;       (* arm_EXTR X15 X14 X15 (rvalue (word 58)) *)
+  0x93cfe9cf;       (* arm_EXTR X15 X14 X15 58 *)
   0xca1301ef;       (* arm_EOR X15 X15 X19 *)
   0xba1f01ef;       (* arm_ADCS X15 X15 XZR *)
   0xf82a6acf;       (* arm_STR X15 X22 (Register_Offset X10) *)
@@ -329,7 +320,7 @@ let bignum_modinv_mc =
   0x9100054a;       (* arm_ADD X10 X10 (rvalue (word 1)) *)
   0xcb00014b;       (* arm_SUB X11 X10 X0 *)
   0xb5ffff0b;       (* arm_CBNZ X11 (word 2097120) *)
-  0xaa3303f3;       (* arm_ORN X19 XZR X19 *)
+  0xaa3303f3;       (* arm_MVN X19 X19 *)
   0xaa1f03ea;       (* arm_MOV X10 XZR *)
   0xab13027f;       (* arm_CMN X19 X19 *)
   0xf86a786b;       (* arm_LDR X11 X3 (Shiftreg_Offset X10 3) *)
@@ -342,7 +333,7 @@ let bignum_modinv_mc =
   0xcb00014b;       (* arm_SUB X11 X10 X0 *)
   0xb5ffff0b;       (* arm_CBNZ X11 (word 2097120) *)
   0xf100e842;       (* arm_SUBS X2 X2 (rvalue (word 58)) *)
-  0x54ffdc28;       (* arm_BHI (word 2096004) *)
+  0x54ffdd48;       (* arm_BHI (word 2096040) *)
   0xa8c15bf5;       (* arm_LDP X21 X22 SP (Postimmediate_Offset (iword (&16))) *)
   0xa8c153f3;       (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   0xd65f03c0        (* arm_RET X30 *)
@@ -394,12 +385,20 @@ let lemma58 = prove
    `m divides e EXP 2 ==> (e * (e * x + y) + z == e * y + z) (mod m)`) THEN
   REWRITE_TAC[EXP_EXP] THEN MATCH_MP_TAC DIVIDES_EXP_LE_IMP THEN ARITH_TAC);;
 
+let lemmabit1 = prove
+ (`!x:int64. val(word_and x (word 2)) = 0 <=> EVEN(val(word_ushr x 1))`,
+  GEN_TAC THEN SUBST1_TAC(SYM(NUM_REDUCE_CONV `2 EXP 1`)) THEN
+  REWRITE_TAC[WORD_AND_POW2; GSYM NOT_ODD; GSYM BIT_LSB] THEN
+  REWRITE_TAC[BIT_WORD_USHR; ADD_CLAUSES; bitval] THEN
+  COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
+  CONV_TAC(DEPTH_CONV(NUM_RED_CONV ORELSEC WORD_RED_CONV)));;
+
 let BIGNUM_MODINV_CORRECT = prove
  (`!k z x a y b w pc.
         nonoverlapping (w,8 * 3 * val k) (z,8 * val k) /\
         ALLPAIRS nonoverlapping
          [(w,8 * 3 * val k); (z,8 * val k)]
-         [(word pc,0x50c); (x,8 * val k); (y,8 * val k)] /\
+         [(word pc,0x4e8); (x,8 * val k); (y,8 * val k)] /\
         val k < 2 EXP 57
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_modinv_mc /\
@@ -407,7 +406,7 @@ let BIGNUM_MODINV_CORRECT = prove
                   C_ARGUMENTS [k;z;x;y;w] s /\
                   bignum_from_memory(x,val k) s = a /\
                   bignum_from_memory(y,val k) s = b)
-             (\s. read PC s = word(pc + 0x500) /\
+             (\s. read PC s = word(pc + 0x4dc) /\
                   (coprime(a,b) /\ ODD b /\ ~(b = 1)
                    ==> bignum_from_memory(z,val k) s < b /\
                        (a * bignum_from_memory(z,val k) s == 1) (mod b)))
@@ -585,7 +584,7 @@ let BIGNUM_MODINV_CORRECT = prove
   SUBGOAL_THEN `64 <= t /\ t <= 128 * k` STRIP_ASSUME_TAC THENL
    [EXPAND_TAC "t" THEN UNDISCH_TAC `~(k = 0)` THEN ARITH_TAC; ALL_TAC] THEN
 
-  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0x80` `pc + 0x4fc`
+  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0x80` `pc + 0x4d8`
     `\i s. (read X0 s = word k /\
             read X1 s = zz /\
             read X3 s = y /\
@@ -915,70 +914,70 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Now set up the somewhat intricate inner loop invariant ***)
 
-  ENSURES_WHILE_PUP_TAC `58` `pc + 0x128` `pc + 0x1a0`
-   `\i s. (read X0 s = word k /\
-           read X1 s = zz /\
-           read X2 s = word t /\
-           read X3 s = y /\
-           read X4 s = ww /\
-           read X5 s = word l /\
-           read X21 s = mm /\
-           read X22 s = nn /\
-           read X20 s = word v /\
-           bignum_from_memory (y,k) s = b /\
-           bignum_from_memory (ww,k) s = w /\
-           bignum_from_memory (zz,k) s = z /\
-           bignum_from_memory (mm,l) s = m /\
-           bignum_from_memory (nn,l) s = n /\
-           bignum_from_memory (mm,k) s = m0 /\
-           bignum_from_memory (nn,k) s = n0 /\
-           read X10 s = word(58 - i) /\
-           val(read X6 s) + val(read X7 s) <= 2 EXP i /\
-           val(read X8 s) + val(read X9 s) <= 2 EXP i /\
-           (ODD b
-           ==> ODD(val(read X16 s)) /\
-               gcd(&(val(read X6 s)) * &m - &(val(read X7 s)) * &n:int,
-                   &(val(read X8 s)) * &m - &(val(read X9 s)) * &n) =
-               &2 pow i * gcd(&m,&n) /\
-               ?q. (--(&1) pow q *
-                    (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n):int ==
-                    &2 pow i * &(val(read X15 s))) (mod (&2 pow 64)) /\
-                   (--(--(&1) pow q) *
-                    (&(val(read X8 s)) * &m - &(val(read X9 s)) * &n):int ==
-                    &2 pow i * &(val(read X16 s))) (mod (&2 pow 64)) /\
-                   let m' = --(&1) pow q *
-                            (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n)
-                   and n' = --(--(&1) pow q) *
-                            (&(val(read X8 s)) * &m - &(val(read X9 s)) * &n)
-                   and m_hi = val(read X13 s)
-                   and n_hi = val(read X14 s)
-                   and m_lo = val(read X15 s)
-                   and n_lo = val(read X16 s) in
-                   --(lowerr i) <= &m_hi - m' / &2 zpow (base + &i) /\
-                   &m_hi - m' / &2 zpow (base + &i) <= upperr i /\
-                   --(lowerr i) <= &n_hi - n' / &2 zpow (base + &i) /\
-                   &n_hi - n' / &2 zpow (base + &i) <= upperr i /\
-                   (min (&m) (&n) < &2 zpow base * &2 pow 5
-                    ==> abs(m') * abs(n') <= &2 pow i * &m * &n /\
-                        (i <= 57
-                         ==> &0 <= m' /\ &0 <= n' /\
-                             (m_hi < n_hi /\
-                              m_hi < 2 EXP 5 /\
-                              2 EXP 63 <= 2 EXP i * (n_hi + 31) /\
-                              &m_hi <= m' / &2 zpow (base + &i) /\
-                              m' / &2 zpow (base + &i) <= &m_hi + &1 \/
-                              n_hi < m_hi /\
-                              n_hi < 2 EXP 5 /\
-                              2 EXP 63 <= 2 EXP i * (m_hi + 31) /\
-                              n' / &2 zpow (base + &i) <= &n_hi + &1))) /\
-                   (&0 <= m' /\ &0 <= n' /\
-                    min m' n' <= &2 pow i * min (&m) (&n) /\
-                    m' * n' <= &2 pow i * &m * &n \/
-                    m' < &0 /\ &0 <= n' /\ m_hi < 16 /\
-                    &n_hi < min (&m) (&n) / &2 zpow base + &16 \/
-                    n' < &0 /\ &0 <= m' /\ n_hi < 16 /\
-                    &m_hi < min (&m) (&n) / &2 zpow base + &16))) /\
-          (read ZF s <=> i = 58)` THEN
+  ENSURES_WHILE_UP_TAC `58` `pc + 0x12c` `pc + 0x17c`
+   `\i s. read X0 s = word k /\
+          read X1 s = zz /\
+          read X2 s = word t /\
+          read X3 s = y /\
+          read X4 s = ww /\
+          read X5 s = word l /\
+          read X21 s = mm /\
+          read X22 s = nn /\
+          read X20 s = word v /\
+          bignum_from_memory (y,k) s = b /\
+          bignum_from_memory (ww,k) s = w /\
+          bignum_from_memory (zz,k) s = z /\
+          bignum_from_memory (mm,l) s = m /\
+          bignum_from_memory (nn,l) s = n /\
+          bignum_from_memory (mm,k) s = m0 /\
+          bignum_from_memory (nn,k) s = n0 /\
+          read X10 s = word(58 - i) /\
+          val(read X6 s) + val(read X7 s) <= 2 EXP i /\
+          val(read X8 s) + val(read X9 s) <= 2 EXP i /\
+          (read ZF s <=> EVEN(val(read X15 s))) /\
+          (ODD b
+          ==> ODD(val(read X16 s)) /\
+              gcd(&(val(read X6 s)) * &m - &(val(read X7 s)) * &n:int,
+                  &(val(read X8 s)) * &m - &(val(read X9 s)) * &n) =
+              &2 pow i * gcd(&m,&n) /\
+              ?q. (--(&1) pow q *
+                   (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n):int ==
+                   &2 pow i * &(val(read X15 s))) (mod (&2 pow 64)) /\
+                  (--(--(&1) pow q) *
+                   (&(val(read X8 s)) * &m - &(val(read X9 s)) * &n):int ==
+                   &2 pow i * &(val(read X16 s))) (mod (&2 pow 64)) /\
+                  let m' = --(&1) pow q *
+                           (&(val(read X6 s)) * &m - &(val(read X7 s)) * &n)
+                  and n' = --(--(&1) pow q) *
+                           (&(val(read X8 s)) * &m - &(val(read X9 s)) * &n)
+                  and m_hi = val(read X13 s)
+                  and n_hi = val(read X14 s)
+                  and m_lo = val(read X15 s)
+                  and n_lo = val(read X16 s) in
+                  --(lowerr i) <= &m_hi - m' / &2 zpow (base + &i) /\
+                  &m_hi - m' / &2 zpow (base + &i) <= upperr i /\
+                  --(lowerr i) <= &n_hi - n' / &2 zpow (base + &i) /\
+                  &n_hi - n' / &2 zpow (base + &i) <= upperr i /\
+                  (min (&m) (&n) < &2 zpow base * &2 pow 5
+                   ==> abs(m') * abs(n') <= &2 pow i * &m * &n /\
+                       (i <= 57
+                        ==> &0 <= m' /\ &0 <= n' /\
+                            (m_hi < n_hi /\
+                             m_hi < 2 EXP 5 /\
+                             2 EXP 63 <= 2 EXP i * (n_hi + 31) /\
+                             &m_hi <= m' / &2 zpow (base + &i) /\
+                             m' / &2 zpow (base + &i) <= &m_hi + &1 \/
+                             n_hi < m_hi /\
+                             n_hi < 2 EXP 5 /\
+                             2 EXP 63 <= 2 EXP i * (m_hi + 31) /\
+                             n' / &2 zpow (base + &i) <= &n_hi + &1))) /\
+                  (&0 <= m' /\ &0 <= n' /\
+                   min m' n' <= &2 pow i * min (&m) (&n) /\
+                   m' * n' <= &2 pow i * &m * &n \/
+                   m' < &0 /\ &0 <= n' /\ m_hi < 16 /\
+                   &n_hi < min (&m) (&n) / &2 zpow base + &16 \/
+                   n' < &0 /\ &0 <= m' /\ n_hi < 16 /\
+                   &m_hi < min (&m) (&n) / &2 zpow base + &16))` THEN
   CONV_TAC(ONCE_DEPTH_CONV let_CONV) THEN REPEAT CONJ_TAC THENL
    [ARITH_TAC;
 
@@ -997,11 +996,16 @@ let BIGNUM_MODINV_CORRECT = prove
       GEN_REWRITE_TAC (LAND_CONV o BINOP_CONV)
        [BIGNUM_FROM_MEMORY_EQ_HIGHDIGITS] THEN
       ASM_REWRITE_TAC[] THEN STRIP_TAC] THEN
-    ARM_STEPS_TAC BIGNUM_MODINV_EXEC (1--20) THEN
+    ARM_STEPS_TAC BIGNUM_MODINV_EXEC (1--21) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     REWRITE_TAC[SUB_0; VAL_WORD_0; VAL_WORD_1] THEN
     REWRITE_TAC[WORD_SUB_LZERO; WORD_NEG_EQ_0; VAL_EQ_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL [ARITH_TAC; ALL_TAC]) THEN
+    CONJ_TAC THENL
+     [REWRITE_TAC[EVEN_VAL_WORD; WORD_AND_1_BITVAL] THEN
+      REWRITE_TAC[WORD_BITVAL_EQ_0; BIT_LSB; NOT_ODD] THEN
+      REWRITE_TAC[VAL_WORD_BIGDIGIT];
+      ALL_TAC] THEN
     SUBGOAL_THEN
      `word (bigdigit m0 0):int64 = word(m MOD 2 EXP 64) /\
       word (bigdigit n0 0):int64 = word(n MOD 2 EXP 64)`
@@ -1305,33 +1309,20 @@ let BIGNUM_MODINV_CORRECT = prove
      [`m_m:num`; `m_n:num`; `n_m:num`; `n_n:num`;
       `m_hi:num`; `n_hi:num`; `m_lo:num`; `n_lo:num`] THEN
 
-    ARM_STEPS_TAC BIGNUM_MODINV_EXEC (1--30) THEN
+    ARM_STEPS_TAC BIGNUM_MODINV_EXEC (1--20) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
-    DISCARD_STATE_TAC "s30" THEN
+    DISCARD_STATE_TAC "s20" THEN
 
     MATCH_MP_TAC(TAUT `p /\ (p ==> q) ==> p /\ q`) THEN CONJ_TAC THENL
      [REWRITE_TAC[ARITH_RULE `n - (i + 1) = n - i - 1`] THEN
       GEN_REWRITE_TAC RAND_CONV [WORD_SUB] THEN
       ASM_SIMP_TAC[ARITH_RULE `i < 58 ==> 1 <= 58 - i`];
       DISCH_THEN SUBST1_TAC] THEN
-    REWRITE_TAC[CONJ_ASSOC] THEN CONJ_TAC THENL
-     [REWRITE_TAC[GSYM CONJ_ASSOC];
-      VAL_INT64_TAC `58 - (i + 1)` THEN
-      ASM_REWRITE_TAC[] THEN SIMPLE_ARITH_TAC] THEN
 
-    SUBGOAL_THEN
-     `val(word_sub (word 2)
-                   (word_add (word_and (word m_lo) (word 1))
-                             (word (bitval (m_hi < n_hi)))):int64) = 0 <=>
-      m_hi < n_hi /\ ODD m_lo`
-    SUBST1_TAC THENL
-     [POP_ASSUM_LIST(K ALL_TAC) THEN
-      REWRITE_TAC[WORD_AND_1; BIT_LSB_WORD; bitval] THEN
-      REPEAT(COND_CASES_TAC THEN ASM_REWRITE_TAC[]) THEN
-      CONV_TAC WORD_REDUCE_CONV THEN CONV_TAC NUM_REDUCE_CONV;
-      ALL_TAC] THEN
-    REWRITE_TAC[WORD_AND_1_BITVAL; VAL_WORD_BITVAL; BITVAL_EQ_0] THEN
+    REWRITE_TAC[lemmabit1; NOT_EVEN] THEN
+    REWRITE_TAC[MESON[VAL_WORD_0; LE_0; NOT_LT]
+     `val(if p then x else word 0) <= a <=> ~(a < val x /\ p)`] THEN
 
     SUBGOAL_THEN
      `val(word(n_m + n_m):int64) = n_m + n_m /\
@@ -1352,9 +1343,9 @@ let BIGNUM_MODINV_CORRECT = prove
       ALL_TAC] THEN
 
     ASM_CASES_TAC `m_hi < n_hi /\ ODD m_lo` THEN
-    ASM_REWRITE_TAC[BIT_LSB_WORD] THEN
-    COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
-    REWRITE_TAC[VAL_WORD_USHR; EXP_1] THEN
+    ASM_REWRITE_TAC[WORD_NEG_SUB] THEN
+    TRY COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
+    ASM_REWRITE_TAC[VAL_WORD_USHR; EXP_1; ADD_CLAUSES; WORD_SUB_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL
      [REWRITE_TAC[EXP_ADD] THEN MAP_EVERY UNDISCH_TAC
        [`m_m + m_n <= 2 EXP i`; `n_m + n_n <= 2 EXP i`] THEN
@@ -2029,7 +2020,9 @@ let BIGNUM_MODINV_CORRECT = prove
     RULE_ASSUM_TAC(REWRITE_RULE[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`]) THEN
     REWRITE_TAC[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`] THEN
     ARM_STEPS_TAC BIGNUM_MODINV_EXEC [1] THEN
-    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[];
+    ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
+    SIMP_TAC[VAL_WORD_EQ; DIMINDEX_64; ARITH_RULE `58 - i < 2 EXP 64`] THEN
+    ASM_REWRITE_TAC[SUB_EQ_0; NOT_LE];
 
     ALL_TAC] THEN
 
@@ -2051,7 +2044,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x1a4`
+  ENSURES_SEQUENCE_TAC `pc + 0x180`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -2270,7 +2263,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
  (*** Congruence cross-multiplication and shift-by-6 "congloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x22c`
+  ENSURES_SEQUENCE_TAC `pc + 0x208`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -2294,7 +2287,7 @@ let BIGNUM_MODINV_CORRECT = prove
         2 EXP (64 * k) * val(read X14 s) + bignum_from_memory (zz,k) s =
         2 EXP 6 * (n_m * w + n_n * z)` THEN
   CONJ_TAC THENL
-   [ENSURES_WHILE_UP_TAC `k:num` `pc + 0x1b8` `pc + 0x21c`
+   [ENSURES_WHILE_UP_TAC `k:num` `pc + 0x194` `pc + 0x1f8`
      `\i s. read X0 s = word k /\
             read X1 s = zz /\
             read X2 s = word t /\
@@ -2427,7 +2420,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The first Montgomery operation ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x2d8`
+  ENSURES_SEQUENCE_TAC `pc + 0x2b4`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -2467,7 +2460,7 @@ let BIGNUM_MODINV_CORRECT = prove
       REWRITE_TAC[VAL_WORD; DIMINDEX_64; MOD_MOD_REFL];
       ALL_TAC] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x24c`
+    ENSURES_SEQUENCE_TAC `pc + 0x228`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -2532,7 +2525,7 @@ let BIGNUM_MODINV_CORRECT = prove
     GLOBALIZE_PRECONDITION_TAC THEN
     FIRST_X_ASSUM(X_CHOOSE_THEN `r0:num` STRIP_ASSUME_TAC) THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x280`
+    ENSURES_SEQUENCE_TAC `pc + 0x25c`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -2575,7 +2568,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
       VAL_INT64_TAC `k - 1` THEN
 
-      ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x250` `pc + 0x278`
+      ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x22c` `pc + 0x254`
        `\i s. read X0 s = word k /\
               read X1 s = zz /\
               read X2 s = word t /\
@@ -2679,7 +2672,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
    (*** The final digit write ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x290`
+    ENSURES_SEQUENCE_TAC `pc + 0x26c`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -2744,7 +2737,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Comparison operation "wcmploop" ***)
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x294` `pc + 0x2a4`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x270` `pc + 0x280`
      `\i s. read X0 s = word k /\
             read X1 s = zz /\
             read X2 s = word t /\
@@ -2799,7 +2792,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     ABBREV_TAC `cg <=> b <= 2 EXP (64 * k) * bitval cf + w2` THEN
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x2b8` `pc + 0x2d0`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x294` `pc + 0x2ac`
      `\i s. read X0 s = word k /\
             read X1 s = zz /\
             read X2 s = word t /\
@@ -2956,7 +2949,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The second Montgomery operation ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x384`
+  ENSURES_SEQUENCE_TAC `pc + 0x360`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -2997,7 +2990,7 @@ let BIGNUM_MODINV_CORRECT = prove
       REWRITE_TAC[VAL_WORD; DIMINDEX_64; MOD_MOD_REFL];
       ALL_TAC] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2f8`
+    ENSURES_SEQUENCE_TAC `pc + 0x2d4`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -3063,7 +3056,7 @@ let BIGNUM_MODINV_CORRECT = prove
     GLOBALIZE_PRECONDITION_TAC THEN
     FIRST_X_ASSUM(X_CHOOSE_THEN `r0:num` STRIP_ASSUME_TAC) THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x32c`
+    ENSURES_SEQUENCE_TAC `pc + 0x308`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -3107,7 +3100,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
       VAL_INT64_TAC `k - 1` THEN
 
-      ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x2fc` `pc + 0x324`
+      ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x2d8` `pc + 0x300`
        `\i s. read X0 s = word k /\
               read X1 s = zz /\
               read X2 s = word t /\
@@ -3212,7 +3205,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
    (*** The final digit write ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x33c`
+    ENSURES_SEQUENCE_TAC `pc + 0x318`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -3278,7 +3271,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Comparison operation "zcmploop" ***)
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x340` `pc + 0x350`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x31c` `pc + 0x32c`
      `\i s. read X0 s = word k /\
             read X1 s = zz /\
             read X2 s = word t /\
@@ -3334,7 +3327,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     ABBREV_TAC `cg <=> b <= 2 EXP (64 * k) * bitval cf + z2` THEN
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x364` `pc + 0x37c`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x340` `pc + 0x358`
      `\i s. read X0 s = word k /\
             read X1 s = zz /\
             read X2 s = word t /\
@@ -3504,7 +3497,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The cross-multiplications loop updating m and n ***)
 
-  ENSURES_WHILE_UP_TAC `l:num` `pc + 0x398` `pc + 0x3fc`
+  ENSURES_WHILE_UP_TAC `l:num` `pc + 0x374` `pc + 0x3d8`
    `\i s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -3623,7 +3616,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Clean sign flag for m' (back to integers for now) ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x404`
+  ENSURES_SEQUENCE_TAC `pc + 0x3e0`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -3696,7 +3689,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Optional right shift and negation of m, negloop1 ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x450`
+  ENSURES_SEQUENCE_TAC `pc + 0x42c`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -3729,7 +3722,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Attempt to make a unified break at negskip1 to handle l = 1 ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x440`
+    ENSURES_SEQUENCE_TAC `pc + 0x41c`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -3783,7 +3776,7 @@ let BIGNUM_MODINV_CORRECT = prove
         REWRITE_TAC[BITVAL_CLAUSES; ADD_CLAUSES];
         ALL_TAC] THEN
 
-      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x418` `pc + 0x43c`
+      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x3f4` `pc + 0x418`
        `\i s. read X0 s = word k /\
               read X1 s = zz /\
               read X2 s = word t /\
@@ -4059,7 +4052,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Clean sign flag for n' (back to integers for now) ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x450`
+  ENSURES_SEQUENCE_TAC `pc + 0x42c`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -4129,7 +4122,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Optional right shift and negation of n, negloop2 ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x49c`
+  ENSURES_SEQUENCE_TAC `pc + 0x478`
    `\s. read X0 s = word k /\
         read X1 s = zz /\
         read X2 s = word t /\
@@ -4160,7 +4153,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Attempt to make a unified break at negskip2 to handle l = 1 ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x48c`
+    ENSURES_SEQUENCE_TAC `pc + 0x468`
      `\s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -4212,7 +4205,7 @@ let BIGNUM_MODINV_CORRECT = prove
         REWRITE_TAC[BITVAL_CLAUSES; ADD_CLAUSES];
         ALL_TAC] THEN
 
-      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x464` `pc + 0x488`
+      ENSURES_WHILE_UP_TAC `l - 1` `pc + 0x440` `pc + 0x464`
        `\i s. read X0 s = word k /\
               read X1 s = zz /\
               read X2 s = word t /\
@@ -4485,7 +4478,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The first optional modular negation "wfliploop" ***)
 
-  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x4a4` `pc + 0x4c0`
+  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x480` `pc + 0x49c`
    `\i s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -4550,7 +4543,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The second optional modular negation "zfliploop" ***)
 
-  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x4d4` `pc + 0x4f0`
+  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x4b0` `pc + 0x4cc`
    `\i s. read X0 s = word k /\
           read X1 s = zz /\
           read X2 s = word t /\
@@ -4845,7 +4838,7 @@ let BIGNUM_MODINV_SUBROUTINE_CORRECT = prove
         ALLPAIRS nonoverlapping
          [(w,8 * 3 * val k); (z,8 * val k);
           (word_sub stackpointer (word 32),32)]
-         [(word pc,0x50c); (x,8 * val k); (y,8 * val k)] /\
+         [(word pc,0x4e8); (x,8 * val k); (y,8 * val k)] /\
         val k < 2 EXP 57
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_modinv_mc /\

--- a/x86/generic/bignum_coprime.S
+++ b/x86/generic/bignum_coprime.S
@@ -289,72 +289,64 @@ toploop:
                 mov     n_nshort, 1
                 mov     ishort, CHUNKSIZE
 
+// Stash more variables over the inner loop to free up regs
+
+                mov     mat_mn, k
+                mov     mat_nm, l
+                mov     mat_mm, m
+                mov     mat_nn, n
+
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed.
+
 innerloop:
 
-// Not quite the same: the value b is in the flags as a NZ condition
-//
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                mov     rax, m_hi
-                sub     rax, n_hi
-                sbb     rax, rax
-                and     rax, 1
-                test    rax, m_lo
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                mov     rax, m_hi
-                cmovnz  m_hi, n_hi
-                cmovnz  n_hi, rax
-
-                mov     rax, m_lo
-                cmovnz  m_lo, n_lo
-                cmovnz  n_lo, rax
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                mov     rax, m_m
-                cmovnz  m_m, n_m
-                cmovnz  n_m, rax
-
-                mov     rax, m_n
-                cmovnz  m_n, n_n
-                cmovnz  n_n, rax
-
-// This time actually put the condition in RBX as a mask
-//
-// b = (m_lo & 1ull);
-
-                mov     rbx, m_lo
-                and     rbx, 1
-                neg     rbx
-
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
-
                 mov     rax, n_hi
-                and     rax, rbx
-                sub     m_hi, rax
-                mov     rax, n_lo
-                and     rax, rbx
-                sub     m_lo, rax
+                mov     k, n_lo
+                mov     l, n_m
+                mov     n, n_n
+                mov     rbx, 1
+                neg     k
+                and     rbx, m_lo
+                cmovz   rax, rbx
+                cmovz   k, rbx
+                cmovz   l, rbx
+                cmovz   n, rbx
+                mov     rbx, m_hi
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                add     k, m_lo
+                mov     m, k
+                neg     k
+                sub     rbx, rax
 
-                mov     rax, n_m
-                and     rax, rbx
-                add     m_m, rax
+                cmovc   n_hi, m_hi
+                cmovc   n_lo, m_lo
+                cmovc   n_m, m_m
+                cmovc   n_n, m_n
+                cmovnc  k, m
+                mov     m_hi, rbx
+                not     rbx
+                inc     rbx
+                cmovc   m_hi, rbx
 
-                mov     rax, n_n
-                and     rax, rbx
-                add     m_n, rax
-
-// m_hi >>= 1; m_lo >>= 1;
-
+                mov     m_lo, k
+                add     m_m, l
+                add     m_n, n
                 shr     m_hi, 1
                 shr     m_lo, 1
-
-// n_m <<= 1; n_n <<= 1;
-
                 lea     n_m, [n_m+n_m]
                 lea     n_n, [n_n+n_n]
 
@@ -362,6 +354,13 @@ innerloop:
 
                 dec     i
                 jnz     innerloop
+
+// Unstash the temporary variables
+
+                mov     k,mat_mn
+                mov     l,mat_nm
+                mov     m,mat_mm
+                mov     n,mat_nn
 
 // Put the matrix entries in memory since we're out of registers
 // We pull them out repeatedly in the next loop

--- a/x86/generic/bignum_modinv.S
+++ b/x86/generic/bignum_modinv.S
@@ -285,72 +285,64 @@ toploop:
                 mov     n_nshort, 1
                 mov     ishort, CHUNKSIZE
 
+// Stash more variables over the inner loop to free up regs
+
+                mov     mat_mn, k
+                mov     mat_nm, l
+                mov     mat_mm, p1
+                mov     mat_nn, p2
+
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed.
+
 innerloop:
 
-// Not quite the same: the value b is in the flags as a NZ condition
-//
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                mov     rax, m_hi
-                sub     rax, n_hi
-                sbb     rax, rax
-                and     rax, 1
-                test    rax, m_lo
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                mov     rax, m_hi
-                cmovnz  m_hi, n_hi
-                cmovnz  n_hi, rax
-
-                mov     rax, m_lo
-                cmovnz  m_lo, n_lo
-                cmovnz  n_lo, rax
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                mov     rax, m_m
-                cmovnz  m_m, n_m
-                cmovnz  n_m, rax
-
-                mov     rax, m_n
-                cmovnz  m_n, n_n
-                cmovnz  n_n, rax
-
-// This time actually put the condition in RBX as a mask
-//
-// b = (m_lo & 1ull);
-
-                mov     rbx, m_lo
-                and     rbx, 1
-                neg     rbx
-
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
-
                 mov     rax, n_hi
-                and     rax, rbx
-                sub     m_hi, rax
-                mov     rax, n_lo
-                and     rax, rbx
-                sub     m_lo, rax
+                mov     k, n_lo
+                mov     l, n_m
+                mov     p2, n_n
+                mov     rbx, 1
+                neg     k
+                and     rbx, m_lo
+                cmovz   rax, rbx
+                cmovz   k, rbx
+                cmovz   l, rbx
+                cmovz   p2, rbx
+                mov     rbx, m_hi
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                add     k, m_lo
+                mov     p1, k
+                neg     k
+                sub     rbx, rax
 
-                mov     rax, n_m
-                and     rax, rbx
-                add     m_m, rax
+                cmovc   n_hi, m_hi
+                cmovc   n_lo, m_lo
+                cmovc   n_m, m_m
+                cmovc   n_n, m_n
+                cmovnc  k, p1
+                mov     m_hi, rbx
+                not     rbx
+                inc     rbx
+                cmovc   m_hi, rbx
 
-                mov     rax, n_n
-                and     rax, rbx
-                add     m_n, rax
-
-// m_hi >>= 1; m_lo >>= 1;
-
+                mov     m_lo, k
+                add     m_m, l
+                add     m_n, p2
                 shr     m_hi, 1
                 shr     m_lo, 1
-
-// n_m <<= 1; n_n <<= 1;
-
                 lea     n_m, [n_m+n_m]
                 lea     n_n, [n_n+n_n]
 
@@ -358,6 +350,13 @@ innerloop:
 
                 dec     i
                 jnz     innerloop
+
+// Unstash the temporary variables
+
+                mov     k,mat_mn
+                mov     l,mat_nm
+                mov     p1,mat_mm
+                mov     p2,mat_nn
 
 // Put the matrix entries in memory since we're out of registers
 // We pull them out repeatedly in the next loop

--- a/x86/proofs/bignum_coprime.ml
+++ b/x86/proofs/bignum_coprime.ml
@@ -35,8 +35,8 @@ let bignum_coprime_mc =
   0x48; 0x0f; 0x42; 0xc2;  (* CMOVB (% rax) (% rdx) *)
   0x49; 0x89; 0xc6;        (* MOV (% r14) (% rax) *)
   0x48; 0x85; 0xc0;        (* TEST (% rax) (% rax) *)
-  0x0f; 0x84; 0xfe; 0x02; 0x00; 0x00;
-                           (* JE (Imm32 (word 766)) *)
+  0x0f; 0x84; 0x1c; 0x03; 0x00; 0x00;
+                           (* JE (Imm32 (word 796)) *)
   0x4f; 0x8d; 0x3c; 0xf0;  (* LEA (% r15) (%%% (r8,3,r14)) *)
   0x4d; 0x31; 0xc9;        (* XOR (% r9) (% r9) *)
   0x48; 0x85; 0xff;        (* TEST (% rdi) (% rdi) *)
@@ -140,44 +140,55 @@ let bignum_coprime_mc =
                            (* MOV (% edx) (Imm32 (word 1)) *)
   0x41; 0xb9; 0x3a; 0x00; 0x00; 0x00;
                            (* MOV (% r9d) (Imm32 (word 58)) *)
-  0x4c; 0x89; 0xe0;        (* MOV (% rax) (% r12) *)
-  0x48; 0x29; 0xe8;        (* SUB (% rax) (% rbp) *)
-  0x48; 0x19; 0xc0;        (* SBB (% rax) (% rax) *)
-  0x48; 0x83; 0xe0; 0x01;  (* AND (% rax) (Imm8 (word 1)) *)
-  0x48; 0x85; 0xf8;        (* TEST (% rax) (% rdi) *)
-  0x4c; 0x89; 0xe0;        (* MOV (% rax) (% r12) *)
-  0x4c; 0x0f; 0x45; 0xe5;  (* CMOVNE (% r12) (% rbp) *)
-  0x48; 0x0f; 0x45; 0xe8;  (* CMOVNE (% rbp) (% rax) *)
-  0x48; 0x89; 0xf8;        (* MOV (% rax) (% rdi) *)
-  0x48; 0x0f; 0x45; 0xfe;  (* CMOVNE (% rdi) (% rsi) *)
-  0x48; 0x0f; 0x45; 0xf0;  (* CMOVNE (% rsi) (% rax) *)
-  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
-  0x4c; 0x0f; 0x45; 0xd1;  (* CMOVNE (% r10) (% rcx) *)
-  0x48; 0x0f; 0x45; 0xc8;  (* CMOVNE (% rcx) (% rax) *)
-  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
-  0x4c; 0x0f; 0x45; 0xda;  (* CMOVNE (% r11) (% rdx) *)
-  0x48; 0x0f; 0x45; 0xd0;  (* CMOVNE (% rdx) (% rax) *)
-  0x48; 0x89; 0xfb;        (* MOV (% rbx) (% rdi) *)
-  0x48; 0x83; 0xe3; 0x01;  (* AND (% rbx) (Imm8 (word 1)) *)
-  0x48; 0xf7; 0xdb;        (* NEG (% rbx) *)
+  0x4c; 0x89; 0x74; 0x24; 0x08;
+                           (* MOV (Memop Quadword (%% (rsp,8))) (% r14) *)
+  0x4c; 0x89; 0x6c; 0x24; 0x10;
+                           (* MOV (Memop Quadword (%% (rsp,16))) (% r13) *)
+  0x4c; 0x89; 0x04; 0x24;  (* MOV (Memop Quadword (%% (rsp,0))) (% r8) *)
+  0x4c; 0x89; 0x7c; 0x24; 0x18;
+                           (* MOV (Memop Quadword (%% (rsp,24))) (% r15) *)
   0x48; 0x89; 0xe8;        (* MOV (% rax) (% rbp) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x29; 0xc4;        (* SUB (% r12) (% rax) *)
-  0x48; 0x89; 0xf0;        (* MOV (% rax) (% rsi) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x48; 0x29; 0xc7;        (* SUB (% rdi) (% rax) *)
-  0x48; 0x89; 0xc8;        (* MOV (% rax) (% rcx) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
-  0x48; 0x89; 0xd0;        (* MOV (% rax) (% rdx) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x49; 0x89; 0xf6;        (* MOV (% r14) (% rsi) *)
+  0x49; 0x89; 0xcd;        (* MOV (% r13) (% rcx) *)
+  0x49; 0x89; 0xd7;        (* MOV (% r15) (% rdx) *)
+  0x48; 0xc7; 0xc3; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm32 (word 1)) *)
+  0x49; 0xf7; 0xde;        (* NEG (% r14) *)
+  0x48; 0x21; 0xfb;        (* AND (% rbx) (% rdi) *)
+  0x48; 0x0f; 0x44; 0xc3;  (* CMOVE (% rax) (% rbx) *)
+  0x4c; 0x0f; 0x44; 0xf3;  (* CMOVE (% r14) (% rbx) *)
+  0x4c; 0x0f; 0x44; 0xeb;  (* CMOVE (% r13) (% rbx) *)
+  0x4c; 0x0f; 0x44; 0xfb;  (* CMOVE (% r15) (% rbx) *)
+  0x4c; 0x89; 0xe3;        (* MOV (% rbx) (% r12) *)
+  0x49; 0x01; 0xfe;        (* ADD (% r14) (% rdi) *)
+  0x4d; 0x89; 0xf0;        (* MOV (% r8) (% r14) *)
+  0x49; 0xf7; 0xde;        (* NEG (% r14) *)
+  0x48; 0x29; 0xc3;        (* SUB (% rbx) (% rax) *)
+  0x49; 0x0f; 0x42; 0xec;  (* CMOVB (% rbp) (% r12) *)
+  0x48; 0x0f; 0x42; 0xf7;  (* CMOVB (% rsi) (% rdi) *)
+  0x49; 0x0f; 0x42; 0xca;  (* CMOVB (% rcx) (% r10) *)
+  0x49; 0x0f; 0x42; 0xd3;  (* CMOVB (% rdx) (% r11) *)
+  0x4d; 0x0f; 0x43; 0xf0;  (* CMOVAE (% r14) (% r8) *)
+  0x49; 0x89; 0xdc;        (* MOV (% r12) (% rbx) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0xff; 0xc3;        (* INC (% rbx) *)
+  0x4c; 0x0f; 0x42; 0xe3;  (* CMOVB (% r12) (% rbx) *)
+  0x4c; 0x89; 0xf7;        (* MOV (% rdi) (% r14) *)
+  0x4d; 0x01; 0xea;        (* ADD (% r10) (% r13) *)
+  0x4d; 0x01; 0xfb;        (* ADD (% r11) (% r15) *)
   0x49; 0xd1; 0xec;        (* SHR (% r12) (Imm8 (word 1)) *)
   0x48; 0xd1; 0xef;        (* SHR (% rdi) (Imm8 (word 1)) *)
   0x48; 0x8d; 0x0c; 0x09;  (* LEA (% rcx) (%%% (rcx,0,rcx)) *)
   0x48; 0x8d; 0x14; 0x12;  (* LEA (% rdx) (%%% (rdx,0,rdx)) *)
   0x49; 0xff; 0xc9;        (* DEC (% r9) *)
-  0x75; 0x83;              (* JNE (Imm8 (word 131)) *)
+  0x75; 0x8b;              (* JNE (Imm8 (word 139)) *)
+  0x4c; 0x8b; 0x74; 0x24; 0x08;
+                           (* MOV (% r14) (Memop Quadword (%% (rsp,8))) *)
+  0x4c; 0x8b; 0x6c; 0x24; 0x10;
+                           (* MOV (% r13) (Memop Quadword (%% (rsp,16))) *)
+  0x4c; 0x8b; 0x04; 0x24;  (* MOV (% r8) (Memop Quadword (%% (rsp,0))) *)
+  0x4c; 0x8b; 0x7c; 0x24; 0x18;
+                           (* MOV (% r15) (Memop Quadword (%% (rsp,24))) *)
   0x4c; 0x89; 0x14; 0x24;  (* MOV (Memop Quadword (%% (rsp,0))) (% r10) *)
   0x4c; 0x89; 0x5c; 0x24; 0x08;
                            (* MOV (Memop Quadword (%% (rsp,8))) (% r11) *)
@@ -267,8 +278,8 @@ let bignum_coprime_mc =
   0x75; 0xd1;              (* JNE (Imm8 (word 209)) *)
   0x48; 0x83; 0x6c; 0x24; 0x20; 0x3a;
                            (* SUB (Memop Quadword (%% (rsp,32))) (Imm8 (word 58)) *)
-  0x0f; 0x87; 0xda; 0xfd; 0xff; 0xff;
-                           (* JA (Imm32 (word 4294966746)) *)
+  0x0f; 0x87; 0xbc; 0xfd; 0xff; 0xff;
+                           (* JA (Imm32 (word 4294966716)) *)
   0x49; 0x8b; 0x07;        (* MOV (% rax) (Memop Quadword (%% (r15,0))) *)
   0x48; 0x83; 0xf0; 0x01;  (* XOR (% rax) (Imm8 (word 1)) *)
   0x49; 0x83; 0xfe; 0x01;  (* CMP (% r14) (Imm8 (word 1)) *)
@@ -319,9 +330,9 @@ let lemma58 = prove
 
 let BIGNUM_COPRIME_CORRECT = prove
  (`!m x a n y b w pc stackpointer.
-        nonoverlapping (word pc,0x331) (stackpointer,48) /\
+        nonoverlapping (word pc,0x34f) (stackpointer,48) /\
         ALL (nonoverlapping (w,8 * 2 * MAX (val m) (val n)))
-            [(word pc,0x331); (stackpointer,48);
+            [(word pc,0x34f); (stackpointer,48);
              (x,8 * val m); (y,8 * val n)] /\
         val m < 2 EXP 57 /\ val n < 2 EXP 57
         ==> ensures x86
@@ -331,7 +342,7 @@ let BIGNUM_COPRIME_CORRECT = prove
                   C_ARGUMENTS [m;x;n;y;w] s /\
                   bignum_from_memory(x,val m) s = a /\
                   bignum_from_memory(y,val n) s = b)
-             (\s. read RIP s = word(pc + 0x322) /\
+             (\s. read RIP s = word(pc + 0x340) /\
                   C_RETURN s = if coprime(a,b) then word 1 else word 0)
              (MAYCHANGE [RIP; RAX; RBX; RCX; RDX; RBP; RDI; RSI;
                          R9; R10; R11; R12; R13; R14; R15] ,,
@@ -749,7 +760,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** The setup of the main outer loop, with the final comparison to 1 ***)
 
-  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xcf` `pc + 0x2ef`
+  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xcf` `pc + 0x30d`
     `\i s. (read RSP s = stackpointer /\
             read (memory :> bytes64(word_add stackpointer (word 40))) s =
             word_or (word(bigdigit a 0)) (word(bigdigit b 0)) /\
@@ -793,7 +804,7 @@ let BIGNUM_COPRIME_CORRECT = prove
     REWRITE_TAC[EXP] THEN
     GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x314`
+    ENSURES_SEQUENCE_TAC `pc + 0x332`
      `\s. read RSP s = stackpointer /\
           read (memory :> bytes64(word_add stackpointer (word 40))) s =
           word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
@@ -832,7 +843,7 @@ let BIGNUM_COPRIME_CORRECT = prove
           ASM_CASES_TAC `n = 0` THEN ASM_REWRITE_TAC[ODD] THEN
           ASM_CASES_TAC `m = 0` THEN ASM_REWRITE_TAC[GCD_0]]]] THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2fc`
+    ENSURES_SEQUENCE_TAC `pc + 0x31a`
      `\s. read RSP s = stackpointer /\
           read (memory :> bytes64(word_add stackpointer (word 40))) s =
           word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
@@ -870,7 +881,7 @@ let BIGNUM_COPRIME_CORRECT = prove
       RULE_ASSUM_TAC(REWRITE_RULE[MULT_CLAUSES]) THEN ASM_SIMP_TAC[MOD_LT];
       ALL_TAC] THEN
 
-    ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x308` `pc + 0x30f`
+    ENSURES_WHILE_AUP_TAC `1` `k:num` `pc + 0x326` `pc + 0x32d`
      `\i s. read RSP s = stackpointer /\
             read (memory :> bytes64(word_add stackpointer (word 40))) s =
             word_or (word (bigdigit a 0)) (word (bigdigit b 0)) /\
@@ -1171,18 +1182,26 @@ let BIGNUM_COPRIME_CORRECT = prove
     ASM_REWRITE_TAC[] THEN CONV_TAC REAL_RAT_REDUCE_CONV;
     ALL_TAC] THEN
 
+  (*** Allow the inner loop to save and restore R8 ***)
+
+  ENSURES_EXISTING_PRESERVED_TAC `R8` THEN
+
   (*** Now set up the somewhat intricate inner loop invariant ***)
 
-  ENSURES_WHILE_PUP_TAC `58` `pc + 0x168` `pc + 0x1e3`
+  ENSURES_WHILE_PUP_TAC `58` `pc + 0x17b` `pc + 0x1ee`
    `\i s. (read RSP s = stackpointer /\
+           read (memory :> bytes64 stackpointer) s =
+           mm /\
+           read (memory :> bytes64(word_add stackpointer (word 8))) s =
+           word k /\
+           read (memory :> bytes64(word_add stackpointer (word 16))) s =
+           word l /\
+           read (memory :> bytes64(word_add stackpointer (word 24))) s =
+           nn /\
            read (memory :> bytes64(word_add stackpointer (word 40))) s =
            evenor /\
-           read R8 s = mm /\
-           read R15 s = nn /\
-           read R14 s = word k /\
            read (memory :> bytes64(word_add stackpointer (word 32))) s =
            word t /\
-           read R13 s = word l /\
            bignum_from_memory (mm,l) s = m /\
            bignum_from_memory (nn,l) s = n /\
            bignum_from_memory (mm,k) s = m0 /\
@@ -1252,7 +1271,7 @@ let BIGNUM_COPRIME_CORRECT = prove
       GEN_REWRITE_TAC (LAND_CONV o BINOP_CONV)
        [BIGNUM_FROM_MEMORY_EQ_HIGHDIGITS] THEN
       ASM_REWRITE_TAC[] THEN STRIP_TAC] THEN
-    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--17) THEN
+    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--21) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     REWRITE_TAC[SUB_0; VAL_WORD_0; VAL_WORD_1] THEN
     REWRITE_TAC[WORD_SUB_LZERO; WORD_NEG_EQ_0; VAL_EQ_0] THEN
@@ -1543,10 +1562,10 @@ let BIGNUM_COPRIME_CORRECT = prove
      [`m_m:num`; `m_n:num`; `n_m:num`; `n_n:num`;
       `m_hi:num`; `n_hi:num`; `m_lo:num`; `n_lo:num`] THEN
 
-    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--37) THEN
+    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--33) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
-    DISCARD_STATE_TAC "s37" THEN
+    DISCARD_STATE_TAC "s33" THEN
 
     MATCH_MP_TAC(TAUT `p /\ (p ==> q) ==> p /\ q`) THEN CONJ_TAC THENL
      [REWRITE_TAC[ARITH_RULE `n - (i + 1) = n - i - 1`] THEN
@@ -1558,28 +1577,16 @@ let BIGNUM_COPRIME_CORRECT = prove
       VAL_INT64_TAC `58 - (i + 1)` THEN
       ASM_REWRITE_TAC[] THEN SIMPLE_ARITH_TAC] THEN
 
-    SUBGOAL_THEN
-     `~(val(word_and (word_and (word_neg (word (bitval (m_hi < n_hi))))
-                               (word 1))
-                     (word m_lo):int64) = 0) <=>
-      m_hi < n_hi /\ ODD m_lo`
-    SUBST1_TAC THENL
-     [POP_ASSUM_LIST(K ALL_TAC) THEN
-      ONCE_REWRITE_TAC[WORD_BITWISE_RULE
-       `word_and (word_and x y) z = word_and y (word_and x z)`] THEN
-      REWRITE_TAC[WORD_AND_1; BIT_LSB_WORD; BIT_WORD_AND; ODD_BITVAL;
-                  BIT_WORD_NEG_CLAUSES; DIMINDEX_64] THEN
-      CONV_TAC NUM_REDUCE_CONV THEN
-      COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
-      CONV_TAC WORD_REDUCE_CONV THEN CONV_TAC NUM_REDUCE_CONV;
-      ALL_TAC] THEN
-
+    REWRITE_TAC[WORD_AND_1_BITVAL; BIT_LSB_WORD; VAL_WORD_BITVAL;
+                BITVAL_EQ_0; COND_SWAP] THEN
+    SIMP_TAC[BITVAL_CLAUSES] THEN
+    REWRITE_TAC[WORD_RULE `word_add (word_not x) (word 1) = word_neg x`] THEN
+    REWRITE_TAC[MESON[VAL_WORD_0; CONJUNCT1 LT]
+     `a < val(if p then x else word 0) <=> a < val x /\ p`] THEN
     REWRITE_TAC[WORD_RULE
      `word_add x (word(1 * val x)) = word_add x x`] THEN
 
-    REWRITE_TAC[WORD_AND_1_BITVAL; VAL_WORD_BITVAL; BITVAL_EQ_0] THEN
-
-    SUBGOAL_THEN
+     SUBGOAL_THEN
      `val(word(n_m + n_m):int64) = n_m + n_m /\
       val(word(n_n + n_n):int64) = n_n + n_n /\
       val(word(m_n + n_n):int64) = m_n + n_n /\
@@ -1601,9 +1608,14 @@ let BIGNUM_COPRIME_CORRECT = prove
       ALL_TAC] THEN
 
     ASM_CASES_TAC `m_hi < n_hi /\ ODD m_lo` THEN
-    ASM_REWRITE_TAC[BIT_LSB_WORD; WORD_AND_MASK] THEN
-
-    COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
+    ASM_REWRITE_TAC[BIT_LSB_WORD; WORD_AND_MASK; WORD_NEG_SUB] THEN
+    ASM_REWRITE_TAC[GSYM NOT_LT] THENL
+     [ASM_REWRITE_TAC[NOT_LT];
+      COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
+      ASM_REWRITE_TAC[NOT_LT]] THEN
+    ASM_REWRITE_TAC[GSYM WORD_ADD; VAL_WORD_0; LE_0; ADD_CLAUSES] THEN
+    REWRITE_TAC[WORD_NEG_SUB; WORD_RULE
+     `word_add (word_neg x) y = word_sub y x`] THEN
     ASM_REWRITE_TAC[VAL_WORD_USHR; EXP_1; ADD_CLAUSES; WORD_SUB_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL
      [REWRITE_TAC[EXP_ADD] THEN MAP_EVERY UNDISCH_TAC
@@ -2300,7 +2312,7 @@ let BIGNUM_COPRIME_CORRECT = prove
     `n':int = &n_m * &m - &n_n * &n`] THEN
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x1f8`
+  ENSURES_SEQUENCE_TAC `pc + 0x216`
    `\s. read RSP s = stackpointer /\
         read (memory :> bytes64(word_add stackpointer (word 40))) s = evenor /\
         read R8 s = mm /\
@@ -2332,7 +2344,7 @@ let BIGNUM_COPRIME_CORRECT = prove
     REWRITE_TAC[BIGNUM_FROM_MEMORY_BYTES] THEN ENSURES_INIT_TAC "s0" THEN
     RULE_ASSUM_TAC(REWRITE_RULE[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`]) THEN
     REWRITE_TAC[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`] THEN
-    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--5) THEN
+    X86_STEPS_TAC BIGNUM_COPRIME_EXEC (1--9) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     DISCH_THEN(fun th -> FIRST_X_ASSUM(MP_TAC o C MATCH_MP th)) THEN
     REPEAT(DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
@@ -2517,7 +2529,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** Cross-multiplication "crossloop" and duplex negation "optnegloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x2b7`
+  ENSURES_SEQUENCE_TAC `pc + 0x2d5`
    `\s. read RSP s = stackpointer /\
         read (memory :> bytes64 (word_add stackpointer (word 40))) s =
         evenor /\
@@ -2539,7 +2551,7 @@ let BIGNUM_COPRIME_CORRECT = prove
    [
     (*** The cross-multiplications loop updating m and n ***)
 
-    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x207` `pc + 0x26b`
+    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x225` `pc + 0x289`
      `\i s. read RSP s = stackpointer /\
             read (memory :> bytes64(word_add stackpointer (word 40))) s =
             evenor /\
@@ -2715,7 +2727,7 @@ let BIGNUM_COPRIME_CORRECT = prove
       ASM_REWRITE_TAC[VAL_BOUND_64; ARITH_RULE `s + 1 <= e <=> s < e`];
       ALL_TAC] THEN
 
-    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x27f` `pc + 0x2ac`
+    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x29d` `pc + 0x2ca`
      `\i s. read RSP s = stackpointer /\
             read (memory :> bytes64 (word_add stackpointer (word 40))) s =
             evenor /\
@@ -2882,7 +2894,7 @@ let BIGNUM_COPRIME_CORRECT = prove
 
   (*** The shift-right-by-58-bits duplex loop "shiftloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x2e9`
+  ENSURES_SEQUENCE_TAC `pc + 0x307`
    `\s. read RSP s = stackpointer /\
         read (memory :> bytes64 (word_add stackpointer (word 40))) s =
         evenor /\
@@ -2909,7 +2921,7 @@ let BIGNUM_COPRIME_CORRECT = prove
     ABBREV_TAC `m3 = 2 EXP (64 * l) * mh + m2` THEN
     ABBREV_TAC `n3 = 2 EXP (64 * l) * nh + n2` THEN
 
-    ENSURES_WHILE_PDOWN_TAC `l:num` `pc + 0x2ba` `pc + 0x2e7`
+    ENSURES_WHILE_PDOWN_TAC `l:num` `pc + 0x2d8` `pc + 0x305`
      `\i s. (read RSP s = stackpointer /\
              read (memory :> bytes64 (word_add stackpointer (word 40))) s =
              evenor /\
@@ -3110,7 +3122,7 @@ let BIGNUM_COPRIME_SUBROUTINE_CORRECT = prove
         ALLPAIRS nonoverlapping
          [(w,8 * 2 * MAX (val m) (val n));
           (word_sub stackpointer (word 96),96)]
-         [(word pc,0x331); (x,8 * val m); (y,8 * val n)] /\
+         [(word pc,0x34f); (x,8 * val m); (y,8 * val n)] /\
         val m < 2 EXP 57 /\ val n < 2 EXP 57
         ==> ensures x86
              (\s. bytes_loaded s (word pc) bignum_coprime_mc /\

--- a/x86/proofs/bignum_modinv.ml
+++ b/x86/proofs/bignum_modinv.ml
@@ -31,8 +31,8 @@ let bignum_modinv_mc =
   0x41; 0x57;              (* PUSH (% r15) *)
   0x48; 0x83; 0xec; 0x50;  (* SUB (% rsp) (Imm8 (word 80)) *)
   0x48; 0x85; 0xff;        (* TEST (% rdi) (% rdi) *)
-  0x0f; 0x84; 0x1d; 0x05; 0x00; 0x00;
-                           (* JE (Imm32 (word 1309)) *)
+  0x0f; 0x84; 0x3b; 0x05; 0x00; 0x00;
+                           (* JE (Imm32 (word 1339)) *)
   0x48; 0x89; 0x74; 0x24; 0x40;
                            (* MOV (Memop Quadword (%% (rsp,64))) (% rsi) *)
   0x4c; 0x89; 0x44; 0x24; 0x38;
@@ -142,44 +142,55 @@ let bignum_modinv_mc =
                            (* MOV (% edx) (Imm32 (word 1)) *)
   0x41; 0xb9; 0x3a; 0x00; 0x00; 0x00;
                            (* MOV (% r9d) (Imm32 (word 58)) *)
-  0x4c; 0x89; 0xe0;        (* MOV (% rax) (% r12) *)
-  0x48; 0x29; 0xe8;        (* SUB (% rax) (% rbp) *)
-  0x48; 0x19; 0xc0;        (* SBB (% rax) (% rax) *)
-  0x48; 0x83; 0xe0; 0x01;  (* AND (% rax) (Imm8 (word 1)) *)
-  0x4c; 0x85; 0xf0;        (* TEST (% rax) (% r14) *)
-  0x4c; 0x89; 0xe0;        (* MOV (% rax) (% r12) *)
-  0x4c; 0x0f; 0x45; 0xe5;  (* CMOVNE (% r12) (% rbp) *)
-  0x48; 0x0f; 0x45; 0xe8;  (* CMOVNE (% rbp) (% rax) *)
-  0x4c; 0x89; 0xf0;        (* MOV (% rax) (% r14) *)
-  0x4c; 0x0f; 0x45; 0xf6;  (* CMOVNE (% r14) (% rsi) *)
-  0x48; 0x0f; 0x45; 0xf0;  (* CMOVNE (% rsi) (% rax) *)
-  0x4c; 0x89; 0xd0;        (* MOV (% rax) (% r10) *)
-  0x4c; 0x0f; 0x45; 0xd1;  (* CMOVNE (% r10) (% rcx) *)
-  0x48; 0x0f; 0x45; 0xc8;  (* CMOVNE (% rcx) (% rax) *)
-  0x4c; 0x89; 0xd8;        (* MOV (% rax) (% r11) *)
-  0x4c; 0x0f; 0x45; 0xda;  (* CMOVNE (% r11) (% rdx) *)
-  0x48; 0x0f; 0x45; 0xd0;  (* CMOVNE (% rdx) (% rax) *)
-  0x4c; 0x89; 0xf3;        (* MOV (% rbx) (% r14) *)
-  0x48; 0x83; 0xe3; 0x01;  (* AND (% rbx) (Imm8 (word 1)) *)
-  0x48; 0xf7; 0xdb;        (* NEG (% rbx) *)
+  0x48; 0x89; 0x7c; 0x24; 0x08;
+                           (* MOV (Memop Quadword (%% (rsp,8))) (% rdi) *)
+  0x4c; 0x89; 0x6c; 0x24; 0x10;
+                           (* MOV (Memop Quadword (%% (rsp,16))) (% r13) *)
+  0x4c; 0x89; 0x04; 0x24;  (* MOV (Memop Quadword (%% (rsp,0))) (% r8) *)
+  0x4c; 0x89; 0x7c; 0x24; 0x18;
+                           (* MOV (Memop Quadword (%% (rsp,24))) (% r15) *)
   0x48; 0x89; 0xe8;        (* MOV (% rax) (% rbp) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x29; 0xc4;        (* SUB (% r12) (% rax) *)
-  0x48; 0x89; 0xf0;        (* MOV (% rax) (% rsi) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x29; 0xc6;        (* SUB (% r14) (% rax) *)
-  0x48; 0x89; 0xc8;        (* MOV (% rax) (% rcx) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x01; 0xc2;        (* ADD (% r10) (% rax) *)
-  0x48; 0x89; 0xd0;        (* MOV (% rax) (% rdx) *)
-  0x48; 0x21; 0xd8;        (* AND (% rax) (% rbx) *)
-  0x49; 0x01; 0xc3;        (* ADD (% r11) (% rax) *)
+  0x48; 0x89; 0xf7;        (* MOV (% rdi) (% rsi) *)
+  0x49; 0x89; 0xcd;        (* MOV (% r13) (% rcx) *)
+  0x49; 0x89; 0xd7;        (* MOV (% r15) (% rdx) *)
+  0x48; 0xc7; 0xc3; 0x01; 0x00; 0x00; 0x00;
+                           (* MOV (% rbx) (Imm32 (word 1)) *)
+  0x48; 0xf7; 0xdf;        (* NEG (% rdi) *)
+  0x4c; 0x21; 0xf3;        (* AND (% rbx) (% r14) *)
+  0x48; 0x0f; 0x44; 0xc3;  (* CMOVE (% rax) (% rbx) *)
+  0x48; 0x0f; 0x44; 0xfb;  (* CMOVE (% rdi) (% rbx) *)
+  0x4c; 0x0f; 0x44; 0xeb;  (* CMOVE (% r13) (% rbx) *)
+  0x4c; 0x0f; 0x44; 0xfb;  (* CMOVE (% r15) (% rbx) *)
+  0x4c; 0x89; 0xe3;        (* MOV (% rbx) (% r12) *)
+  0x4c; 0x01; 0xf7;        (* ADD (% rdi) (% r14) *)
+  0x49; 0x89; 0xf8;        (* MOV (% r8) (% rdi) *)
+  0x48; 0xf7; 0xdf;        (* NEG (% rdi) *)
+  0x48; 0x29; 0xc3;        (* SUB (% rbx) (% rax) *)
+  0x49; 0x0f; 0x42; 0xec;  (* CMOVB (% rbp) (% r12) *)
+  0x49; 0x0f; 0x42; 0xf6;  (* CMOVB (% rsi) (% r14) *)
+  0x49; 0x0f; 0x42; 0xca;  (* CMOVB (% rcx) (% r10) *)
+  0x49; 0x0f; 0x42; 0xd3;  (* CMOVB (% rdx) (% r11) *)
+  0x49; 0x0f; 0x43; 0xf8;  (* CMOVAE (% rdi) (% r8) *)
+  0x49; 0x89; 0xdc;        (* MOV (% r12) (% rbx) *)
+  0x48; 0xf7; 0xd3;        (* NOT (% rbx) *)
+  0x48; 0xff; 0xc3;        (* INC (% rbx) *)
+  0x4c; 0x0f; 0x42; 0xe3;  (* CMOVB (% r12) (% rbx) *)
+  0x49; 0x89; 0xfe;        (* MOV (% r14) (% rdi) *)
+  0x4d; 0x01; 0xea;        (* ADD (% r10) (% r13) *)
+  0x4d; 0x01; 0xfb;        (* ADD (% r11) (% r15) *)
   0x49; 0xd1; 0xec;        (* SHR (% r12) (Imm8 (word 1)) *)
   0x49; 0xd1; 0xee;        (* SHR (% r14) (Imm8 (word 1)) *)
   0x48; 0x8d; 0x0c; 0x09;  (* LEA (% rcx) (%%% (rcx,0,rcx)) *)
   0x48; 0x8d; 0x14; 0x12;  (* LEA (% rdx) (%%% (rdx,0,rdx)) *)
   0x49; 0xff; 0xc9;        (* DEC (% r9) *)
-  0x75; 0x83;              (* JNE (Imm8 (word 131)) *)
+  0x75; 0x8b;              (* JNE (Imm8 (word 139)) *)
+  0x48; 0x8b; 0x7c; 0x24; 0x08;
+                           (* MOV (% rdi) (Memop Quadword (%% (rsp,8))) *)
+  0x4c; 0x8b; 0x6c; 0x24; 0x10;
+                           (* MOV (% r13) (Memop Quadword (%% (rsp,16))) *)
+  0x4c; 0x8b; 0x04; 0x24;  (* MOV (% r8) (Memop Quadword (%% (rsp,0))) *)
+  0x4c; 0x8b; 0x7c; 0x24; 0x18;
+                           (* MOV (% r15) (Memop Quadword (%% (rsp,24))) *)
   0x4c; 0x89; 0x14; 0x24;  (* MOV (Memop Quadword (%% (rsp,0))) (% r10) *)
   0x4c; 0x89; 0x5c; 0x24; 0x08;
                            (* MOV (Memop Quadword (%% (rsp,8))) (% r11) *)
@@ -458,8 +469,8 @@ let bignum_modinv_mc =
   0x72; 0xc3;              (* JB (Imm8 (word 195)) *)
   0x48; 0x83; 0x6c; 0x24; 0x20; 0x3a;
                            (* SUB (Memop Quadword (%% (rsp,32))) (Imm8 (word 58)) *)
-  0x0f; 0x87; 0x9a; 0xfb; 0xff; 0xff;
-                           (* JA (Imm32 (word 4294966170)) *)
+  0x0f; 0x87; 0x7c; 0xfb; 0xff; 0xff;
+                           (* JA (Imm32 (word 4294966140)) *)
   0x48; 0x83; 0xc4; 0x50;  (* ADD (% rsp) (Imm8 (word 80)) *)
   0x41; 0x5f;              (* POP (% r15) *)
   0x41; 0x5e;              (* POP (% r14) *)
@@ -520,10 +531,10 @@ let BIGNUM_MODINV_CORRECT = prove
  (`!k z x a y b w pc stackpointer.
         nonoverlapping (w,8 * 3 * val k) (z,8 * val k) /\
         ALL (nonoverlapping (stackpointer,80))
-            [(word pc,0x543); (x,8 * val k); (y,8 * val k)] /\
+            [(word pc,0x561); (x,8 * val k); (y,8 * val k)] /\
         ALLPAIRS nonoverlapping
          [(w,8 * 3 * val k); (z,8 * val k)]
-         [(word pc,0x543); (stackpointer,80);
+         [(word pc,0x561); (stackpointer,80);
           (x,8 * val k); (y,8 * val k)] /\
         val k < 2 EXP 57
         ==> ensures x86
@@ -533,7 +544,7 @@ let BIGNUM_MODINV_CORRECT = prove
                   C_ARGUMENTS [k;z;x;y;w] s /\
                   bignum_from_memory(x,val k) s = a /\
                   bignum_from_memory(y,val k) s = b)
-             (\s. read RIP s = word(pc + 0x534) /\
+             (\s. read RIP s = word(pc + 0x552) /\
                   (coprime(a,b) /\ ODD b /\ ~(b = 1)
                    ==> bignum_from_memory(z,val k) s < b /\
                        (a * bignum_from_memory(z,val k) s == 1) (mod b)))
@@ -721,7 +732,7 @@ let BIGNUM_MODINV_CORRECT = prove
   SUBGOAL_THEN `64 <= t /\ t <= 128 * k` STRIP_ASSUME_TAC THENL
    [EXPAND_TAC "t" THEN UNDISCH_TAC `~(k = 0)` THEN ARITH_TAC; ALL_TAC] THEN
 
-  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xce` `pc + 0x52e`
+  ENSURES_WHILE_PUP_TAC `(t + 57) DIV 58` `pc + 0xce` `pc + 0x54c`
     `\i s. (read RSP s = stackpointer /\
             read RDI s = word k /\
             bignum_from_memory (y,k) s = b /\
@@ -1057,10 +1068,16 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Now set up the somewhat intricate inner loop invariant ***)
 
-  ENSURES_WHILE_PUP_TAC `58` `pc + 0x170` `pc + 0x1eb`
+  ENSURES_WHILE_PUP_TAC `58` `pc + 0x183` `pc + 0x1f6`
    `\i s. (read RSP s = stackpointer /\
-           read RDI s = word k /\
-           read R13 s = word l /\
+           read (memory :> bytes64 stackpointer) s =
+           mm /\
+           read (memory :> bytes64(word_add stackpointer (word 8))) s =
+           word k /\
+           read (memory :> bytes64(word_add stackpointer (word 16))) s =
+           word l /\
+           read (memory :> bytes64(word_add stackpointer (word 24))) s =
+           nn /\
            bignum_from_memory (y,k) s = b /\
            read (memory :> bytes64(word_add stackpointer (word 32))) s =
            word t /\
@@ -1141,7 +1158,7 @@ let BIGNUM_MODINV_CORRECT = prove
       GEN_REWRITE_TAC (LAND_CONV o BINOP_CONV)
        [BIGNUM_FROM_MEMORY_EQ_HIGHDIGITS] THEN
       ASM_REWRITE_TAC[] THEN STRIP_TAC] THEN
-    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--17) THEN
+    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--21) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     REWRITE_TAC[SUB_0; VAL_WORD_0; VAL_WORD_1] THEN
     REWRITE_TAC[WORD_SUB_LZERO; WORD_NEG_EQ_0; VAL_EQ_0] THEN
@@ -1432,10 +1449,10 @@ let BIGNUM_MODINV_CORRECT = prove
      [`m_m:num`; `m_n:num`; `n_m:num`; `n_n:num`;
       `m_hi:num`; `n_hi:num`; `m_lo:num`; `n_lo:num`] THEN
 
-    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--37) THEN
+    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--33) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
 
-    DISCARD_STATE_TAC "s37" THEN
+    DISCARD_STATE_TAC "s33" THEN
 
     MATCH_MP_TAC(TAUT `p /\ (p ==> q) ==> p /\ q`) THEN CONJ_TAC THENL
      [REWRITE_TAC[ARITH_RULE `n - (i + 1) = n - i - 1`] THEN
@@ -1447,26 +1464,14 @@ let BIGNUM_MODINV_CORRECT = prove
       VAL_INT64_TAC `58 - (i + 1)` THEN
       ASM_REWRITE_TAC[] THEN SIMPLE_ARITH_TAC] THEN
 
-    SUBGOAL_THEN
-     `~(val(word_and (word_and (word_neg (word (bitval (m_hi < n_hi))))
-                               (word 1))
-                     (word m_lo):int64) = 0) <=>
-      m_hi < n_hi /\ ODD m_lo`
-    SUBST1_TAC THENL
-     [POP_ASSUM_LIST(K ALL_TAC) THEN
-      ONCE_REWRITE_TAC[WORD_BITWISE_RULE
-       `word_and (word_and x y) z = word_and y (word_and x z)`] THEN
-      REWRITE_TAC[WORD_AND_1; BIT_LSB_WORD; BIT_WORD_AND; ODD_BITVAL;
-                  BIT_WORD_NEG_CLAUSES; DIMINDEX_64] THEN
-      CONV_TAC NUM_REDUCE_CONV THEN
-      COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
-      CONV_TAC WORD_REDUCE_CONV THEN CONV_TAC NUM_REDUCE_CONV;
-      ALL_TAC] THEN
-
+    REWRITE_TAC[WORD_AND_1_BITVAL; BIT_LSB_WORD; VAL_WORD_BITVAL;
+                BITVAL_EQ_0; COND_SWAP] THEN
+    SIMP_TAC[BITVAL_CLAUSES] THEN
+    REWRITE_TAC[WORD_RULE `word_add (word_not x) (word 1) = word_neg x`] THEN
+    REWRITE_TAC[MESON[VAL_WORD_0; CONJUNCT1 LT]
+     `a < val(if p then x else word 0) <=> a < val x /\ p`] THEN
     REWRITE_TAC[WORD_RULE
      `word_add x (word(1 * val x)) = word_add x x`] THEN
-
-    REWRITE_TAC[WORD_AND_1_BITVAL; VAL_WORD_BITVAL; BITVAL_EQ_0] THEN
 
     SUBGOAL_THEN
      `val(word(n_m + n_m):int64) = n_m + n_m /\
@@ -1490,9 +1495,14 @@ let BIGNUM_MODINV_CORRECT = prove
       ALL_TAC] THEN
 
     ASM_CASES_TAC `m_hi < n_hi /\ ODD m_lo` THEN
-    ASM_REWRITE_TAC[BIT_LSB_WORD; WORD_AND_MASK] THEN
-
-    COND_CASES_TAC THEN ASM_REWRITE_TAC[GSYM WORD_ADD] THEN
+    ASM_REWRITE_TAC[BIT_LSB_WORD; WORD_AND_MASK; WORD_NEG_SUB] THEN
+    ASM_REWRITE_TAC[GSYM NOT_LT] THENL
+     [ASM_REWRITE_TAC[NOT_LT];
+      COND_CASES_TAC THEN ASM_REWRITE_TAC[] THEN
+      ASM_REWRITE_TAC[NOT_LT]] THEN
+    ASM_REWRITE_TAC[GSYM WORD_ADD; VAL_WORD_0; LE_0; ADD_CLAUSES] THEN
+    REWRITE_TAC[WORD_NEG_SUB; WORD_RULE
+     `word_add (word_neg x) y = word_sub y x`] THEN
     ASM_REWRITE_TAC[VAL_WORD_USHR; EXP_1; ADD_CLAUSES; WORD_SUB_0] THEN
     REPLICATE_TAC 2 (CONJ_TAC THENL
      [REWRITE_TAC[EXP_ADD] THEN MAP_EVERY UNDISCH_TAC
@@ -2189,7 +2199,7 @@ let BIGNUM_MODINV_CORRECT = prove
     `n':int = &n_m * &m - &n_n * &n`] THEN
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
 
-  ENSURES_SEQUENCE_TAC `pc + 0x200`
+  ENSURES_SEQUENCE_TAC `pc + 0x21e`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -2228,7 +2238,7 @@ let BIGNUM_MODINV_CORRECT = prove
     REWRITE_TAC[BIGNUM_FROM_MEMORY_BYTES] THEN ENSURES_INIT_TAC "s0" THEN
     RULE_ASSUM_TAC(REWRITE_RULE[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`]) THEN
     REWRITE_TAC[TAUT `~p /\ ~q ==> r <=> p \/ q \/ r`] THEN
-    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--5) THEN
+    X86_STEPS_TAC BIGNUM_MODINV_EXEC (1--9) THEN
     ENSURES_FINAL_STATE_TAC THEN ASM_REWRITE_TAC[] THEN
     DISCH_THEN(fun th -> FIRST_X_ASSUM(MP_TAC o C MATCH_MP th)) THEN
     REPEAT(DISCH_THEN(CONJUNCTS_THEN2 ASSUME_TAC MP_TAC)) THEN
@@ -2413,7 +2423,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Congruence cross-multiplication and shift-by-6 "congloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x290`
+  ENSURES_SEQUENCE_TAC `pc + 0x2ae`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -2443,7 +2453,7 @@ let BIGNUM_MODINV_CORRECT = prove
         2 EXP (64 * k) * val(read RSI s) + bignum_from_memory (zz,k) s =
         2 EXP 6 * (n_m * w + n_n * z)` THEN
   CONJ_TAC THENL
-   [ENSURES_WHILE_UP_TAC `k:num` `pc + 0x219` `pc + 0x281`
+   [ENSURES_WHILE_UP_TAC `k:num` `pc + 0x237` `pc + 0x29f`
      `\i s. read RSP s = stackpointer /\
             read RDI s = word k /\
             read R13 s = word l /\
@@ -2582,7 +2592,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The first Montgomery operation ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x333`
+  ENSURES_SEQUENCE_TAC `pc + 0x351`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -2628,7 +2638,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** The prelude of the Montgomery reduction ***)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2b9`
+    ENSURES_SEQUENCE_TAC `pc + 0x2d7`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -2703,7 +2713,7 @@ let BIGNUM_MODINV_CORRECT = prove
     GLOBALIZE_PRECONDITION_TAC THEN
     FIRST_X_ASSUM(X_CHOOSE_THEN `r0:num` STRIP_ASSUME_TAC) THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2df`
+    ENSURES_SEQUENCE_TAC `pc + 0x2fd`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -2752,7 +2762,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
       VAL_INT64_TAC `k - 1` THEN
 
-      ENSURES_WHILE_PAUP_TAC `1` `k:num` `pc + 0x2bb` `pc + 0x2dd`
+      ENSURES_WHILE_PAUP_TAC `1` `k:num` `pc + 0x2d9` `pc + 0x2fb`
        `\i s.
          (read RSP s = stackpointer /\
           read RDI s = word k /\
@@ -2880,7 +2890,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
    (*** The final digit write ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x2ed`
+    ENSURES_SEQUENCE_TAC `pc + 0x30b`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -2954,7 +2964,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Comparison operation "wcmploop" ***)
 
-    ENSURES_WHILE_PUP_TAC `k:num` `pc + 0x2f3` `pc + 0x301`
+    ENSURES_WHILE_PUP_TAC `k:num` `pc + 0x311` `pc + 0x31f`
      `\i s.
          (read RSP s = stackpointer /\
           read RDI s = word k /\
@@ -3029,7 +3039,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     ABBREV_TAC `cg <=> b <= 2 EXP (64 * k) * bitval cf + w2` THEN
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x313` `pc + 0x32e`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x331` `pc + 0x34c`
      `\i s. read RSP s = stackpointer /\
             read RDI s = word k /\
             read R13 s = word l /\
@@ -3191,7 +3201,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The second Montgomery operation ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x3d6`
+  ENSURES_SEQUENCE_TAC `pc + 0x3f4`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -3237,7 +3247,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** The prelude of the Montgomery reduction ***)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x35c`
+    ENSURES_SEQUENCE_TAC `pc + 0x37a`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -3313,7 +3323,7 @@ let BIGNUM_MODINV_CORRECT = prove
     GLOBALIZE_PRECONDITION_TAC THEN
     FIRST_X_ASSUM(X_CHOOSE_THEN `r0:num` STRIP_ASSUME_TAC) THEN
 
-    ENSURES_SEQUENCE_TAC `pc + 0x382`
+    ENSURES_SEQUENCE_TAC `pc + 0x3a0`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -3363,7 +3373,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
       VAL_INT64_TAC `k - 1` THEN
 
-      ENSURES_WHILE_PAUP_TAC `1` `k:num` `pc + 0x35e` `pc + 0x380`
+      ENSURES_WHILE_PAUP_TAC `1` `k:num` `pc + 0x37c` `pc + 0x39e`
        `\i s.
          (read RSP s = stackpointer /\
           read RDI s = word k /\
@@ -3492,7 +3502,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
    (*** The final digit write ****)
 
-    ENSURES_SEQUENCE_TAC `pc + 0x390`
+    ENSURES_SEQUENCE_TAC `pc + 0x3ae`
      `\s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -3567,7 +3577,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     (*** Comparison operation "zcmploop" ***)
 
-    ENSURES_WHILE_PUP_TAC `k:num` `pc + 0x396` `pc + 0x3a4`
+    ENSURES_WHILE_PUP_TAC `k:num` `pc + 0x3b4` `pc + 0x3c2`
      `\i s.
          (read RSP s = stackpointer /\
           read RDI s = word k /\
@@ -3643,7 +3653,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
     ABBREV_TAC `cg <=> b <= 2 EXP (64 * k) * bitval cf + z2` THEN
 
-    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x3b6` `pc + 0x3d1`
+    ENSURES_WHILE_UP_TAC `k:num` `pc + 0x3d4` `pc + 0x3ef`
      `\i s. read RSP s = stackpointer /\
             read RDI s = word k /\
             read R13 s = word l /\
@@ -3818,7 +3828,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** Cross-multiplication "crossloop" and duplex negation "optnegloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x49e`
+  ENSURES_SEQUENCE_TAC `pc + 0x4bc`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -3856,7 +3866,7 @@ let BIGNUM_MODINV_CORRECT = prove
    [
     (*** The cross-multiplications loop updating m and n ***)
 
-    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x3ee` `pc + 0x452`
+    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x40c` `pc + 0x470`
      `\i s. read RSP s = stackpointer /\
             read RDI s = word k /\
             read R13 s = word l /\
@@ -4037,7 +4047,7 @@ let BIGNUM_MODINV_CORRECT = prove
       ASM_REWRITE_TAC[VAL_BOUND_64; ARITH_RULE `s + 1 <= e <=> s < e`];
       ALL_TAC] THEN
 
-    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x466` `pc + 0x493`
+    ENSURES_WHILE_UP_TAC `l:num` `pc + 0x484` `pc + 0x4b1`
      `\i s. read RSP s = stackpointer /\
             read RDI s = word k /\
             read R13 s = word l /\
@@ -4218,7 +4228,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The shift-right-by-58-bits duplex loop "shiftloop" ***)
 
-  ENSURES_SEQUENCE_TAC `pc + 0x4d0`
+  ENSURES_SEQUENCE_TAC `pc + 0x4ee`
    `\s. read RSP s = stackpointer /\
         read RDI s = word k /\
         read R13 s = word l /\
@@ -4261,7 +4271,7 @@ let BIGNUM_MODINV_CORRECT = prove
     ABBREV_TAC `m3 = 2 EXP (64 * l) * mh + m2` THEN
     ABBREV_TAC `n3 = 2 EXP (64 * l) * nh + n2` THEN
 
-    ENSURES_WHILE_PDOWN_TAC `l:num` `pc + 0x4a1` `pc + 0x4ce`
+    ENSURES_WHILE_PDOWN_TAC `l:num` `pc + 0x4bf` `pc + 0x4ec`
      `\i s.
         (read RSP s = stackpointer /\
          read RDI s = word k /\
@@ -4392,7 +4402,7 @@ let BIGNUM_MODINV_CORRECT = prove
 
   (*** The duplex optional modular negation "fliploop" ***)
 
-  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x4eb` `pc + 0x523`
+  ENSURES_WHILE_UP_TAC `k:num` `pc + 0x509` `pc + 0x541`
    `\i s. read RSP s = stackpointer /\
           read RDI s = word k /\
           read R13 s = word l /\
@@ -4700,10 +4710,10 @@ let BIGNUM_MODINV_SUBROUTINE_CORRECT = prove
  (`!k z x a y b w pc stackpointer returnaddress.
         nonoverlapping (w,8 * 3 * val k) (z,8 * val k) /\
         ALL (nonoverlapping (word_sub stackpointer (word 128),128))
-            [(word pc,0x543); (x,8 * val k); (y,8 * val k)] /\
+            [(word pc,0x561); (x,8 * val k); (y,8 * val k)] /\
         ALLPAIRS nonoverlapping
          [(w,8 * 3 * val k); (z,8 * val k)]
-         [(word pc,0x543); (word_sub stackpointer (word 128),136);
+         [(word pc,0x561); (word_sub stackpointer (word 128),136);
           (x,8 * val k); (y,8 * val k)] /\
         val k < 2 EXP 57
         ==> ensures x86

--- a/x86_att/generic/bignum_coprime.S
+++ b/x86_att/generic/bignum_coprime.S
@@ -289,72 +289,64 @@ toploop:
                 movl    $1, n_nshort
                 movl    $CHUNKSIZE, ishort
 
+// Stash more variables over the inner loop to free up regs
+
+                movq    k, mat_mn
+                movq    l, mat_nm
+                movq    m, mat_mm
+                movq    n, mat_nn
+
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed.
+
 innerloop:
 
-// Not quite the same: the value b is in the flags as a NZ condition
-//
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                movq    m_hi, %rax
-                subq    n_hi, %rax
-                sbbq    %rax, %rax
-                andq    $1, %rax
-                testq   m_lo, %rax
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                movq    m_hi, %rax
-                cmovnzq n_hi, m_hi
-                cmovnzq %rax, n_hi
-
-                movq    m_lo, %rax
-                cmovnzq n_lo, m_lo
-                cmovnzq %rax, n_lo
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                movq    m_m, %rax
-                cmovnzq n_m, m_m
-                cmovnzq %rax, n_m
-
-                movq    m_n, %rax
-                cmovnzq n_n, m_n
-                cmovnzq %rax, n_n
-
-// This time actually put the condition in RBX as a mask
-//
-// b = (m_lo & 1ull);
-
-                movq    m_lo, %rbx
-                andq    $1, %rbx
-                negq    %rbx
-
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
-
                 movq    n_hi, %rax
-                andq    %rbx, %rax
-                subq    %rax, m_hi
-                movq    n_lo, %rax
-                andq    %rbx, %rax
-                subq    %rax, m_lo
+                movq    n_lo, k
+                movq    n_m, l
+                movq    n_n, n
+                movq    $1, %rbx
+                negq    k
+                andq    m_lo, %rbx
+                cmovzq  %rbx, %rax
+                cmovzq  %rbx, k
+                cmovzq  %rbx, l
+                cmovzq  %rbx, n
+                movq    m_hi, %rbx
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                addq    m_lo, k
+                movq    k, m
+                negq    k
+                subq    %rax, %rbx
 
-                movq    n_m, %rax
-                andq    %rbx, %rax
-                addq    %rax, m_m
+                cmovcq  m_hi, n_hi
+                cmovcq  m_lo, n_lo
+                cmovcq  m_m, n_m
+                cmovcq  m_n, n_n
+                cmovncq m, k
+                movq    %rbx, m_hi
+                notq    %rbx
+                incq    %rbx
+                cmovcq  %rbx, m_hi
 
-                movq    n_n, %rax
-                andq    %rbx, %rax
-                addq    %rax, m_n
-
-// m_hi >>= 1; m_lo >>= 1;
-
+                movq    k, m_lo
+                addq    l, m_m
+                addq    n, m_n
                 shrq    $1, m_hi
                 shrq    $1, m_lo
-
-// n_m <<= 1; n_n <<= 1;
-
                 leaq    (n_m,n_m), n_m
                 leaq    (n_n,n_n), n_n
 
@@ -362,6 +354,13 @@ innerloop:
 
                 decq    i
                 jnz     innerloop
+
+// Unstash the temporary variables
+
+                movq    mat_mn, k
+                movq    mat_nm, l
+                movq    mat_mm, m
+                movq    mat_nn, n
 
 // Put the matrix entries in memory since we're out of registers
 // We pull them out repeatedly in the next loop

--- a/x86_att/generic/bignum_modinv.S
+++ b/x86_att/generic/bignum_modinv.S
@@ -285,72 +285,64 @@ toploop:
                 movl    $1, n_nshort
                 movl    $CHUNKSIZE, ishort
 
+// Stash more variables over the inner loop to free up regs
+
+                movq    k, mat_mn
+                movq    l, mat_nm
+                movq    p1, mat_mm
+                movq    p2, mat_nn
+
+// Conceptually in the inner loop we follow these steps:
+//
+// * If m_lo is odd and m_hi < n_hi, then swap the four pairs
+//    (m_hi,n_hi); (m_lo,n_lo); (m_m,n_m); (m_n,n_n)
+//
+// * Now, if m_lo is odd (old or new, doesn't matter as initial n_lo is odd)
+//    m_hi := m_hi - n_hi, m_lo := m_lo - n_lo
+//    m_m  := m_m + n_m, m_n := m_n + n_n
+//
+// * Halve and double them
+//     m_hi := m_hi / 2, m_lo := m_lo / 2
+//     n_m := n_m * 2, n_n := n_n * 2
+//
+// The actual computation computes updates before actually swapping and
+// then corrects as needed.
+
 innerloop:
 
-// Not quite the same: the value b is in the flags as a NZ condition
-//
-// b = (m_lo & 1ull) & (m_hi < n_hi);
-
-                movq    m_hi, %rax
-                subq    n_hi, %rax
-                sbbq    %rax, %rax
-                andq    $1, %rax
-                testq   m_lo, %rax
-
-// if (b) { swap(m_hi,n_hi); swap(m_lo,n_lo); }
-
-                movq    m_hi, %rax
-                cmovnzq n_hi, m_hi
-                cmovnzq %rax, n_hi
-
-                movq    m_lo, %rax
-                cmovnzq n_lo, m_lo
-                cmovnzq %rax, n_lo
-
-// if (b) { swap(m_m,n_m); swap(m_n,n_n); }
-
-                movq    m_m, %rax
-                cmovnzq n_m, m_m
-                cmovnzq %rax, n_m
-
-                movq    m_n, %rax
-                cmovnzq n_n, m_n
-                cmovnzq %rax, n_n
-
-// This time actually put the condition in RBX as a mask
-//
-// b = (m_lo & 1ull);
-
-                movq    m_lo, %rbx
-                andq    $1, %rbx
-                negq    %rbx
-
-// if (b) { m_hi -= n_hi; m_lo -= n_lo; }
-
                 movq    n_hi, %rax
-                andq    %rbx, %rax
-                subq    %rax, m_hi
-                movq    n_lo, %rax
-                andq    %rbx, %rax
-                subq    %rax, m_lo
+                movq    n_lo, k
+                movq    n_m, l
+                movq    n_n, p2
+                movq    $1, %rbx
+                negq    k
+                andq    m_lo, %rbx
+                cmovzq  %rbx, %rax
+                cmovzq  %rbx, k
+                cmovzq  %rbx, l
+                cmovzq  %rbx, p2
+                movq    m_hi, %rbx
 
-// if (b) { m_m += n_m; m_n += n_n; }
+                addq    m_lo, k
+                movq    k, p1
+                negq    k
+                subq    %rax, %rbx
 
-                movq    n_m, %rax
-                andq    %rbx, %rax
-                addq    %rax, m_m
+                cmovcq  m_hi, n_hi
+                cmovcq  m_lo, n_lo
+                cmovcq  m_m, n_m
+                cmovcq  m_n, n_n
+                cmovncq p1, k
+                movq    %rbx, m_hi
+                notq    %rbx
+                incq    %rbx
+                cmovcq  %rbx, m_hi
 
-                movq    n_n, %rax
-                andq    %rbx, %rax
-                addq    %rax, m_n
-
-// m_hi >>= 1; m_lo >>= 1;
-
+                movq    k, m_lo
+                addq    l, m_m
+                addq    p2, m_n
                 shrq    $1, m_hi
                 shrq    $1, m_lo
-
-// n_m <<= 1; n_n <<= 1;
-
                 leaq    (n_m,n_m), n_m
                 leaq    (n_n,n_n), n_n
 
@@ -358,6 +350,13 @@ innerloop:
 
                 decq    i
                 jnz     innerloop
+
+// Unstash the temporary variables
+
+                movq    mat_mn, k
+                movq    mat_nm, l
+                movq    mat_mm, p1
+                movq    mat_nn, p2
 
 // Put the matrix entries in memory since we're out of registers
 // We pull them out repeatedly in the next loop


### PR DESCRIPTION
The new version restructures the inner (word-level) loop. The net
result is exactly the same as before, but the computation uses fewer
instructions and/or has better dependent latency, especially on ARM.
For relatively small size, e.g. those used in common elliptic curves,
the speedup is significant. At larger RSA-type sizes the
multiplications dominate anyway so the overall benefit is relatively
more modest. The same changes are applied to the coprimality
predicate, which uses the same basic inner loop.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
