### PR TITLE
Add a dummy `sematest` target and update proofs and tests CI

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -369,3 +369,8 @@ sm2/%.correct: proofs/%.ml sm2/%.o ; (cd ..; (echo 'loadt "arm/proofs/base.ml";;
 run_proofs: $(PROOFS);
 
 proofs: run_proofs ; ../tools/check-proofs.sh .
+
+# Always run sematest regardless of dependency check
+FORCE: ;
+# Dummy
+sematest: FORCE; echo "todo"

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -14,4 +14,5 @@ phases:
       - CORE_COUNT=$(nproc --all)
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
+      - make sematest
       - make -j ${CORE_COUNT} proofs

--- a/codebuild/tests.yml
+++ b/codebuild/tests.yml
@@ -9,4 +9,6 @@ phases:
       - cd ${CODEBUILD_SRC_DIR}/tests
       - make complete
       - make ctCheck
+      - cd ${CODEBUILD_SRC_DIR}/benchmarks
+      - make
 

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -421,3 +421,8 @@ sm2/%.correct: proofs/%.ml sm2/%.o sm2/%.obj ; (cd ..; (echo 'loadt "x86/proofs/
 run_proofs: $(PROOFS);
 
 proofs: run_proofs ; ../tools/check-proofs.sh .
+
+# Always run sematest regardless of dependency check
+FORCE: ;
+# Dummy
+sematest: FORCE; echo "todo"


### PR DESCRIPTION
This patch
- Adds a dummy `sematest` target
- Let proofs CI run it
- Let tests CI compile benchmarks.

This is a splitted patch of #65 to enable CI in the updated configuration first.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
