### PR TITLE
Switch to clean 8-bit array type in signature for high-level curve25519 algorithm APIs

### DIFF
--- a/arm/curve25519/curve25519_ladderstep.S
+++ b/arm/curve25519/curve25519_ladderstep.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/arm/curve25519/curve25519_ladderstep_alt.S
+++ b/arm/curve25519/curve25519_ladderstep_alt.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep_alt
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/arm/curve25519/curve25519_pxscalarmul.S
+++ b/arm/curve25519/curve25519_pxscalarmul.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/arm/curve25519/curve25519_pxscalarmul_alt.S
+++ b/arm/curve25519/curve25519_pxscalarmul_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/arm/curve25519/curve25519_x25519.S
+++ b/arm/curve25519/curve25519_x25519.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519_alt.S
+++ b/arm/curve25519/curve25519_x25519_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519base.S
+++ b/arm/curve25519/curve25519_x25519base.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/curve25519_x25519base_alt.S
+++ b/arm/curve25519/curve25519_x25519base_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/edwards25519_epadd.S
+++ b/arm/curve25519/edwards25519_epadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/arm/curve25519/edwards25519_epadd_alt.S
+++ b/arm/curve25519/edwards25519_epadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/arm/curve25519/edwards25519_epdouble.S
+++ b/arm/curve25519/edwards25519_epdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
 // extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/arm/curve25519/edwards25519_epdouble_alt.S
+++ b/arm/curve25519/edwards25519_epdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
-// extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+// extern void edwards25519_epdouble_alt
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/arm/curve25519/edwards25519_pdouble.S
+++ b/arm/curve25519/edwards25519_pdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
 // extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/arm/curve25519/edwards25519_pdouble_alt.S
+++ b/arm/curve25519/edwards25519_pdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
-// extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+// extern void edwards25519_pdouble_alt
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/arm/curve25519/edwards25519_pepadd.S
+++ b/arm/curve25519/edwards25519_pepadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/arm/curve25519/edwards25519_pepadd_alt.S
+++ b/arm/curve25519/edwards25519_pepadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -803,43 +803,43 @@ extern void bignum_triple_sm2_alt (uint64_t z[static 4], uint64_t x[static 4]);
 
 // Montgomery ladder step for curve25519
 // Inputs point[8], pp[16], b; output rr[16]
-extern void curve25519_ladderstep(uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b);
-extern void curve25519_ladderstep_alt(uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b);
+extern void curve25519_ladderstep(uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
+extern void curve25519_ladderstep_alt(uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 
 // Projective scalar multiplication, x coordinate only, for curve25519
 // Inputs scalar[4], point[4]; output res[8]
-extern void curve25519_pxscalarmul(uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4]);
-extern void curve25519_pxscalarmul_alt(uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4]);
+extern void curve25519_pxscalarmul(uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
+extern void curve25519_pxscalarmul_alt(uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 
 // x25519 function for curve25519
 // Inputs scalar[4], point[4]; output res[4]
-extern void curve25519_x25519(uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4]);
-extern void curve25519_x25519_alt(uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4]);
+extern void curve25519_x25519(uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
+extern void curve25519_x25519_alt(uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 
 // x25519 function for curve25519 on base element 9
 // Input scalar[4]; output res[4]
-extern void curve25519_x25519base(uint64_t res[static 4],uint64_t scalar[static 4]);
-extern void curve25519_x25519base_alt(uint64_t res[static 4],uint64_t scalar[static 4]);
+extern void curve25519_x25519base(uint8_t res[static 32],uint8_t scalar[static 32]);
+extern void curve25519_x25519base_alt(uint8_t res[static 32],uint8_t scalar[static 32]);
 
 // Extended projective addition for edwards25519
 // Inputs p1[16], p2[16]; output p3[16]
-extern void edwards25519_epadd(uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16]);
-extern void edwards25519_epadd_alt(uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16]);
+extern void edwards25519_epadd(uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
+extern void edwards25519_epadd_alt(uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 
 // Extended projective doubling for edwards25519
 // Inputs p1[12]; output p3[16]
-extern void edwards25519_epdouble(uint64_t p3[static 16],uint64_t p1[static 12]);
-extern void edwards25519_epdouble_alt(uint64_t p3[static 16],uint64_t p1[static 12]);
+extern void edwards25519_epdouble(uint8_t p3[static 128],uint8_t p1[static 96]);
+extern void edwards25519_epdouble_alt(uint8_t p3[static 128],uint8_t p1[static 96]);
 
 // Projective doubling for edwards25519
 // Inputs p1[12]; output p3[12]
-extern void edwards25519_pdouble(uint64_t p3[static 12],uint64_t p1[static 12]);
-extern void edwards25519_pdouble_alt(uint64_t p3[static 12],uint64_t p1[static 12]);
+extern void edwards25519_pdouble(uint8_t p3[static 96],uint8_t p1[static 96]);
+extern void edwards25519_pdouble_alt(uint8_t p3[static 96],uint8_t p1[static 96]);
 
 // Extended projective + precomputed mixed addition for edwards25519
 // Inputs p1[16], p2[12]; output p3[16]
-extern void edwards25519_pepadd(uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12]);
-extern void edwards25519_pepadd_alt(uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12]);
+extern void edwards25519_pepadd(uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
+extern void edwards25519_pepadd_alt(uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 // Inputs p1[12], p2[12]; output p3[12]

--- a/x86/curve25519/curve25519_ladderstep.S
+++ b/x86/curve25519/curve25519_ladderstep.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86/curve25519/curve25519_ladderstep_alt.S
+++ b/x86/curve25519/curve25519_ladderstep_alt.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep_alt
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86/curve25519/curve25519_pxscalarmul.S
+++ b/x86/curve25519/curve25519_pxscalarmul.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86/curve25519/curve25519_pxscalarmul_alt.S
+++ b/x86/curve25519/curve25519_pxscalarmul_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86/curve25519/curve25519_x25519.S
+++ b/x86/curve25519/curve25519_x25519.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86/curve25519/curve25519_x25519_alt.S
+++ b/x86/curve25519/curve25519_x25519_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86/curve25519/curve25519_x25519base.S
+++ b/x86/curve25519/curve25519_x25519base.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86/curve25519/curve25519_x25519base_alt.S
+++ b/x86/curve25519/curve25519_x25519base_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86/curve25519/edwards25519_epadd.S
+++ b/x86/curve25519/edwards25519_epadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86/curve25519/edwards25519_epadd_alt.S
+++ b/x86/curve25519/edwards25519_epadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86/curve25519/edwards25519_epdouble.S
+++ b/x86/curve25519/edwards25519_epdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
 // extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86/curve25519/edwards25519_epdouble_alt.S
+++ b/x86/curve25519/edwards25519_epdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
-// extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+// extern void edwards25519_epdouble_alt
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86/curve25519/edwards25519_pdouble.S
+++ b/x86/curve25519/edwards25519_pdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
 // extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86/curve25519/edwards25519_pdouble_alt.S
+++ b/x86/curve25519/edwards25519_pdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
-// extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+// extern void edwards25519_pdouble_alt
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86/curve25519/edwards25519_pepadd.S
+++ b/x86/curve25519/edwards25519_pepadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/x86/curve25519/edwards25519_pepadd_alt.S
+++ b/x86/curve25519/edwards25519_pepadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/x86_att/curve25519/curve25519_ladderstep.S
+++ b/x86_att/curve25519/curve25519_ladderstep.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86_att/curve25519/curve25519_ladderstep_alt.S
+++ b/x86_att/curve25519/curve25519_ladderstep_alt.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep_alt
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint8_t rr[128],uint8_t point[64],uint8_t pp[128],uint8_t b[8]);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86_att/curve25519/curve25519_pxscalarmul.S
+++ b/x86_att/curve25519/curve25519_pxscalarmul.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86_att/curve25519/curve25519_pxscalarmul_alt.S
+++ b/x86_att/curve25519/curve25519_pxscalarmul_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective scalar multiplication, x coordinate only, for curve25519
-// Inputs scalar[4], point[4]; output res[8]
+// Inputs scalar[32], point[32]; output res[64]
 //
 // extern void curve25519_pxscalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 64],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86_att/curve25519/curve25519_x25519.S
+++ b/x86_att/curve25519/curve25519_x25519.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86_att/curve25519/curve25519_x25519_alt.S
+++ b/x86_att/curve25519/curve25519_x25519_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519
-// Inputs scalar[4], point[4]; output res[4]
+// Inputs scalar[32], point[32]; output res[32]
 //
 // extern void curve25519_x25519_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86_att/curve25519/curve25519_x25519base.S
+++ b/x86_att/curve25519/curve25519_x25519base.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86_att/curve25519/curve25519_x25519base_alt.S
+++ b/x86_att/curve25519/curve25519_x25519base_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // The x25519 function for curve25519 on base element 9
-// Input scalar[4]; output res[4]
+// Input scalar[32]; output res[32]
 //
 // extern void curve25519_x25519base_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint8_t res[static 32],uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86_att/curve25519/edwards25519_epadd.S
+++ b/x86_att/curve25519/edwards25519_epadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86_att/curve25519/edwards25519_epadd_alt.S
+++ b/x86_att/curve25519/edwards25519_epadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective addition for edwards25519
-// Inputs p1[16], p2[16]; output p3[16]
+// Inputs p1[128], p2[128]; output p3[128]
 //
 // extern void edwards25519_epadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 128]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86_att/curve25519/edwards25519_epdouble.S
+++ b/x86_att/curve25519/edwards25519_epdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
 // extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86_att/curve25519/edwards25519_epdouble_alt.S
+++ b/x86_att/curve25519/edwards25519_epdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective doubling for edwards25519
-// Input p1[12]; output p3[16]
+// Input p1[96]; output p3[128]
 //
-// extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+// extern void edwards25519_epdouble_alt
+//   (uint8_t p3[static 128],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86_att/curve25519/edwards25519_pdouble.S
+++ b/x86_att/curve25519/edwards25519_pdouble.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
 // extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86_att/curve25519/edwards25519_pdouble_alt.S
+++ b/x86_att/curve25519/edwards25519_pdouble_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Projective doubling for edwards25519
-// Input p1[12]; output p3[12]
+// Input p1[96]; output p3[96]
 //
-// extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+// extern void edwards25519_pdouble_alt
+//   (uint8_t p3[static 96],uint8_t p1[static 96]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86_att/curve25519/edwards25519_pepadd.S
+++ b/x86_att/curve25519/edwards25519_pepadd.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/x86_att/curve25519/edwards25519_pepadd_alt.S
+++ b/x86_att/curve25519/edwards25519_pepadd_alt.S
@@ -3,10 +3,10 @@
 
 // ----------------------------------------------------------------------------
 // Extended projective + precomputed mixed addition for edwards25519
-// Inputs p1[16], p2[12]; output p3[16]
+// Inputs p1[128], p2[96]; output p3[128]
 //
 // extern void edwards25519_pepadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint8_t p3[static 128],uint8_t p1[static 128],uint8_t p2[static 96]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where


### PR DESCRIPTION
**Issue #, if available:**

CryptoAlg-1601

**Description of changes:**

Switch API to use `uint8_t []` array type instead of `uint64_t []` array type. This is what applications typically operate with (in particular, AWS-LC).

It avoids a lot of copying around in AWS-LC which would otherwise add overhead. The copying is necessary because we can't cast array types, and interfaces are strictly checked in AWS-LC (even though it might just be decoration).

There are still a lot of interfaces to change, if we want to align everything to `uint8_t`!

The unit tests now throws interface type warnings. But maybe these can be solved in subsequent PRs. It would requires quite a few changes in `test.c`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
