### PR TITLE
Add `[ARM|X86]_GEN_ACCSTEP{S}_TAC`

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -442,9 +442,15 @@ let ARM_XACCSTEP_TAC th excs aflag s =
   (if aflag then TRY(ACCUMULATEX_ARITH_TAC excs s THEN CLARIFY_TAC)
    else ALL_TAC);;
 
-let ARM_ACCSTEP_TAC th aflag s =
+(* ARM_GEN_ACCSTEP_TAC runs acc_preproc before ACCUMULATE_ARITH_TAC. This is
+   useful when the output goal of ARM_SINGLE_STEP_TAC needs additional rewrites
+   for accumulator to recognize it. *)
+let ARM_GEN_ACCSTEP_TAC acc_preproc th aflag s =
   ARM_SINGLE_STEP_TAC th s THEN
-  (if aflag then TRY(ACCUMULATE_ARITH_TAC s THEN CLARIFY_TAC) else ALL_TAC);;
+  (if aflag then acc_preproc THEN TRY(ACCUMULATE_ARITH_TAC s THEN CLARIFY_TAC)
+   else ALL_TAC);;
+
+let ARM_ACCSTEP_TAC th aflag s = ARM_GEN_ACCSTEP_TAC ALL_TAC th aflag s;;
 
 let ARM_VSTEPS_TAC th snums =
   MAP_EVERY (ARM_VERBOSE_STEP_TAC th) (statenames "s" snums);;
@@ -461,9 +467,17 @@ let ARM_XACCSTEPS_TAC th excs anums snums =
    (fun n -> ARM_XACCSTEP_TAC th excs (mem n anums) ("s"^string_of_int n))
    snums;;
 
+(* ARM_GEN_ACCSTEPS_TAC runs acc_preproc before ACCUMULATE_ARITH_TAC.
+   acc_preproc is a function from string (which is a state name) to tactic. *)
+let ARM_GEN_ACCSTEPS_TAC acc_preproc th anums snums =
+  MAP_EVERY
+    (fun n ->
+      let state_name = "s"^string_of_int n in
+      ARM_GEN_ACCSTEP_TAC (acc_preproc state_name) th (mem n anums) state_name)
+    snums;;
+
 let ARM_ACCSTEPS_TAC th anums snums =
-  MAP_EVERY (fun n -> ARM_ACCSTEP_TAC th (mem n anums) ("s"^string_of_int n))
-            snums;;
+  ARM_GEN_ACCSTEPS_TAC (fun _ -> ALL_TAC) th anums snums;;
 
 (* ------------------------------------------------------------------------- *)
 (* More convenient wrappings of basic simulation flow.                       *)

--- a/x86/proofs/bignum_montmul_p256_alt.ml
+++ b/x86/proofs/bignum_montmul_p256_alt.ml
@@ -237,12 +237,10 @@ let BIGNUM_MONTMUL_P256_ALT_CORRECT = time prove
 
   (*** Simulate the core pre-reduced result accumulation ***)
 
-  MAP_EVERY (fun n ->
-    X86_STEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC [n] THEN
-    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
-     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
-    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
-   (1--149) THEN
+  X86_GEN_ACCSTEPS_TAC
+    (fun _ -> RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+                `word_sub x (word_neg y):int64 = word_add x y`]))
+    BIGNUM_MONTMUL_P256_ALT_EXEC (1--149) (1--149) THEN
   ABBREV_TAC
    `t = bignum_of_wordlist
           [sum_s133; sum_s141; sum_s147; sum_s148; sum_s149]` THEN
@@ -363,12 +361,10 @@ let BIGNUM_AMONTMUL_P256_ALT_CORRECT = time prove
 
   (*** Simulate the core pre-reduced result accumulation ***)
 
-  MAP_EVERY (fun n ->
-    X86_STEPS_TAC BIGNUM_MONTMUL_P256_ALT_EXEC [n] THEN
-    RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
-     `word_sub x (word_neg y):int64 = word_add x y`]) THEN
-    TRY(ACCUMULATE_ARITH_TAC("s"^string_of_int n)))
-   (1--149) THEN
+  X86_GEN_ACCSTEPS_TAC
+    (fun _ -> RULE_ASSUM_TAC(REWRITE_RULE[WORD_RULE
+                `word_sub x (word_neg y):int64 = word_add x y`]))
+    BIGNUM_MONTMUL_P256_ALT_EXEC (1--149) (1--149) THEN
   ABBREV_TAC
    `t = bignum_of_wordlist
           [sum_s133; sum_s141; sum_s147; sum_s148; sum_s149]` THEN


### PR DESCRIPTION
This patch adds `ARM_GEN_ACCSTEP{S}_TAC` and `X86_GEN_ACCSTEP{S}_TAC` that has additional `acc_preproc` argument. The tactics run `acc_preproc` before `ACCUMULATE_ARITH_TAC` and this argument is useful when the output goal of `*_SINGLE_STEP_TAC` needs additional rewrites for accumulator to recognize it.

This PR also updates x86/proofs/bignum_montmul_p256_alt.ml to use the generalized tactic. This checks the sanity of the new tactics.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
