### PR TITLE
Add a simulator that tests the semantics of ARM instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.correct
 *.o
 *.obj
+tests/test
+benchmarks/benchmark

--- a/arm/proofs/armsimulate
+++ b/arm/proofs/armsimulate
@@ -1,0 +1,16 @@
+# Get the directory path that includes this 'armsimulate' file
+DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
+DIR="$( realpath -- "$DIR"; )"
+
+cd $DIR
+temp="$( mktemp )"
+temp_s="${temp}.S"
+temp_o="${temp}.o"
+cat template.S | sed -e "s/ICODE/$1/" >$temp_s
+gcc -c $temp_s -o $temp_o
+gcc -o $temp simulator.c $temp_o
+
+shift 1
+$temp $*
+
+rm -f $temp $temp_s $temp_o

--- a/arm/proofs/simulator.c
+++ b/arm/proofs/simulator.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <stdlib.h>
+
+#define DEBUG 0
+
+// regs[0 ~ 31]:  X registers
+// regs[32 + 2*i]: Qi.d[0]
+// regs[32 + 2*i+1]: Qi.d[1]
+static uint64_t regs[32 + /*Q registers */2 * 32];
+
+extern uint64_t harness(uint64_t *regfile);
+
+void print_regs()
+{ uint64_t i;
+  for (i = 0; i < 32; ++i)
+    printf("   %sX%ld = 0x%016lx\n",((i<10)?" ":""),i,regs[i]);
+  for (i = 0; i < 32; ++i)
+    printf("   %sQ%ld.{d[0], d[1]} = { 0x%016lx, 0x%016lx }\n",((i<10)?" ":""),i,regs[32+i*2],regs[32+i*2+1]);
+}
+
+int main(int argc, char *argv[])
+{ uint64_t retval, i;
+
+  for (i = 1; i < argc && i <= 32 + 2 * 32; ++i)
+    regs[i-1] = strtoul(argv[i],NULL,0);
+
+  if (DEBUG)
+   { printf("About to call harness with these arguments\n");
+     print_regs();
+   }
+
+  retval = harness(regs);
+
+  if (DEBUG)
+   { printf("Called it and got %lu\n",retval);
+     print_regs();
+   }
+  else
+   { for (i = 0; i < 32 + 2 * 32; ++i) printf("%lu ",regs[i]);
+     printf("\n");
+   }
+
+  return retval;
+}

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -1,0 +1,357 @@
+(* ------------------------------------------------------------------------- *)
+(* Encoding the registers and flags as a 32-element list of numbers.         *)
+(* ------------------------------------------------------------------------- *)
+
+needs "arm/proofs/base.ml";;
+
+let regfile = new_definition
+ `regfile s =
+   [val(read X0 s); val(read X1 s); val(read X2 s); val(read X3 s);
+    val(read X4 s); val(read X5 s); val(read X6 s); val(read X7 s);
+    val(read X8 s); val(read X9 s); val(read X10 s); val(read X11 s);
+    val(read X12 s); val(read X13 s); val(read X14 s); val(read X15 s);
+    val(read X16 s); val(read X17 s); val(read X18 s); val(read X19 s);
+    val(read X20 s); val(read X21 s); val(read X22 s); val(read X23 s);
+    val(read X24 s); val(read X25 s); val(read X26 s); val(read X27 s);
+    val(read X28 s); val(read X29 s); val(read X30 s);
+    bitval(read VF s) + 2 * bitval(read CF s) +
+    4 * bitval(read ZF s) + 8 * bitval(read NF s);
+    val(read Q0 s); val(read Q1 s); val(read Q2 s); val(read Q3 s);
+    val(read Q4 s); val(read Q5 s); val(read Q6 s); val(read Q7 s);
+    val(read Q8 s); val(read Q9 s); val(read Q10 s); val(read Q11 s);
+    val(read Q12 s); val(read Q13 s); val(read Q14 s); val(read Q15 s);
+    val(read Q16 s); val(read Q17 s); val(read Q18 s); val(read Q19 s);
+    val(read Q20 s); val(read Q21 s); val(read Q22 s); val(read Q23 s);
+    val(read Q24 s); val(read Q25 s); val(read Q26 s); val(read Q27 s);
+    val(read Q28 s); val(read Q29 s); val(read Q30 s); val(read Q31 s)]`;;
+
+let FLAGENCODING_11 = prove
+ (`bitval b0 + 2 * bitval b1 + 4 * bitval b2 + 8 * bitval b3 = n <=>
+   n < 16 /\
+   (b0 <=> ODD n) /\
+   (b1 <=> ODD(n DIV 2)) /\
+   (b2 <=> ODD(n DIV 4)) /\
+   (b3 <=> ODD(n DIV 8))`,
+  REWRITE_TAC[bitval] THEN REPEAT(COND_CASES_TAC THEN ASM_REWRITE_TAC[]) THEN
+  (EQ_TAC THENL
+    [DISCH_THEN(SUBST1_TAC o SYM) THEN CONV_TAC NUM_REDUCE_CONV; ALL_TAC]) THEN
+  REWRITE_TAC[IMP_CONJ] THEN SPEC_TAC(`n:num`,`n:num`) THEN
+  CONV_TAC EXPAND_CASES_CONV THEN CONV_TAC NUM_REDUCE_CONV);;
+
+(* ------------------------------------------------------------------------- *)
+(* Random numbers with random bit density, random state for simulating.      *)
+(* ------------------------------------------------------------------------- *)
+
+let random_boold d = Random.int 64 < d;;
+
+let randomnd n density =
+    funpow n (fun n ->
+      (if random_boold density then num_1 else num_0) +/ num_2 */ n) num_0;;
+
+let random64() = randomnd 64 (Random.int 65);;
+
+let random_regstate () =
+  let d = Random.int 65 in
+  map (fun _ -> randomnd 64 d) (0--30) @
+  [mod_num (random64()) (Int 16)] @
+  map (fun _ -> randomnd 128 d) (0--31);;
+
+(* ------------------------------------------------------------------------- *)
+(* Generate random instance of instruction class itself.                     *)
+(* ------------------------------------------------------------------------- *)
+
+let classbit s =
+  match s with
+   "0" -> num_0
+  | "1" -> num_1
+  | _ -> if Random.bool() then num_1 else num_0;;
+
+let random_iclass s =
+  if String.length s <> 32 then failwith "random_iclass: malformed string"
+  else itlist (fun c n -> classbit c +/ Int 2 */ n) (rev(explode s)) num_0;;
+
+let random_instruction iclasses =
+  let iclass = el (Random.int (length iclasses)) iclasses in
+  random_iclass iclass;;
+
+(* ------------------------------------------------------------------------- *)
+(* The iclasses to simulate.                                                 *)
+(* ------------------------------------------------------------------------- *)
+
+let iclasses =
+ [(*** CCMN immediate ***)
+  (*** CCMN register ***)
+  "x0111010010xxxxxxxxx10xxxxx0xxxx";
+  "x0111010010xxxxxxxxx00xxxxx0xxxx";
+
+  (*** CCMP immediate ***)
+  (*** CCMP register ***)
+  "x1111010010xxxxxxxxx10xxxxx0xxxx";
+  "x1111010010xxxxxxxxx00xxxxx0xxxx";
+
+  (*** ADC, ADCS, SBC, SBCS with register-register operands ***)
+  "xxx11010000xxxxx000000xxxxxxxxxx";
+
+  (*** ADD, ADDS, SUB, SUBS with immediate operand ***)
+
+  (*** We want to avoid any use of SP since our crude simulation
+   *** framework doesn't work in such cases. While it misses a
+   *** bit of the state space, we force both registers to have
+   *** zero bits in their encoding.
+   ***)
+  "xxx100010xxxxxxxxxxxxxxx0xxxxxx0";
+  "xxx100010xxxxxxxxxxxxxxx0xxxxxx0";
+  "xxx100010xxxxxxxxxxxxx0xxxxx0xxx";
+  "xxx100010xxxxxxxxxxxxx0xxxx0xxxx";
+
+  (*** ADD, ADDS, SUB, SUBS, shifted registers ***)
+  "xxx01011xx0xxxxxxxxxxxxxxxxxxxxx";
+
+  (*** AND, ANDS, EOR, ORR with immediate operand, no negated forms ***)
+  (*** Again we want to avoid using SP except for in ANDS ***)
+
+  "x00100100xxxxxxxxxxxxxxxxxxxxxx0";
+  "x00100100xxxxxxxxxxxxxxxxxxxxx0x";
+  "x01100100xxxxxxxxxxxxxxxxxxxx0xx";
+  "x01100100xxxxxxxxxxxxxxxxxxx0xxx";
+  "x10100100xxxxxxxxxxxxxxxxxx0xxxx";
+  "x10100100xxxxxxxxxxxxxxxxxxxxxx0";
+  "x11100100xxxxxxxxxxxxxxxxxxxxxxx";
+
+  (*** CSEL, CSINC, CSINV, CSNEG register-register ***)
+  "xx011010100xxxxxxxxx0xxxxxxxxxxx";
+
+  (*** AND, BIC, ..., ORN, shifted registers ***)
+  "xxx01010xxxxxxxxxxxxxxxxxxxxxxxx";
+
+  (*** MOVN, MOVZ, MOVK ***)
+  "xxx100101xxxxxxxxxxxxxxxxxxxxxxx";
+
+  (*** Extr ***)
+  "x00100111x0xxxxxxxxxxxxxxxxxxxxx";
+
+  (*** LSLV, LSRV ***)
+  "x0011010110xxxxx0010xxxxxxxxxxxx";
+
+  (*** UBFM, SBFM ***)
+  "xx0100110xxxxxxxxxxxxxxxxxxxxxxx";
+
+  (*** CLZ ***)
+  "x101101011000000000100xxxxxxxxxx";
+
+  (*** MADD, MSUB ***)
+  "x0011011000xxxxxxxxxxxxxxxxxxxxx";
+
+  (*** UMULH ***)
+  "10011011110xxxxx011111xxxxxxxxxx";
+
+  (*** UMADDL, UMSUBL ***)
+  "10011011101xxxxxxxxxxxxxxxxxxxxx";
+
+  (****** NEON INSTRUCTIONS *****)
+  (*** ADD ***)
+  "01001110xx1xxxxx100001xxxxxxxxxx"; (* 128 bits *)
+  "000011100x1xxxxx100001xxxxxxxxxx"; (* 64 bits, size=0 or 1 *)
+  "00001110101xxxxx100001xxxxxxxxxx"; (* 64 bits, size=2 *)
+
+  (*** AND ***)
+  "0x001110001xxxxx000111xxxxxxxxxx";
+
+  (*** DUP ***)
+  "01001110000x1000000011xxxxxxxxxx"; (* DUP Vd.2d, xn *)
+
+  (*** EXT ***)
+  "01101110000xxxxx0xxxx0xxxxxxxxxx"; (* 128 bits only *)
+
+  (*** MOVI ***)
+  "0110111100000xxx111001xxxxxxxxxx"; (* q=1, cmode=1110 *)
+
+  (*** MUL ***)
+  "01001110001xxxxx100111xxxxxxxxxx"; (* .b *)
+  "01001110011xxxxx100111xxxxxxxxxx"; (* .h *)
+  "01001110101xxxxx100111xxxxxxxxxx"; (* .s *)
+
+  (*** ORR ***)
+  "0x001110101xxxxx000111xxxxxxxxxx";
+
+  (*** REV64 ***)
+  "010011100x100000000010xxxxxxxxxx"; (* .h, .b *)
+  "0100111010100000000010xxxxxxxxxx"; (* .s *)
+
+  (*** SHL ***)
+  "01001111001xxxxx010101xxxxxxxxxx"; (* .s *)
+  "0100111101xxxxxx010101xxxxxxxxxx"; (* .d *)
+
+  (*** SHRN ***)
+  "00001111001xxxxx100001xxxxxxxxxx"; (* q=0, immh!=0 *)
+  "000011110001xxxx100001xxxxxxxxxx"; (* q=0, immh!=0 *)
+  "0000111100001xxx100001xxxxxxxxxx"; (* q=0, immh!=0 *)
+
+  (*** SLI ***)
+  "0110111101xxxxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
+  "01101111001xxxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
+  "011011110001xxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
+  "0110111100001xxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
+
+  (*** UADDLP ***)
+  "011011100x100000001010xxxxxxxxxx"; (* src: .b, .h *)
+  "0110111010100000001010xxxxxxxxxx"; (* src: .s *)
+
+  (*** UMOV (.d, .s) ***)
+  "01001110000x1000001111xxxxxxxxxx";
+  "00001110000xx100001111xxxxxxxxxx";
+
+  (*** UMADDL, UMSUBL ***)
+  "10011011101xxxxxxxxxxxxxxxxxxxxx";
+
+  (*** UMLAL ***)
+  "001011100x1xxxxx100000xxxxxxxxxx"; (* src: .b, .h *)
+  "00101110101xxxxx100000xxxxxxxxxx"; (* src: .s *)
+
+  (*** UMULL ***)
+  "001011100x1xxxxx110000xxxxxxxxxx"; (* size!=11 *)
+  "00101110101xxxxx110000xxxxxxxxxx"; (* size!=11 *)
+
+  (*** USRA ***)
+  "0110111101xxxxxx000101xxxxxxxxxx"; (* q=1 *)
+  "01101111001xxxxx000101xxxxxxxxxx"; (* q=1 *)
+  "011011110001xxxx000101xxxxxxxxxx"; (* q=1 *)
+  "0110111100001xxx000101xxxxxxxxxx"; (* q=1 *)
+  "00101111001xxxxx000101xxxxxxxxxx"; (* q=0 *)
+  "001011110001xxxx000101xxxxxxxxxx"; (* q=0 *)
+  "0010111100001xxx000101xxxxxxxxxx"; (* q=0 *)
+
+  (*** UZP1 ***)
+  "01001110xx0xxxxx000110xxxxxxxxxx";
+
+  (*** ZIP1 ***)
+  "01001110xx0xxxxx001110xxxxxxxxxx"; (* q=1 *)
+  "000011100x0xxxxx001110xxxxxxxxxx"; (* q=0, size!=3 *)
+  "00001110100xxxxx001110xxxxxxxxxx"; (* q=0, size!=3 *)
+ ];;
+
+(* ------------------------------------------------------------------------- *)
+(* Run a random example.                                                     *)
+(* ------------------------------------------------------------------------- *)
+
+let PRINT_GOAL_TAC (desc: string): tactic =
+  fun gl -> let _ = printf "<%s>\n" desc; print_goal gl in ALL_TAC gl;;
+
+let template =
+ `ensures arm
+     (\s. aligned_bytes_loaded s (word pc) ibytes /\
+          read PC s = word pc /\
+          regfile s = input_state)
+     (\s. regfile s = output_state)
+     (MAYCHANGE [PC; X0; X1; X2; X3; X4; X5; X6; X7; X8; X9;
+                 X10; X11; X12; X13; X14; X15; X16; X17; X18; X19;
+                 X20; X21; X22; X23; X24; X25; X26; X27; X28; X29; X30] ,,
+      MAYCHANGE [Q0; Q1; Q2; Q3; Q4; Q5; Q6; Q7; Q8; Q9;
+                 Q10; Q11; Q12; Q13; Q14; Q15; Q16; Q17; Q18; Q19;
+                 Q20; Q21; Q22; Q23; Q24; Q25; Q26; Q27; Q28; Q29;
+                 Q30; Q31] ,,
+      MAYCHANGE SOME_FLAGS)`;;
+
+let num_two_to_64 = Num.num_of_string "18446744073709551616";;
+
+let rec split_first_n (ls: 'a list) (n: int) =
+  if n = 0 then ([], ls)
+  else match ls with
+    | h::t -> let l1, l2 = split_first_n t (n-1) in (h::l1, l2)
+    | [] -> failwith "n cannot be smaller than the length of ls";;
+
+let run_random_simulation () =
+  let icode:num = random_instruction iclasses in
+  let _ = printf "random inst: decode %d\n" (Num.int_of_num icode) in
+
+  let ibytes =
+    [mod_num icode (Int 256);
+     mod_num (quo_num icode (Int 256)) (Int 256);
+     mod_num (quo_num icode (Int 65536)) (Int 256);
+     quo_num icode (Int 16777216)] in
+
+  let ibyteterm =
+    mk_flist(map (curry mk_comb `word:num->byte` o mk_numeral) ibytes) in
+
+
+  let input_state = random_regstate() in
+
+  let outfile = Filename.temp_file "armsimulator" ".out" in
+
+  let command_arg =
+    (* Split q registers that are 128 bits to 64 + 64 bits *)
+    let xregs, qregs = split_first_n input_state 32 in
+    xregs @ List.concat (map (fun n -> [Num.mod_num n num_two_to_64; Num.quo_num n num_two_to_64]) qregs) in
+
+  let command =
+    rev_itlist (fun s t -> t ^ " " ^ string_of_num s) (icode::command_arg)
+    "arm/proofs/armsimulate" ^ " >" ^ outfile in
+
+  let _ = Sys.command command in
+
+  (*** This branch determines whether the actual simulation worked ***)
+  (*** In each branch we try to confirm that we likewise do or don't ***)
+
+  if strings_of_file outfile <> [] then
+    let resultstring = string_of_file outfile in
+
+    let output_state_raw =
+      map (fun (Ident s) -> num_of_string s)
+          (lex(explode resultstring)) in
+
+    (* Synthesize q registers from two 64 ints *)
+    let output_state =
+      let xregs, qregs = split_first_n (output_state_raw) 32 in
+      xregs @ snd (List.fold_left (fun (prev_num, ls) n ->
+        (* prev_num is None on 0, 2, 4, ..th item and Some n' on 1, 3, ..th item *)
+        match prev_num with
+        | None -> (Some n, ls)
+        | Some n' -> (None, ls @ [num_two_to_64 */ n +/ n'])) (None, []) qregs) in
+
+    let goal = subst
+      [ibyteterm,`ibytes:byte list`;
+       mk_flist(map mk_numeral input_state),`input_state:num list`;
+       mk_flist(map mk_numeral output_state),`output_state:num list`]
+      template in
+
+    let execth = ARM_MK_EXEC_RULE(REFL ibyteterm) in
+
+    let decoded =
+      rand(rand(snd(strip_forall(rand(concl execth)))))
+    and result =
+    can prove
+     (goal,
+      REWRITE_TAC[regfile; CONS_11; FLAGENCODING_11; VAL_WORD_GALOIS] THEN
+      REWRITE_TAC[DIMINDEX_64; DIMINDEX_128] THEN CONV_TAC NUM_REDUCE_CONV THEN
+      REWRITE_TAC[SOME_FLAGS] THEN
+      ARM_SIM_TAC execth [1] THEN
+      PRINT_GOAL_TAC "result mismatch" THEN
+      NO_TAC) in
+    (decoded,result)
+  else
+    let decoded = mk_numeral icode in
+    decoded,not(can ARM_MK_EXEC_RULE(REFL ibyteterm));;
+
+(* ------------------------------------------------------------------------- *)
+(* Keep running tests till a failure happens then return it.                 *)
+(* ------------------------------------------------------------------------- *)
+
+let rec run_random_simulations () =
+  let decoded,result = run_random_simulation() in
+  if result then
+   let fey = if is_numeral decoded
+             then " (fails correctly) instruction code " else " " in
+   (Format.print_string("OK:" ^ fey ^ string_of_term decoded);
+    Format.print_newline();
+    run_random_simulations())
+  else (decoded,result);;
+
+(*** Depending on the degree of repeatability wanted.
+ *** After a few experiments I'm now going full random.
+ ***
+ *** Random.init(Hashtbl.hash (Sys.getenv "HOST"));;
+ ***)
+
+Random.self_init();;
+
+run_random_simulations();;

--- a/arm/proofs/template.S
+++ b/arm/proofs/template.S
@@ -1,0 +1,242 @@
+// -------------------------------------------------------------------------
+// Simulator for single ARM register-only instruction:
+//
+//         uint64_t harness(uint64_t *regfile);
+//
+// Copies state from "regfile" into registers and flags:
+//
+//         X0 = regfile[0]
+//         X1 = regfile[1]
+//         ...
+//         X30 = regfile[30]
+//         NF:ZF:CF:VF = regfile[31] & 0xF
+//         Q0.d[0] = regfile[32]
+//         Q0.d[1] = regfile[33]
+//         ...
+//         Q31.d[1] = regfile[95]
+//
+// executes the instruction at "modinst", then copies the new state
+// back into the same array, also returning new value X0 directly.
+// -------------------------------------------------------------------------
+
+        .globl  harness
+        .text
+        .balign 4
+
+#define regfile x0
+
+#define pccode x20
+
+harness:
+
+// Save non-modifiable input registers and input arguments on the stack
+
+                str     q31, [sp, -16]!
+                str     q30, [sp, -16]!
+                str     q29, [sp, -16]!
+                str     q28, [sp, -16]!
+                str     q27, [sp, -16]!
+                str     q26, [sp, -16]!
+                str     q25, [sp, -16]!
+                str     q24, [sp, -16]!
+                str     q23, [sp, -16]!
+                str     q22, [sp, -16]!
+                str     q21, [sp, -16]!
+                str     q20, [sp, -16]!
+                str     q19, [sp, -16]!
+                str     q18, [sp, -16]!
+                str     q17, [sp, -16]!
+                str     q16, [sp, -16]!
+                str     q15, [sp, -16]!
+                str     q14, [sp, -16]!
+                str     q13, [sp, -16]!
+                str     q12, [sp, -16]!
+                str     q11, [sp, -16]!
+                str     q10, [sp, -16]!
+                str     q9,  [sp, -16]!
+                str     q8,  [sp, -16]!
+                str     q7,  [sp, -16]!
+                str     q6,  [sp, -16]!
+                str     q5,  [sp, -16]!
+                str     q4,  [sp, -16]!
+                str     q3,  [sp, -16]!
+                str     q2,  [sp, -16]!
+                str     q1,  [sp, -16]!
+                str     q0,  [sp, -16]!
+                stp     x30, xzr,  [sp, -16]!
+                stp     x28, x29,  [sp, -16]!
+                stp     x26, x27,  [sp, -16]!
+                stp     x24, x25,  [sp, -16]!
+                stp     x22, x23,  [sp, -16]!
+                stp     x20, x21,  [sp, -16]!
+                stp     x18, x19,  [sp, -16]!
+                stp     x0, x1,    [sp, -16]!
+
+// Load new register contents from regfile (last overwrites args)
+
+                ldr     q31, [regfile, 16*47]
+                ldr     q30, [regfile, 16*46]
+                ldr     q29, [regfile, 16*45]
+                ldr     q28, [regfile, 16*44]
+                ldr     q27, [regfile, 16*43]
+                ldr     q26, [regfile, 16*42]
+                ldr     q25, [regfile, 16*41]
+                ldr     q24, [regfile, 16*40]
+                ldr     q23, [regfile, 16*39]
+                ldr     q22, [regfile, 16*38]
+                ldr     q21, [regfile, 16*37]
+                ldr     q20, [regfile, 16*36]
+                ldr     q19, [regfile, 16*35]
+                ldr     q18, [regfile, 16*34]
+                ldr     q17, [regfile, 16*33]
+                ldr     q16, [regfile, 16*32]
+                ldr     q15, [regfile, 16*31]
+                ldr     q14, [regfile, 16*30]
+                ldr     q13, [regfile, 16*29]
+                ldr     q12, [regfile, 16*28]
+                ldr     q11, [regfile, 16*27]
+                ldr     q10, [regfile, 16*26]
+                ldr     q9,  [regfile, 16*25]
+                ldr     q8,  [regfile, 16*24]
+                ldr     q7,  [regfile, 16*23]
+                ldr     q6,  [regfile, 16*22]
+                ldr     q5,  [regfile, 16*21]
+                ldr     q4,  [regfile, 16*20]
+                ldr     q3,  [regfile, 16*19]
+                ldr     q2,  [regfile, 16*18]
+                ldr     q1,  [regfile, 16*17]
+                ldr     q0,  [regfile, 16*16]
+                ldp     x30, x29,  [regfile, 16*15]
+                lsl     x29, x29, #28
+                msr     nzcv, x29
+                ldp     x28, x29,  [regfile, 16*14]
+                ldp     x26, x27,  [regfile, 16*13]
+                ldp     x24, x25,  [regfile, 16*12]
+                ldp     x22, x23,  [regfile, 16*11]
+                ldp     x20, x21,  [regfile, 16*10]
+                ldp     x18, x19,  [regfile, 16*9]
+                ldp     x16, x17,  [regfile, 16*8]
+                ldp     x14, x15,  [regfile, 16*7]
+                ldp     x12, x13,  [regfile, 16*6]
+                ldp     x10, x11,  [regfile, 16*5]
+                ldp     x8, x9,    [regfile, 16*4]
+                ldp     x6, x7,    [regfile, 16*3]
+                ldp     x4, x5,    [regfile, 16*2]
+                ldp     x2, x3,    [regfile, 16*1]
+                ldp     x0, x1,    [regfile, 16*0]
+
+// Execute the instruction, which may be modified from this placeholder
+
+modinst:
+                .inst      ICODE   // To be modified by script
+
+// Copy new state back to the buffer
+
+                stp     x0, x1, [sp, -16]!
+                ldr     regfile, [sp, 16]
+
+                str     q31, [regfile, 16*47]
+                str     q30, [regfile, 16*46]
+                str     q29, [regfile, 16*45]
+                str     q28, [regfile, 16*44]
+                str     q27, [regfile, 16*43]
+                str     q26, [regfile, 16*42]
+                str     q25, [regfile, 16*41]
+                str     q24, [regfile, 16*40]
+                str     q23, [regfile, 16*39]
+                str     q22, [regfile, 16*38]
+                str     q21, [regfile, 16*37]
+                str     q20, [regfile, 16*36]
+                str     q19, [regfile, 16*35]
+                str     q18, [regfile, 16*34]
+                str     q17, [regfile, 16*33]
+                str     q16, [regfile, 16*32]
+                str     q15, [regfile, 16*31]
+                str     q14, [regfile, 16*30]
+                str     q13, [regfile, 16*29]
+                str     q12, [regfile, 16*28]
+                str     q11, [regfile, 16*27]
+                str     q10, [regfile, 16*26]
+                str     q9,  [regfile, 16*25]
+                str     q8,  [regfile, 16*24]
+                str     q7,  [regfile, 16*23]
+                str     q6,  [regfile, 16*22]
+                str     q5,  [regfile, 16*21]
+                str     q4,  [regfile, 16*20]
+                str     q3,  [regfile, 16*19]
+                str     q2,  [regfile, 16*18]
+                str     q1,  [regfile, 16*17]
+                str     q0,  [regfile, 16*16]
+
+                mrs     x1, nzcv
+                lsr     x1, x1, #28
+                and     x1, x1, #0xF
+                stp     x30, x1,   [regfile, 16*15]
+
+                stp     x28, x29,  [regfile, 16*14]
+                stp     x26, x27,  [regfile, 16*13]
+                stp     x24, x25,  [regfile, 16*12]
+                stp     x22, x23,  [regfile, 16*11]
+                stp     x20, x21,  [regfile, 16*10]
+                stp     x18, x19,  [regfile, 16*9]
+                stp     x16, x17,  [regfile, 16*8]
+                stp     x14, x15,  [regfile, 16*7]
+                stp     x12, x13,  [regfile, 16*6]
+                stp     x10, x11,  [regfile, 16*5]
+                stp     x8, x9,    [regfile, 16*4]
+                stp     x6, x7,    [regfile, 16*3]
+                stp     x4, x5,    [regfile, 16*2]
+                stp     x2, x3,    [regfile, 16*1]
+
+                ldp     x2, x3,    [sp], #16
+
+                stp     x2, x3,    [regfile, 16*0]
+
+// Load back the preserved registers
+
+                add     sp, sp, 16
+                ldp     x18, x19, [sp], #16
+                ldp     x20, x21, [sp], #16
+                ldp     x22, x23, [sp], #16
+                ldp     x24, x25, [sp], #16
+                ldp     x26, x27, [sp], #16
+                ldp     x28, x29, [sp], #16
+                ldp     x30, xzr, [sp], #16
+                ldr     q0,  [sp], #16
+                ldr     q1,  [sp], #16
+                ldr     q2,  [sp], #16
+                ldr     q3,  [sp], #16
+                ldr     q4,  [sp], #16
+                ldr     q5,  [sp], #16
+                ldr     q6,  [sp], #16
+                ldr     q7,  [sp], #16
+                ldr     q8,  [sp], #16
+                ldr     q9,  [sp], #16
+                ldr     q10, [sp], #16
+                ldr     q11, [sp], #16
+                ldr     q12, [sp], #16
+                ldr     q13, [sp], #16
+                ldr     q14, [sp], #16
+                ldr     q15, [sp], #16
+                ldr     q16, [sp], #16
+                ldr     q17, [sp], #16
+                ldr     q18, [sp], #16
+                ldr     q19, [sp], #16
+                ldr     q20, [sp], #16
+                ldr     q21, [sp], #16
+                ldr     q22, [sp], #16
+                ldr     q23, [sp], #16
+                ldr     q24, [sp], #16
+                ldr     q25, [sp], #16
+                ldr     q26, [sp], #16
+                ldr     q27, [sp], #16
+                ldr     q28, [sp], #16
+                ldr     q29, [sp], #16
+                ldr     q30, [sp], #16
+                ldr     q31, [sp], #16
+
+// Also return x0 from the instruction, which was moved to x2
+
+                mov     x0, x2
+
+                ret


### PR DESCRIPTION
This patch adds a simulator that tests the semantics of ARM instructions. The simulator was mostly written by John, and my only update is adding NEON instruction support and adding minor changes such as using random file names to avoid conflicts between two different simulator runs.

This

(1) Generates a random bitvector that can be decoded as an instruction, as well as random bitvectors for input values of register 

(2) Execute it with respect to s2n-bignum's operational semantics

(3) Compare the result with actual ARM CPU's output, by compiling a template code and run it

How to use: Open HOL Light at the s2n-bignum directory, then simply run `loadt "arm/proofs/simulator.ml";;`.
No need to load "arm/proofs/base.ml" because simulator.ml has `needs "arm/proofs/base.ml"`.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
