### PR TITLE
Several files missing .text directive

### DIFF
--- a/x86_att/curve25519/bignum_add_p25519.S
+++ b/x86_att/curve25519/bignum_add_p25519.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p25519)
         .text

--- a/x86_att/curve25519/bignum_cmul_p25519.S
+++ b/x86_att/curve25519/bignum_cmul_p25519.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p25519)
         .text

--- a/x86_att/curve25519/bignum_cmul_p25519_alt.S
+++ b/x86_att/curve25519/bignum_cmul_p25519_alt.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p25519_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p25519_alt)
         .text

--- a/x86_att/curve25519/bignum_mul_p25519.S
+++ b/x86_att/curve25519/bignum_mul_p25519.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p25519)
         .text

--- a/x86_att/curve25519/bignum_mul_p25519_alt.S
+++ b/x86_att/curve25519/bignum_mul_p25519_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p25519_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p25519_alt)
         .text

--- a/x86_att/curve25519/bignum_neg_p25519.S
+++ b/x86_att/curve25519/bignum_neg_p25519.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p25519)
         .text

--- a/x86_att/curve25519/bignum_sqr_p25519.S
+++ b/x86_att/curve25519/bignum_sqr_p25519.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p25519)
         .text

--- a/x86_att/curve25519/bignum_sqr_p25519_alt.S
+++ b/x86_att/curve25519/bignum_sqr_p25519_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p25519_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p25519_alt)
         .text

--- a/x86_att/curve25519/bignum_sub_p25519.S
+++ b/x86_att/curve25519/bignum_sub_p25519.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p25519)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p25519)
         .text

--- a/x86_att/fastmul/bignum_emontredc_8n.S
+++ b/x86_att/fastmul/bignum_emontredc_8n.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_emontredc_8n)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_emontredc_8n)
         .text

--- a/x86_att/fastmul/bignum_kmul_16_32.S
+++ b/x86_att/fastmul/bignum_kmul_16_32.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_kmul_16_32)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_kmul_16_32)
         .text

--- a/x86_att/fastmul/bignum_kmul_32_64.S
+++ b/x86_att/fastmul/bignum_kmul_32_64.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_kmul_32_64)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_kmul_32_64)
         .text

--- a/x86_att/fastmul/bignum_ksqr_16_32.S
+++ b/x86_att/fastmul/bignum_ksqr_16_32.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_ksqr_16_32)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_ksqr_16_32)
         .text

--- a/x86_att/fastmul/bignum_ksqr_32_64.S
+++ b/x86_att/fastmul/bignum_ksqr_32_64.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_ksqr_32_64)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_ksqr_32_64)
         .text

--- a/x86_att/fastmul/bignum_mul_4_8.S
+++ b/x86_att/fastmul/bignum_mul_4_8.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_4_8)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_4_8)
         .text

--- a/x86_att/fastmul/bignum_mul_4_8_alt.S
+++ b/x86_att/fastmul/bignum_mul_4_8_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_4_8_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_4_8_alt)
         .text

--- a/x86_att/fastmul/bignum_mul_6_12.S
+++ b/x86_att/fastmul/bignum_mul_6_12.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_6_12)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_6_12)
         .text

--- a/x86_att/fastmul/bignum_mul_6_12_alt.S
+++ b/x86_att/fastmul/bignum_mul_6_12_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_6_12_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_6_12_alt)
         .text

--- a/x86_att/fastmul/bignum_mul_8_16.S
+++ b/x86_att/fastmul/bignum_mul_8_16.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_8_16)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_8_16)
         .text

--- a/x86_att/fastmul/bignum_mul_8_16_alt.S
+++ b/x86_att/fastmul/bignum_mul_8_16_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_8_16_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_8_16_alt)
         .text

--- a/x86_att/fastmul/bignum_sqr_4_8.S
+++ b/x86_att/fastmul/bignum_sqr_4_8.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_4_8)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_4_8)
         .text

--- a/x86_att/fastmul/bignum_sqr_4_8_alt.S
+++ b/x86_att/fastmul/bignum_sqr_4_8_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_4_8_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_4_8_alt)
         .text

--- a/x86_att/fastmul/bignum_sqr_6_12.S
+++ b/x86_att/fastmul/bignum_sqr_6_12.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_6_12)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_6_12)
         .text

--- a/x86_att/fastmul/bignum_sqr_6_12_alt.S
+++ b/x86_att/fastmul/bignum_sqr_6_12_alt.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_6_12_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_6_12_alt)
         .text

--- a/x86_att/fastmul/bignum_sqr_8_16.S
+++ b/x86_att/fastmul/bignum_sqr_8_16.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_8_16)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_8_16)
         .text

--- a/x86_att/fastmul/bignum_sqr_8_16_alt.S
+++ b/x86_att/fastmul/bignum_sqr_8_16_alt.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_8_16_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_8_16_alt)
         .text

--- a/x86_att/generic/bignum_add.S
+++ b/x86_att/generic/bignum_add.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add)
         .text

--- a/x86_att/generic/bignum_amontifier.S
+++ b/x86_att/generic/bignum_amontifier.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_amontifier)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_amontifier)
         .text

--- a/x86_att/generic/bignum_amontmul.S
+++ b/x86_att/generic/bignum_amontmul.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_amontmul)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_amontmul)
         .text

--- a/x86_att/generic/bignum_amontredc.S
+++ b/x86_att/generic/bignum_amontredc.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_amontredc)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_amontredc)
         .text

--- a/x86_att/generic/bignum_amontsqr.S
+++ b/x86_att/generic/bignum_amontsqr.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_amontsqr)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_amontsqr)
         .text

--- a/x86_att/generic/bignum_bitfield.S
+++ b/x86_att/generic/bignum_bitfield.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bitfield)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bitfield)
         .text

--- a/x86_att/generic/bignum_bitsize.S
+++ b/x86_att/generic/bignum_bitsize.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bitsize)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bitsize)
         .text

--- a/x86_att/generic/bignum_cdiv.S
+++ b/x86_att/generic/bignum_cdiv.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cdiv)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cdiv)
         .text

--- a/x86_att/generic/bignum_cdiv_exact.S
+++ b/x86_att/generic/bignum_cdiv_exact.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cdiv_exact)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cdiv_exact)
         .text

--- a/x86_att/generic/bignum_cld.S
+++ b/x86_att/generic/bignum_cld.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cld)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cld)
         .text

--- a/x86_att/generic/bignum_clz.S
+++ b/x86_att/generic/bignum_clz.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_clz)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_clz)
         .text

--- a/x86_att/generic/bignum_cmadd.S
+++ b/x86_att/generic/bignum_cmadd.S
@@ -33,6 +33,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmadd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmadd)
         .text

--- a/x86_att/generic/bignum_cmnegadd.S
+++ b/x86_att/generic/bignum_cmnegadd.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmnegadd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmnegadd)
         .text

--- a/x86_att/generic/bignum_cmod.S
+++ b/x86_att/generic/bignum_cmod.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmod)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmod)
         .text

--- a/x86_att/generic/bignum_cmul.S
+++ b/x86_att/generic/bignum_cmul.S
@@ -35,6 +35,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul)
         .text

--- a/x86_att/generic/bignum_coprime.S
+++ b/x86_att/generic/bignum_coprime.S
@@ -34,6 +34,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_coprime)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_coprime)
         .text

--- a/x86_att/generic/bignum_copy.S
+++ b/x86_att/generic/bignum_copy.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_copy)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_copy)
         .text

--- a/x86_att/generic/bignum_ctd.S
+++ b/x86_att/generic/bignum_ctd.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_ctd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_ctd)
         .text

--- a/x86_att/generic/bignum_ctz.S
+++ b/x86_att/generic/bignum_ctz.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_ctz)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_ctz)
         .text

--- a/x86_att/generic/bignum_demont.S
+++ b/x86_att/generic/bignum_demont.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont)
         .text

--- a/x86_att/generic/bignum_digit.S
+++ b/x86_att/generic/bignum_digit.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_digit)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_digit)
         .text

--- a/x86_att/generic/bignum_digitsize.S
+++ b/x86_att/generic/bignum_digitsize.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_digitsize)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_digitsize)
         .text

--- a/x86_att/generic/bignum_divmod10.S
+++ b/x86_att/generic/bignum_divmod10.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_divmod10)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_divmod10)
         .text

--- a/x86_att/generic/bignum_emontredc.S
+++ b/x86_att/generic/bignum_emontredc.S
@@ -36,6 +36,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_emontredc)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_emontredc)
         .text

--- a/x86_att/generic/bignum_eq.S
+++ b/x86_att/generic/bignum_eq.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_eq)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_eq)
         .text

--- a/x86_att/generic/bignum_even.S
+++ b/x86_att/generic/bignum_even.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_even)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_even)
         .text

--- a/x86_att/generic/bignum_ge.S
+++ b/x86_att/generic/bignum_ge.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_ge)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_ge)
         .text

--- a/x86_att/generic/bignum_gt.S
+++ b/x86_att/generic/bignum_gt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_gt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_gt)
         .text

--- a/x86_att/generic/bignum_iszero.S
+++ b/x86_att/generic/bignum_iszero.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_iszero)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_iszero)
         .text

--- a/x86_att/generic/bignum_le.S
+++ b/x86_att/generic/bignum_le.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_le)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_le)
         .text

--- a/x86_att/generic/bignum_lt.S
+++ b/x86_att/generic/bignum_lt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_lt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_lt)
         .text

--- a/x86_att/generic/bignum_madd.S
+++ b/x86_att/generic/bignum_madd.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_madd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_madd)
         .text

--- a/x86_att/generic/bignum_modadd.S
+++ b/x86_att/generic/bignum_modadd.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_modadd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_modadd)
         .text

--- a/x86_att/generic/bignum_moddouble.S
+++ b/x86_att/generic/bignum_moddouble.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_moddouble)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_moddouble)
         .text

--- a/x86_att/generic/bignum_modifier.S
+++ b/x86_att/generic/bignum_modifier.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_modifier)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_modifier)
         .text

--- a/x86_att/generic/bignum_modinv.S
+++ b/x86_att/generic/bignum_modinv.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_modinv)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_modinv)
         .text

--- a/x86_att/generic/bignum_modoptneg.S
+++ b/x86_att/generic/bignum_modoptneg.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_modoptneg)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_modoptneg)
         .text

--- a/x86_att/generic/bignum_modsub.S
+++ b/x86_att/generic/bignum_modsub.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_modsub)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_modsub)
         .text

--- a/x86_att/generic/bignum_montifier.S
+++ b/x86_att/generic/bignum_montifier.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montifier)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montifier)
         .text

--- a/x86_att/generic/bignum_montmul.S
+++ b/x86_att/generic/bignum_montmul.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul)
         .text

--- a/x86_att/generic/bignum_montredc.S
+++ b/x86_att/generic/bignum_montredc.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montredc)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montredc)
         .text

--- a/x86_att/generic/bignum_montsqr.S
+++ b/x86_att/generic/bignum_montsqr.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr)
         .text

--- a/x86_att/generic/bignum_mul.S
+++ b/x86_att/generic/bignum_mul.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul)
         .text

--- a/x86_att/generic/bignum_muladd10.S
+++ b/x86_att/generic/bignum_muladd10.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_muladd10)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_muladd10)
         .text

--- a/x86_att/generic/bignum_mux.S
+++ b/x86_att/generic/bignum_mux.S
@@ -28,6 +28,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux)
         .text

--- a/x86_att/generic/bignum_mux16.S
+++ b/x86_att/generic/bignum_mux16.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux16)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux16)
         .text

--- a/x86_att/generic/bignum_negmodinv.S
+++ b/x86_att/generic/bignum_negmodinv.S
@@ -32,6 +32,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_negmodinv)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_negmodinv)
         .text

--- a/x86_att/generic/bignum_nonzero.S
+++ b/x86_att/generic/bignum_nonzero.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero)
         .text

--- a/x86_att/generic/bignum_normalize.S
+++ b/x86_att/generic/bignum_normalize.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_normalize)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_normalize)
         .text

--- a/x86_att/generic/bignum_odd.S
+++ b/x86_att/generic/bignum_odd.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_odd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_odd)
         .text

--- a/x86_att/generic/bignum_of_word.S
+++ b/x86_att/generic/bignum_of_word.S
@@ -28,6 +28,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_of_word)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_of_word)
         .text

--- a/x86_att/generic/bignum_optadd.S
+++ b/x86_att/generic/bignum_optadd.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optadd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optadd)
         .text

--- a/x86_att/generic/bignum_optneg.S
+++ b/x86_att/generic/bignum_optneg.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg)
         .text

--- a/x86_att/generic/bignum_optsub.S
+++ b/x86_att/generic/bignum_optsub.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optsub)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optsub)
         .text

--- a/x86_att/generic/bignum_optsubadd.S
+++ b/x86_att/generic/bignum_optsubadd.S
@@ -36,6 +36,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optsubadd)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optsubadd)
         .text

--- a/x86_att/generic/bignum_pow2.S
+++ b/x86_att/generic/bignum_pow2.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_pow2)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_pow2)
         .text

--- a/x86_att/generic/bignum_shl_small.S
+++ b/x86_att/generic/bignum_shl_small.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_shl_small)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_shl_small)
         .text

--- a/x86_att/generic/bignum_shr_small.S
+++ b/x86_att/generic/bignum_shr_small.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_shr_small)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_shr_small)
         .text

--- a/x86_att/generic/bignum_sqr.S
+++ b/x86_att/generic/bignum_sqr.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr)
         .text

--- a/x86_att/generic/bignum_sub.S
+++ b/x86_att/generic/bignum_sub.S
@@ -31,6 +31,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub)
         .text

--- a/x86_att/generic/word_bytereverse.S
+++ b/x86_att/generic/word_bytereverse.S
@@ -21,7 +21,9 @@
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_bytereverse)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_bytereverse)

--- a/x86_att/generic/word_clz.S
+++ b/x86_att/generic/word_clz.S
@@ -22,7 +22,9 @@
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_clz)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_clz)

--- a/x86_att/generic/word_ctz.S
+++ b/x86_att/generic/word_ctz.S
@@ -22,7 +22,9 @@
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_ctz)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_ctz)

--- a/x86_att/generic/word_max.S
+++ b/x86_att/generic/word_max.S
@@ -22,7 +22,9 @@
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_max)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_max)

--- a/x86_att/generic/word_min.S
+++ b/x86_att/generic/word_min.S
@@ -22,7 +22,9 @@
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_min)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_min)

--- a/x86_att/generic/word_negmodinv.S
+++ b/x86_att/generic/word_negmodinv.S
@@ -27,7 +27,9 @@
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_negmodinv)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_negmodinv)

--- a/x86_att/generic/word_recip.S
+++ b/x86_att/generic/word_recip.S
@@ -27,7 +27,9 @@
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX
 // ----------------------------------------------------------------------------
+
 #include "_internal_s2n_bignum.h"
+
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(word_recip)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(word_recip)

--- a/x86_att/p256/bignum_add_p256.S
+++ b/x86_att/p256/bignum_add_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p256)
         .text

--- a/x86_att/p256/bignum_bigendian_4.S
+++ b/x86_att/p256/bignum_bigendian_4.S
@@ -38,6 +38,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_4)
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_4)

--- a/x86_att/p256/bignum_cmul_p256.S
+++ b/x86_att/p256/bignum_cmul_p256.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p256)
         .text

--- a/x86_att/p256/bignum_cmul_p256_alt.S
+++ b/x86_att/p256/bignum_cmul_p256_alt.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p256_alt)
         .text

--- a/x86_att/p256/bignum_deamont_p256.S
+++ b/x86_att/p256/bignum_deamont_p256.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p256)
         .text

--- a/x86_att/p256/bignum_deamont_p256_alt.S
+++ b/x86_att/p256/bignum_deamont_p256_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p256_alt)
         .text

--- a/x86_att/p256/bignum_demont_p256.S
+++ b/x86_att/p256/bignum_demont_p256.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p256)
         .text

--- a/x86_att/p256/bignum_demont_p256_alt.S
+++ b/x86_att/p256/bignum_demont_p256_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p256_alt)
         .text

--- a/x86_att/p256/bignum_double_p256.S
+++ b/x86_att/p256/bignum_double_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p256)
         .text

--- a/x86_att/p256/bignum_half_p256.S
+++ b/x86_att/p256/bignum_half_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p256)
         .text

--- a/x86_att/p256/bignum_littleendian_4.S
+++ b/x86_att/p256/bignum_littleendian_4.S
@@ -37,6 +37,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_4)
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_4)

--- a/x86_att/p256/bignum_mod_n256.S
+++ b/x86_att/p256/bignum_mod_n256.S
@@ -28,6 +28,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n256)
         .text

--- a/x86_att/p256/bignum_mod_n256_4.S
+++ b/x86_att/p256/bignum_mod_n256_4.S
@@ -28,6 +28,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n256_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n256_4)
         .text

--- a/x86_att/p256/bignum_mod_n256_alt.S
+++ b/x86_att/p256/bignum_mod_n256_alt.S
@@ -28,6 +28,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n256_alt)
         .text

--- a/x86_att/p256/bignum_mod_p256.S
+++ b/x86_att/p256/bignum_mod_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p256)
         .text

--- a/x86_att/p256/bignum_mod_p256_4.S
+++ b/x86_att/p256/bignum_mod_p256_4.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p256_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p256_4)
         .text

--- a/x86_att/p256/bignum_mod_p256_alt.S
+++ b/x86_att/p256/bignum_mod_p256_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p256_alt)
         .text

--- a/x86_att/p256/bignum_montmul_p256.S
+++ b/x86_att/p256/bignum_montmul_p256.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p256)
         .text

--- a/x86_att/p256/bignum_montmul_p256_alt.S
+++ b/x86_att/p256/bignum_montmul_p256_alt.S
@@ -30,6 +30,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p256_alt)
         .text

--- a/x86_att/p256/bignum_montsqr_p256.S
+++ b/x86_att/p256/bignum_montsqr_p256.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p256)
         .text

--- a/x86_att/p256/bignum_montsqr_p256_alt.S
+++ b/x86_att/p256/bignum_montsqr_p256_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p256_alt)
         .text

--- a/x86_att/p256/bignum_mux_4.S
+++ b/x86_att/p256/bignum_mux_4.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_4)
         .text

--- a/x86_att/p256/bignum_neg_p256.S
+++ b/x86_att/p256/bignum_neg_p256.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p256)
         .text

--- a/x86_att/p256/bignum_nonzero_4.S
+++ b/x86_att/p256/bignum_nonzero_4.S
@@ -25,6 +25,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_4)
         .text

--- a/x86_att/p256/bignum_optneg_p256.S
+++ b/x86_att/p256/bignum_optneg_p256.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p256)
         .text

--- a/x86_att/p256/bignum_sub_p256.S
+++ b/x86_att/p256/bignum_sub_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p256)
         .text

--- a/x86_att/p256/bignum_tomont_p256.S
+++ b/x86_att/p256/bignum_tomont_p256.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p256)
         .text

--- a/x86_att/p256/bignum_tomont_p256_alt.S
+++ b/x86_att/p256/bignum_tomont_p256_alt.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p256_alt)
         .text

--- a/x86_att/p256/bignum_triple_p256.S
+++ b/x86_att/p256/bignum_triple_p256.S
@@ -31,6 +31,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p256)
+        .text
 
 #define z %rdi
 #define x %rsi

--- a/x86_att/p256/bignum_triple_p256.S
+++ b/x86_att/p256/bignum_triple_p256.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p256)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p256)
         .text

--- a/x86_att/p256/bignum_triple_p256_alt.S
+++ b/x86_att/p256/bignum_triple_p256_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p256_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p256_alt)
         .text

--- a/x86_att/p384/bignum_add_p384.S
+++ b/x86_att/p384/bignum_add_p384.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
         .text

--- a/x86_att/p384/bignum_add_p384.S
+++ b/x86_att/p384/bignum_add_p384.S
@@ -28,6 +28,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p384)
+        .text
 
 #define z %rdi
 #define x %rsi

--- a/x86_att/p384/bignum_bigendian_6.S
+++ b/x86_att/p384/bignum_bigendian_6.S
@@ -38,6 +38,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_bigendian_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_bigendian_6)
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_frombebytes_6)

--- a/x86_att/p384/bignum_cmul_p384.S
+++ b/x86_att/p384/bignum_cmul_p384.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384)
         .text

--- a/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/x86_att/p384/bignum_cmul_p384_alt.S
@@ -27,6 +27,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
         .text

--- a/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/x86_att/p384/bignum_cmul_p384_alt.S
@@ -29,6 +29,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p384_alt)
+        .text
 
 #define z %rdi
 

--- a/x86_att/p384/bignum_deamont_p384.S
+++ b/x86_att/p384/bignum_deamont_p384.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
         .text

--- a/x86_att/p384/bignum_deamont_p384.S
+++ b/x86_att/p384/bignum_deamont_p384.S
@@ -31,6 +31,8 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384)
+        .text
+
 #define z %rdi
 #define x %rsi
 

--- a/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/x86_att/p384/bignum_deamont_p384_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
         .text

--- a/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/x86_att/p384/bignum_deamont_p384_alt.S
@@ -31,6 +31,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p384_alt)
+        .text
 
 #define z %rdi
 #define x %rsi

--- a/x86_att/p384/bignum_demont_p384.S
+++ b/x86_att/p384/bignum_demont_p384.S
@@ -31,6 +31,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
+        .text
 
 #define z %rdi
 #define x %rsi

--- a/x86_att/p384/bignum_demont_p384.S
+++ b/x86_att/p384/bignum_demont_p384.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384)
         .text

--- a/x86_att/p384/bignum_demont_p384_alt.S
+++ b/x86_att/p384/bignum_demont_p384_alt.S
@@ -29,6 +29,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
         .text

--- a/x86_att/p384/bignum_demont_p384_alt.S
+++ b/x86_att/p384/bignum_demont_p384_alt.S
@@ -31,6 +31,7 @@
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p384_alt)
+        .text
 
 #define z %rdi
 #define x %rsi

--- a/x86_att/p384/bignum_double_p384.S
+++ b/x86_att/p384/bignum_double_p384.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p384)
         .text

--- a/x86_att/p384/bignum_half_p384.S
+++ b/x86_att/p384/bignum_half_p384.S
@@ -26,6 +26,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p384)
         .text

--- a/x86_att/p384/bignum_littleendian_6.S
+++ b/x86_att/p384/bignum_littleendian_6.S
@@ -37,6 +37,7 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_littleendian_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_littleendian_6)
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_6)

--- a/x86_att/p384/bignum_mod_n384.S
+++ b/x86_att/p384/bignum_mod_n384.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mod_n384_6.S
+++ b/x86_att/p384/bignum_mod_n384_6.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_6)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mod_n384_alt.S
+++ b/x86_att/p384/bignum_mod_n384_alt.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mod_p384.S
+++ b/x86_att/p384/bignum_mod_p384.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mod_p384_6.S
+++ b/x86_att/p384/bignum_mod_p384_6.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_6)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mod_p384_alt.S
+++ b/x86_att/p384/bignum_mod_p384_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_montmul_p384.S
+++ b/x86_att/p384/bignum_montmul_p384.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/x86_att/p384/bignum_montmul_p384_alt.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_montsqr_p384.S
+++ b/x86_att/p384/bignum_montsqr_p384.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_mux_6.S
+++ b/x86_att/p384/bignum_mux_6.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mux_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mux_6)
-
         .text
 
 #define p %rdi

--- a/x86_att/p384/bignum_neg_p384.S
+++ b/x86_att/p384/bignum_neg_p384.S
@@ -25,9 +25,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_nonzero_6.S
+++ b/x86_att/p384/bignum_nonzero_6.S
@@ -25,9 +25,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_nonzero_6)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_nonzero_6)
-
         .text
 
 #define x %rdi

--- a/x86_att/p384/bignum_optneg_p384.S
+++ b/x86_att/p384/bignum_optneg_p384.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_sub_p384.S
+++ b/x86_att/p384/bignum_sub_p384.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_tomont_p384.S
+++ b/x86_att/p384/bignum_tomont_p384.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/x86_att/p384/bignum_tomont_p384_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_triple_p384.S
+++ b/x86_att/p384/bignum_triple_p384.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384)
-
         .text
 
 #define z %rdi

--- a/x86_att/p384/bignum_triple_p384_alt.S
+++ b/x86_att/p384/bignum_triple_p384_alt.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p384_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p384_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_add_p521.S
+++ b/x86_att/p521/bignum_add_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_cmul_p521.S
+++ b/x86_att/p521/bignum_cmul_p521.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/x86_att/p521/bignum_cmul_p521_alt.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p521_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_deamont_p521.S
+++ b/x86_att/p521/bignum_deamont_p521.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_demont_p521.S
+++ b/x86_att/p521/bignum_demont_p521.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_double_p521.S
+++ b/x86_att/p521/bignum_double_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/x86_att/p521/bignum_fromlebytes_p521.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_fromlebytes_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_fromlebytes_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_half_p521.S
+++ b/x86_att/p521/bignum_half_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_mod_n521_9.S
+++ b/x86_att/p521/bignum_mod_n521_9.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n521_9_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n521_9_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_mod_p521_9.S
+++ b/x86_att/p521/bignum_mod_p521_9.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p521_9)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p521_9)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_montmul_p521.S
+++ b/x86_att/p521/bignum_montmul_p521.S
@@ -31,9 +31,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/x86_att/p521/bignum_montmul_p521_alt.S
@@ -31,9 +31,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p521_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_montsqr_p521.S
+++ b/x86_att/p521/bignum_montsqr_p521.S
@@ -31,9 +31,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -31,9 +31,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p521_alt)
-
         .text
 
 // Input arguments

--- a/x86_att/p521/bignum_mul_p521.S
+++ b/x86_att/p521/bignum_mul_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_mul_p521_alt.S
+++ b/x86_att/p521/bignum_mul_p521_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p521_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_neg_p521.S
+++ b/x86_att/p521/bignum_neg_p521.S
@@ -25,9 +25,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_optneg_p521.S
+++ b/x86_att/p521/bignum_optneg_p521.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_sqr_p521.S
+++ b/x86_att/p521/bignum_sqr_p521.S
@@ -25,9 +25,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/x86_att/p521/bignum_sqr_p521_alt.S
@@ -25,9 +25,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p521_alt)
-
         .text
 
 // Input arguments

--- a/x86_att/p521/bignum_sub_p521.S
+++ b/x86_att/p521/bignum_sub_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_tolebytes_p521.S
+++ b/x86_att/p521/bignum_tolebytes_p521.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tolebytes_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tolebytes_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_tomont_p521.S
+++ b/x86_att/p521/bignum_tomont_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_triple_p521.S
+++ b/x86_att/p521/bignum_triple_p521.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521)
-
         .text
 
 #define z %rdi

--- a/x86_att/p521/bignum_triple_p521_alt.S
+++ b/x86_att/p521/bignum_triple_p521_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p521_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p521_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_add_p256k1.S
+++ b/x86_att/secp256k1/bignum_add_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_add_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_add_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_cmul_p256k1.S
+++ b/x86_att/secp256k1/bignum_cmul_p256k1.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_cmul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_cmul_p256k1_alt.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_cmul_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_cmul_p256k1_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_deamont_p256k1.S
+++ b/x86_att/secp256k1/bignum_deamont_p256k1.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_deamont_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_deamont_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_demont_p256k1.S
+++ b/x86_att/secp256k1/bignum_demont_p256k1.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_demont_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_demont_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_double_p256k1.S
+++ b/x86_att/secp256k1/bignum_double_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_double_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_double_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_half_p256k1.S
+++ b/x86_att/secp256k1/bignum_half_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_half_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_half_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_mod_n256k1_4.S
+++ b/x86_att/secp256k1/bignum_mod_n256k1_4.S
@@ -28,9 +28,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_n256k1_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_n256k1_4)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_mod_p256k1_4.S
+++ b/x86_att/secp256k1/bignum_mod_p256k1_4.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mod_p256k1_4)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mod_p256k1_4)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_montmul_p256k1.S
+++ b/x86_att/secp256k1/bignum_montmul_p256k1.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p256k1)
-
         .text
 
 // These are actually right

--- a/x86_att/secp256k1/bignum_montmul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_montmul_p256k1_alt.S
@@ -30,9 +30,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montmul_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montmul_p256k1_alt)
-
         .text
 
 // These are actually right

--- a/x86_att/secp256k1/bignum_montsqr_p256k1.S
+++ b/x86_att/secp256k1/bignum_montsqr_p256k1.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_montsqr_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_montsqr_p256k1_alt.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_montsqr_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_montsqr_p256k1_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_mul_p256k1.S
+++ b/x86_att/secp256k1/bignum_mul_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p256k1)
-
         .text
 
 // These are actually right

--- a/x86_att/secp256k1/bignum_mul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_mul_p256k1_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_mul_p256k1_alt)
-
         .text
 
 // These are actually right

--- a/x86_att/secp256k1/bignum_neg_p256k1.S
+++ b/x86_att/secp256k1/bignum_neg_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_neg_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_neg_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_optneg_p256k1.S
+++ b/x86_att/secp256k1/bignum_optneg_p256k1.S
@@ -27,9 +27,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_optneg_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_optneg_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_sqr_p256k1.S
+++ b/x86_att/secp256k1/bignum_sqr_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_sqr_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_sqr_p256k1_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sqr_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sqr_p256k1_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_sub_p256k1.S
+++ b/x86_att/secp256k1/bignum_sub_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_sub_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_sub_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_tomont_p256k1.S
+++ b/x86_att/secp256k1/bignum_tomont_p256k1.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_tomont_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_tomont_p256k1_alt.S
@@ -26,9 +26,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_tomont_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_tomont_p256k1_alt)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_triple_p256k1.S
+++ b/x86_att/secp256k1/bignum_triple_p256k1.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p256k1)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p256k1)
-
         .text
 
 #define z %rdi

--- a/x86_att/secp256k1/bignum_triple_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_triple_p256k1_alt.S
@@ -29,9 +29,9 @@
 
 #include "_internal_s2n_bignum.h"
 
+
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_triple_p256k1_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_triple_p256k1_alt)
-
         .text
 
 #define z %rdi


### PR DESCRIPTION
*Description of changes:*
I found that I had accidentally removed a few `.text` directives on a previous PR. This should restore them.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
