### PR TITLE
Add s2n-bignum-arm-sematests build project to CI

### DIFF
--- a/codebuild/cloudformation.yml
+++ b/codebuild/cloudformation.yml
@@ -145,6 +145,72 @@ Resources:
           Status: "DISABLED"
           EncryptionDisabled: false
 
+  CodeBuildProjectArmSemaTests:
+    Type: "AWS::CodeBuild::Project"
+    Properties:
+      Name: !Sub ${ProjectName}-arm-sematests
+      Description: !Ref ProjectDescription
+      Source:
+        Location: !Ref SourceLocation
+        BuildSpec: codebuild/sematests.yml
+        GitCloneDepth: 1
+        GitSubmodulesConfig:
+          FetchSubmodules: true
+        InsecureSsl: false
+        ReportBuildStatus: true
+        Type: "GITHUB"
+      SecondarySources:
+        -
+          Type: "GITHUB"
+          Location: https://github.com/jrh13/hol-light
+          ReportBuildStatus: false
+          SourceIdentifier: hol_light
+      Artifacts:
+        Type: "NO_ARTIFACTS"
+      Cache:
+        Type: "NO_CACHE"
+      Environment:
+        ComputeType: "BUILD_GENERAL1_LARGE"
+        Image: "aws/codebuild/amazonlinux2-aarch64-standard:2.0"
+        ImagePullCredentialsType: "CODEBUILD"
+        PrivilegedMode: false
+        Type: "ARM_CONTAINER"
+        EnvironmentVariables:
+          - Name: S2N_BIGNUM_ARCH
+            Type: PLAINTEXT
+            Value: arm
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      EncryptionKey: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/s3"
+      BadgeEnabled: true
+      Triggers:
+        Webhook: true
+        BuildType: "BUILD"
+        FilterGroups:
+          - - Type: EVENT # Standard builds
+              Pattern: PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED
+            - Type: BASE_REF
+              Pattern: ^refs/heads/main$
+              ExcludeMatchedPattern: false
+            - Type: FILE_PATH # Don't allow arbitrary users to change build configuration
+              Pattern: codebuild
+              ExcludeMatchedPattern: true
+          - - Type: EVENT # Builds which change build configuration are restricted
+              Pattern: PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED
+            - Type: BASE_REF
+              Pattern: ^refs/heads/main$
+              ExcludeMatchedPattern: false
+            - Type: FILE_PATH # Don't allow arbitrary users to change build configuration
+              Pattern: codebuild
+              ExcludeMatchedPattern: false
+      LogsConfig:
+        CloudWatchLogs:
+          Status: "ENABLED"
+        S3Logs:
+          Status: "DISABLED"
+          EncryptionDisabled: false
+
   CodeBuildProjectX86Proofs:
     Type: "AWS::CodeBuild::Project"
     Properties:

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -1,0 +1,26 @@
+version: 0.2
+phases:
+  install:
+    commands:
+      - yum -y install ocaml
+      - yum -y install perl-CPAN
+      - perl -MCPAN -e'install "IPC::System::Simple"
+      - perl -MCPAN -e'install "String::ShellQuote"'
+      - wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
+      - chmod +x install.sh
+      - ./install.sh
+      - opam init
+      - opam switch create 4.05.0
+      - eval $(opam env)
+      - echo $(ocamlc -version)
+      - opam pin add camlp5 7.10
+      - opam install num
+      - cd ${CODEBUILD_SRC_DIR_hol_light}
+      - make
+  build:
+    commands:
+      - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
+      - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
+      - make sematest
+      - cd proofs
+      - echo 'loadt "arm/proofs/base.ml";;' | HOLLIGHT_DIR=$(HOLDIR) ocaml -init $(HOLDIR)/hol.ml


### PR DESCRIPTION
This PR adds s2n-bignum-arm-sematests build project to CI.

The CI (1) configures an ARM instance using Amazon Linux 2, (2) installs HOL Light, and (3) runs `make sematest` (which does nothing) and also runs `loadt "arm/proofs/base.ml"` for sanity check.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
