### PR TITLE
Update sematests CI to run the ARM simulator

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -372,5 +372,9 @@ proofs: run_proofs ; ../tools/check-proofs.sh .
 
 # Always run sematest regardless of dependency check
 FORCE: ;
-# Dummy
-sematest: FORCE; echo "todo"
+# Always use max. # of cores because in Makefile one cannot get the passed number of -j.
+# A portable way of getting the number of max. cores:
+# https://stackoverflow.com/a/23569003/1488216
+NUM_CORES_FOR_SEMATEST = $(shell getconf _NPROCESSORS_ONLN)
+sematest: FORCE; ../tools/run-sematest.sh . $(NUM_CORES_FOR_SEMATEST) "$(HOLLIGHT)"
+

--- a/arm/proofs/armsimulate
+++ b/arm/proofs/armsimulate
@@ -1,14 +1,17 @@
+#!/bin/bash
 # Get the directory path that includes this 'armsimulate' file
 DIR="$( dirname -- "${BASH_SOURCE[0]}"; )"
 DIR="$( realpath -- "$DIR"; )"
+
 
 cd $DIR
 temp="$( mktemp )"
 temp_s="${temp}.S"
 temp_o="${temp}.o"
-cat template.S | sed -e "s/ICODE/$1/" >$temp_s
-gcc -c $temp_s -o $temp_o
-gcc -o $temp simulator.c $temp_o
+#cat template.S | sed -e "s/ICODE/$1/" >$temp_s
+cc -DICODE=$1 -E -xassembler-with-cpp template.S -o $temp_s
+as $temp_s -o $temp_o
+cc -o $temp simulator.c $temp_o
 
 shift 1
 $temp $*

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -14,5 +14,4 @@ phases:
       - CORE_COUNT=$(nproc --all)
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
-      - make sematest
       - make -j ${CORE_COUNT} proofs

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -3,24 +3,29 @@ phases:
   install:
     commands:
       - yum -y install ocaml
+      # Perl dependencies for OPAM
       - yum -y install perl-CPAN
-      - perl -MCPAN -e'install "IPC::System::Simple"
-      - perl -MCPAN -e'install "String::ShellQuote"'
+      - SHELL=/bin/sh perl -MCPAN -e'install "IPC::System::Simple"'
+      - SHELL=/bin/sh perl -MCPAN -e'install "String::ShellQuote"'
+      # Install OPAM
       - wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
       - chmod +x install.sh
-      - ./install.sh
-      - opam init
+      - echo "/usr/local/bin" | sh ./install.sh
+      - opam init --disable-sandboxing
       - opam switch create 4.05.0
-      - eval $(opam env)
+      - eval $(opam env --switch=4.05.0)
       - echo $(ocamlc -version)
-      - opam pin add camlp5 7.10
-      - opam install num
+      - opam pin -y add camlp5 7.10
+      - opam install -y num
+      - echo $(camlp5 -v)
+      # Build s2n-bignum
       - cd ${CODEBUILD_SRC_DIR_hol_light}
       - make
   build:
     commands:
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
-      - make sematest
-      - cd proofs
-      - echo 'loadt "arm/proofs/base.ml";;' | HOLLIGHT_DIR=$(HOLDIR) ocaml -init $(HOLDIR)/hol.ml
+      - echo $HOLDIR
+      - eval $(opam env --switch=4.05.0)
+      - echo "`camlp5 -where`"
+      - make sematest HOLLIGHT="HOLLIGHT_DIR=${HOLDIR} ocaml -I `camlp5 -where` -init ${HOLDIR}/hol.ml"

--- a/tools/run-sematest.sh
+++ b/tools/run-sematest.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+if [ "$#" -ne 3 ]; then
+  echo "run-sematest.sh <dir (e.g., arm)> <N> <HOL Light command>"
+  echo "This script runs the simulator ('<dir>/proofs/simulator.ml') that tests the semantics "
+  echo "of instructions. It launches N simulators in parallel, and uses the given "
+  echo "HOL Light command to run them."
+  exit 1
+fi
+
+s2n_bignum_arch=$1
+nproc=$2
+hol_light_cmd=$3
+cd $s2n_bignum_arch
+
+log_paths=()
+children_pids=()
+for (( i = 1; i <= $nproc; i++ )) ; do
+  log_path=`mktemp`
+  log_paths[$i]=$log_path
+  (cd ..; (echo 'loadt "arm/proofs/simulator.ml";;') | eval "$hol_light_cmd" >$log_path 2>&1) &
+  background_pid=$!
+  children_pids[$i]=$background_pid
+  echo "- Child $i (pid $background_pid) has started (log path: $log_path)"
+done
+
+for (( i = 1; i <= $nproc; i++ )) ; do
+  wait ${children_pids[$i]}
+  exitcode=$?
+  echo "- Last 100 lines of simulator $i's log (path: ${log_paths[$i]}):"
+  tail -100 ${log_paths[$i]}
+  if [ $exitcode -ne 0 ]; then
+    echo "Simulator $i failed!"
+    exit 1
+  else
+    echo "- Simulator $i finished successfully"
+  fi
+done


### PR DESCRIPTION
This patch updates the 's2n-bignum-arm-sematests' CI to run the ARM simulator in parallel. Its running time is set to 30 minutes by default.

To achieve parallelism, a custom bash script is written and invoked from Makefile instead of writing everything in Makefile.
This is because there is a challenge in relying on `make -j` to run simulators in parallel. `make -j` assigns one subprocess for one target object, but in this case, a simulator does not have any target object that it outputs. To resolve this, we can create N artifical outputs, but then another challenge is that in Makefile one cannot get the number of processes given to `-j`. :( (see also: https://stackoverflow.com/q/5303553/1488216)

`make sematest` always runs the simulators using all cores in CPU.

Also, add '!/bin/bash' to the header of armsimulate.

This problem was found while Carl Kwan was running the simulator on his machine

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
