### PR TITLE
Formalize MUL and SHL with vector operands in ARMv8

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -200,6 +200,28 @@ let decode = new_definition `!w:int32. decode w =
   | [x; 0b01010010:8; ld; imm7:7; Rt2:5; Rn:5; Rt:5] ->
     SOME (arm_ldstp ld x Rt Rt2 (XREG_SP Rn)
       (Immediate_Offset (iword (ival imm7 * &(if x then 8 else 4)))))
+
+  // SIMD operations
+  | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b100111:6; Rn:5; Rd:5] ->
+    if size = word 0b11 then NONE // "UNDEFINED"
+    else if ~q then NONE // datasize = 64 is unsupported yet
+    else
+      let esize:(64)word = word_shl (word 8: (64)word) (val size) in
+      let datasize:(64)word = word 128 in
+      let elements:(64)word = word_udiv datasize esize in
+      SOME (arm_MUL_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
+  | [0:1; q; 0b0011110:7; immh:4; immb:3; 0b010101:6; Rn:5; Rd:5] ->
+    if immh = (word 0b0: (4)word) then NONE // "asimdimm case"
+    else if bit 3 immh /\ ~q then NONE // "UNDEFINED"
+    else if ~q then NONE // datasize = 64 is unsupported yet
+    else
+      let esize:(64)word = word_shl (word 0b1000: (64)word) (3 - word_clz immh) in
+      let datasize:(64)word = word 128 in
+      let elements:(64)word = word_udiv datasize esize in
+      let shiftamnt:(64)word = word_sub (word_join immh immb:64 word) esize in
+      SOME (arm_SHL_VEC (QREG' Rd) (QREG' Rn) (val shiftamnt) (val esize))
+
   | [0:1; q; 0b001110000:9; imm5:5; 0b001111:6; Rn:5; Rd:5] ->
     if q /\ word_subword imm5 (0,4) = (word 0b1000: 4 word) then // v.d
       SOME (arm_UMOV (XREG' Rd) (QREG' Rn) (val (word_subword imm5 (4,1): 1 word)) 8)
@@ -622,16 +644,25 @@ let PURE_DECODE_CONV =
   | Comb(Comb(Const("arm_ldstb",_),_),_) -> eval_nary pth_ldstrb t F
   | Comb(Comb(Comb(Comb(Const("arm_ldstp",_),_),_),_),_) ->
     eval_nary pth_ldstp t F
+  | Comb(Comb((Const("bit",_) as f),a),b) ->
+    eval_binary f a b F WORD_RED_CONV
   | Comb((Const("Condition",_) as f),a) -> eval_unary f a F CONDITION_CONV
   | Comb((Const("decode_shift",_) as f),a) -> eval_unary f a F DECODE_SHIFT_CONV
   | Comb(Comb(Comb(Const("decode_bitmask",_),_),_),_) ->
     eval_opt t F DECODE_BITMASK_CONV
+  | Comb((Const("word_clz",_) as f),a) -> eval_unary f a F WORD_RED_CONV
   | Comb((Const("word_zx",_) as f),a) -> eval_unary f a F WORD_ZX_CONV
   | Comb((Const("word_sx",_) as f),a) -> eval_unary f a F IWORD_SX_CONV
   | Comb((Const("word_not",_) as f),a) -> eval_unary f a F WORD_RED_CONV
   | Comb(Comb((Const("word_join",_) as f),a),b) ->
     eval_binary f a b F WORD_RED_CONV
+  | Comb(Comb((Const("word_shl",_) as f),a),b) ->
+    eval_binary f a b F WORD_RED_CONV
+  | Comb(Comb((Const("word_sub",_) as f),a),b) ->
+    eval_binary f a b F WORD_RED_CONV
   | Comb(Comb((Const("word_subword",_) as f),a),b) ->
+    eval_binary f a b F WORD_RED_CONV
+  | Comb(Comb((Const("word_udiv",_) as f),a),b) ->
     eval_binary f a b F WORD_RED_CONV
   | Comb(Const("@",_),_) -> raise (Invalid_argument "ARB")
   | Const("ARB",_) -> raise (Invalid_argument "ARB")

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -207,8 +207,7 @@ let decode = new_definition `!w:int32. decode w =
     else if ~q then NONE // datasize = 64 is unsupported yet
     else
       let esize:(64)word = word_shl (word 8: (64)word) (val size) in
-      let datasize:(64)word = word 128 in
-      let elements:(64)word = word_udiv datasize esize in
+      // datasize is fixed to 128. elements is datasize / esize.
       SOME (arm_MUL_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
 
   | [0:1; q; 0b0011110:7; immh:4; immb:3; 0b010101:6; Rn:5; Rd:5] ->
@@ -217,8 +216,7 @@ let decode = new_definition `!w:int32. decode w =
     else if ~q then NONE // datasize = 64 is unsupported yet
     else
       let esize:(64)word = word_shl (word 0b1000: (64)word) (3 - word_clz immh) in
-      let datasize:(64)word = word 128 in
-      let elements:(64)word = word_udiv datasize esize in
+      // datasize is fixed to 128. elements is datasize / esize.
       let shiftamnt:(64)word = word_sub (word_join immh immb:64 word) esize in
       SOME (arm_SHL_VEC (QREG' Rd) (QREG' Rn) (val shiftamnt) (val esize))
 
@@ -661,8 +659,6 @@ let PURE_DECODE_CONV =
   | Comb(Comb((Const("word_sub",_) as f),a),b) ->
     eval_binary f a b F WORD_RED_CONV
   | Comb(Comb((Const("word_subword",_) as f),a),b) ->
-    eval_binary f a b F WORD_RED_CONV
-  | Comb(Comb((Const("word_udiv",_) as f),a),b) ->
     eval_binary f a b F WORD_RED_CONV
   | Comb(Const("@",_),_) -> raise (Invalid_argument "ARB")
   | Const("ARB",_) -> raise (Invalid_argument "ARB")


### PR DESCRIPTION
This PR formalizes [MUL](https://developer.arm.com/documentation/ddi0596/2021-09/SIMD-FP-Instructions/MUL--vector---Multiply--vector--) and [SHL](
https://developer.arm.com/documentation/ddi0596/2021-09/SIMD-FP-Instructions/SHL--Shift-Left--immediate--?lang=en) with vector operands in ARMv8.

Examples:
```
shl v0.2d, v1.2d, #32 // 0x4F605420
shl v0.4s, v1.4s, #3 // 0x4F235420

mul v5.4s, v6.4s, v7.4s // 0x4EA79CC5
mul v8.8h, v9.8h, v10.8h // 0x4E6A9D28
mul v11.16b, v12.16b, v13.16b // 0x4E2D9D8B
```

64-bit versions of the vector instructions (`Q` = 0 in the decoding phase) are not encoded since it is not used yet.

To unfold the definition of `simdN` and `usimdN`, `_ALT` variants are added as well.

An attached [litmus_test.zip](https://github.com/awslabs/s2n-bignum/files/10395999/litmus_test.zip) contains `litmus_test.ml` that shows decoding and `ARM_VSTEPS_TAC` runs expectedly.
