### PR TITLE
Update proofs CI to run the simulator

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -369,3 +369,11 @@ sm2/%.correct: proofs/%.ml sm2/%.o ; (cd ..; (echo 'loadt "arm/proofs/base.ml";;
 run_proofs: $(PROOFS);
 
 proofs: run_proofs ; ../tools/check-proofs.sh .
+
+# Always run sematest regardless of dependency check
+FORCE: ;
+# Always use max. # of cores because in Makefile one cannot get the passed number of -j.
+# A portable way of getting the number of max. cores:
+# https://stackoverflow.com/a/23569003/1488216
+NUM_CORES_FOR_SEMATEST = $(shell getconf _NPROCESSORS_ONLN)
+sematest: FORCE; ../tools/run-sematest.sh . $(NUM_CORES_FOR_SEMATEST) "$(HOLLIGHT)"

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -14,4 +14,5 @@ phases:
       - CORE_COUNT=$(nproc --all)
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
+      - make sematest
       - make -j ${CORE_COUNT} proofs

--- a/codebuild/tests.yml
+++ b/codebuild/tests.yml
@@ -9,4 +9,6 @@ phases:
       - cd ${CODEBUILD_SRC_DIR}/tests
       - make complete
       - make ctCheck
+      - cd ${CODEBUILD_SRC_DIR}/benchmarks
+      - make
 

--- a/tools/run-sematest.sh
+++ b/tools/run-sematest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+if [ "$#" -ne 3 ]; then
+  echo "run-sematest.sh <dir (e.g., arm)> <N> <HOL Light command>"
+  echo "This script runs the simulator ('<dir>/proofs/simulator.ml') that tests the semantics "
+  echo "of instructions. It launches N simulators in parallel, and uses the given "
+  echo "HOL Light command to run them."
+  exit 1
+fi
+
+s2n_bignum_arch=$1
+nproc=$2
+hol_light_cmd=$3
+cd $s2n_bignum_arch
+
+log_paths=()
+children_pids=()
+for (( i = 1; i <= $nproc; i++ )) ; do
+  log_path=`mktemp`
+  log_paths[$i]=$log_path
+  (cd ..; (echo 'loadt "arm/proofs/simulator.ml";;') | $hol_light_cmd >$log_path 2>&1) &
+  background_pid=$!
+  children_pids[$i]=$background_pid
+  echo "- Child $i (pid $background_pid) has started (log path: $log_path)"
+done
+
+for (( i = 1; i <= $nproc; i++ )) ; do
+  wait ${children_pids[$i]}
+  exitcode=$?
+  echo "- Last 7 lines of simulator $i's log (path: ${log_paths[$i]}):"
+  tail -7 ${log_paths[$i]}
+  if [ $exitcode -ne 0 ]; then
+    echo "Simulator $i failed!"
+    exit 1
+  else
+    echo "- Simulator $i finished successfully"
+  fi
+done


### PR DESCRIPTION
This patch updates the 'proofs' CI to run the simulator in parallel. It is set to 30 minutes by default.
Also, this adds a new Makefile target that runs the simulators. It can be run using `make sematest`.

To achieve parallelism, a custom bash script is written and invoked from Makefile instead of writing everything in Makefile.
This is because there is a challenge in relying on `make -j` to run simulators in parallel. `make -j` assigns one subprocess for one target object, but in this case, a simulator does not have any target object that it outputs. To resolve this, we can create N artifical outputs, but then another challenge is that in Makefile one cannot get the number of processes given to `-j`. :( (see also: https://stackoverflow.com/q/5303553/1488216)

`make sematest` always runs the simulators using all cores in CPU.

Also, additionally, `codebuild/tests.yml` is updated to build benchmark as well.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
