### PR TITLE
Formalize UMOV of ARMv8

### DIFF
--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -986,6 +986,12 @@ let arm_UBFM = define
           else word_shl (word_subword x (0,imms+1)) (dimindex(:N) - immr) in
         (Rd := y) s`;;
 
+let arm_UMOV = define
+ `arm_UMOV Rd Rn idx size =
+   \s. let n = read Rn (s:armstate) in
+       let d:N word = word_subword n (idx*size*8,size*8) in
+       (Rd := d) s`;;
+
 let arm_UMULH = define
  `arm_UMULH Rd Rn Rm =
     \s. let n:N word = read Rn (s:armstate)
@@ -1447,7 +1453,7 @@ let ARM_OPERATION_CLAUSES =
        arm_LSL; arm_LSLV; arm_LSR; arm_LSRV;
        arm_MADD; arm_MOVK_ALT; arm_MOVN; arm_MOVZ;
        arm_MSUB; arm_ORN; arm_ORR; arm_RET; arm_RORV; arm_SBC; arm_SBCS_ALT;
-       arm_SUB; arm_SUBS_ALT; arm_UBFM; arm_UMULH;
+       arm_SUB; arm_SUBS_ALT; arm_UBFM; arm_UMOV; arm_UMULH;
     (*** 32-bit backups since the ALT forms are 64-bit only ***)
        INST_TYPE[`:32`,`:N`] arm_ADCS;
        INST_TYPE[`:32`,`:N`] arm_ADDS;


### PR DESCRIPTION
This PR formalizes [UMOV](https://developer.arm.com/documentation/ddi0596/2021-12/SIMD-FP-Instructions/UMOV--Unsigned-Move-vector-element-to-general-purpose-register-?lang=en) which is an alias of `mov` from an element of a NEON register to a general register:
```
mov <Rd>, <Rn>.<Ts>[<index>] (* aliases umov *)
```

Currently this PR supports `<Ts>` = `d` and `s`, but not `B` or `H` because they are not used in the vectorization pattern yet. Also it seems to add a slight complexity to the definition.
Also, this PR does not add `umov` as an alias of `mov` since `mov` was already (correctly) registered as an alias of `orr <reg>, zero`.

I tested the updated `decode` by running these two examples and checking the output:
```
(* mov x0, v0.d[1] , 4E183C00 *)
# let exp = `decode (word 0x4E183C00)` in DECODE_CONV exp;;
val it : thm = |- decode (word 1310211072) = SOME (arm_UMOV X0 Q0 1 8) 

(* mov w1, v2.s[3] , 0E1C3C41 *)
# let exp = `decode (word 0x0E1C3C41)` in DECODE_CONV exp;;
val it : thm = |- decode (word 236731457) = SOME (arm_UMOV W1 Q2 3 4)
```

I couldn't test the implemented semantics of umov which is `arm_UMOV` however. Before running random testing, I would like to write some simple unit tests that is analogous to the ones using `DECODE_CONV`. How can I write ones?