### PR TITLE
Adding support for SHA256 and SHA512 intrinsics

### DIFF
--- a/arm/proofs/base.ml
+++ b/arm/proofs/base.ml
@@ -36,9 +36,35 @@ loadt "common/relational.ml";;
 loadt "common/interval.ml";;
 loadt "common/elf.ml";;
 
+(* ------------------------------------------------------------------------- *)
+(* Support for additional SHA instrinsics (from Carl Kwan)                   *)
+(* ------------------------------------------------------------------------- *)
+
+loadt "arm/proofs/sha256.ml";;
+loadt "arm/proofs/sha512.ml";;
+(* Adding extra conversions for SHA intrinsics *)
+extra_word_CONV :=
+        [SHA256H_REDUCE_CONV;
+         SHA256H2_REDUCE_CONV;
+         SHA256SU0_REDUCE_CONV;
+         SHA256SU1_REDUCE_CONV;
+         SHA512H_REDUCE_CONV;
+         SHA512H2_REDUCE_CONV;
+         SHA512SU0_REDUCE_CONV;
+         SHA512SU1_REDUCE_CONV]
+        @ (!extra_word_CONV);;
+
+(* ------------------------------------------------------------------------- *)
+(* The main ARM model.                                                       *)
+(* ------------------------------------------------------------------------- *)
+
 loadt "arm/proofs/instruction.ml";;
 loadt "arm/proofs/decode.ml";;
 loadt "arm/proofs/arm.ml";;
+
+(* ------------------------------------------------------------------------- *)
+(* Bignum material and standard overloading                                  *)
+(* ------------------------------------------------------------------------- *)
 
 prioritize_int();;
 prioritize_real();;

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -371,6 +371,38 @@ let decode = new_definition `!w:int32. decode w =
       let esize:(64)word = word_shl (word 0b1000: (64)word) (val size) in
       SOME (arm_REV64_VEC (QREG' Rd) (QREG' Rn) (val esize))
 
+  | [0b01011110000:11; Rm:5; 0b010000:6; Rn:5; Rd:5] ->
+    // SHA256H
+    SOME (arm_SHA256H (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
+  | [0b01011110000:11; Rm:5; 0b010100:6; Rn:5; Rd:5] ->
+    // SHA256H2
+    SOME (arm_SHA256H2 (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
+  | [0b0101111000101000001010:22; Rn:5; Rd:5] ->
+    // SHA256SU0
+    SOME (arm_SHA256SU0 (QREG' Rd) (QREG' Rn))
+
+  | [0b01011110000:11; Rm:5; 0b011000:6; Rn:5; Rd:5] ->
+    // SHA256SU1
+    SOME (arm_SHA256SU1 (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
+  | [0b11001110011:11; Rm:5; 0b100000:6; Rn:5; Rd:5] ->
+    // SHA512H
+    SOME (arm_SHA512H (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
+  | [0b11001110011:11; Rm:5; 0b100001:6; Rn:5; Rd:5] ->
+    // SHA512H2
+    SOME (arm_SHA512H2 (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
+  | [0b1100111011000000100000:22; Rn:5; Rd:5] ->
+    // SHA512SU0
+    SOME (arm_SHA512SU0 (QREG' Rd) (QREG' Rn))
+
+  | [0b11001110011:11; Rm:5; 0b100010:6; Rn:5; Rd:5] ->
+    // SHA512SU1
+    SOME (arm_SHA512SU1 (QREG' Rd) (QREG' Rn) (QREG' Rm))
+
   | [0:1; q; 0b0011110:7; immh:4; immb:3; 0b010101:6; Rn:5; Rd:5] ->
     // SHL
     if immh = (word 0b0: (4)word) then NONE // "asimdimm case"
@@ -446,7 +478,9 @@ let decode = new_definition `!w:int32. decode w =
       // part is 0, pairs is elements / 2
       SOME (arm_ZIP1 (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
 
-  | _ -> NONE`;;
+ | _ -> NONE`;;
+
+
 
 (* ------------------------------------------------------------------------- *)
 (* Decode tactics.                                                           *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1477,6 +1477,80 @@ let arm_STP = define
          else ASSIGNS entirety) s`;;
 
 (* ------------------------------------------------------------------------- *)
+(* SHA-related SIMD operations                                               *)
+(* ------------------------------------------------------------------------- *)
+
+let arm_SHA256H = define
+ `arm_SHA256H Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha256h d n m in
+        (Rd := d') s`;;
+
+let arm_SHA256H2 = define
+ `arm_SHA256H2 Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha256h2 d n m in
+        (Rd := d') s`;;
+
+let arm_SHA256SU0 = define
+ `arm_SHA256SU0 Rd Rm =
+    \s:armstate.
+        let d = read Rd s
+        and m = read Rm s in
+        let d' = sha256su0 d m in
+        (Rd := d') s`;;
+
+let arm_SHA256SU1 = define
+ `arm_SHA256SU1 Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha256su1 d n m in
+        (Rd := d') s`;;
+
+let arm_SHA512H = define
+ `arm_SHA512H Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha512h d n m in
+        (Rd := d') s`;;
+
+let arm_SHA512H2 = define
+ `arm_SHA512H2 Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha512h2 d n m in
+        (Rd := d') s`;;
+
+let arm_SHA512SU0 = define
+ `arm_SHA512SU0 Rd Rm =
+    \s:armstate.
+        let d = read Rd s
+        and m = read Rm s in
+        let d' = sha512su0 d m in
+        (Rd := d') s`;;
+
+let arm_SHA512SU1 = define
+ `arm_SHA512SU1 Rd Rn Rm =
+    \s:armstate.
+        let d = read Rd s
+        and n = read Rn s
+        and m = read Rm s in
+        let d' = sha512su1 d n m in
+        (Rd := d') s`;;
+
+(* ------------------------------------------------------------------------- *)
 (* Pseudo-instructions that are defined by ARM as aliases.                   *)
 (* ------------------------------------------------------------------------- *)
 
@@ -1886,7 +1960,16 @@ let ARM_OPERATION_CLAUSES =
        INST_TYPE[`:32`,`:N`] arm_ADCS;
        INST_TYPE[`:32`,`:N`] arm_ADDS;
        INST_TYPE[`:32`,`:N`] arm_SBCS;
-       INST_TYPE[`:32`,`:N`] arm_SUBS];;
+       INST_TYPE[`:32`,`:N`] arm_SUBS;
+    (*** SHA256 & SHA512 instructions from Carl Kwan ***)
+       arm_SHA256H;
+       arm_SHA256H2;
+       arm_SHA256SU0;
+       arm_SHA256SU1;
+       arm_SHA512H;
+       arm_SHA512H2;
+       arm_SHA512SU0;
+       arm_SHA512SU1 ];;
 
 let ARM_LOAD_STORE_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)

--- a/arm/proofs/sha256.ml
+++ b/arm/proofs/sha256.ml
@@ -1,0 +1,337 @@
+(** Carl Kwan: ARM SHA256 intrinsics in HOL Light **)
+
+needs "Library/words.ml";;
+
+(****************************************************)
+(**                                                **)
+(** COMMONLY USED FUNCTIONS FOR SHA256 INTRINSICS  **)
+(**                                                **)
+(****************************************************)
+
+let sha_choose = new_definition
+  `sha_choose (x:int32) (y:int32) (z:int32) : int32 = 
+          word_xor (word_and (word_xor y z) x) z`;;
+
+let sha_maj = new_definition
+  `sha_maj (x:int32) (y:int32) (z:int32) : int32 = 
+          word_or (word_and x y) (word_and (word_or x y) z)`;;
+
+let sha_hash_sigma_0 = new_definition
+  `sha_hash_sigma_0 (x:int32) : int32 = 
+          word_xor (word_ror x 2) (word_xor (word_ror x 13) (word_ror x 22))`;;
+
+let sha_hash_sigma_1 = new_definition
+  `sha_hash_sigma_1 (x:int32) : int32 = 
+          word_xor (word_ror x 6) (word_xor (word_ror x 11) (word_ror x 25))`;;
+
+(** 
+ **  ARM pseudo code definition of elem
+ ** 
+ **    bits(size) Elem[bits(N) vector, integer e, integer size]
+ **        assert e >= 0 && (e+1)*size <= N;
+ **        return vector<e*size+size-1 : e*size>;
+ **    
+ **    This just grabs some sequence of bits from the middle of the word
+ **)
+
+let elem = new_definition
+  `elem (w:M word) (e:num) (size:num) : size word =
+          word_subword w (e*size, size)`;;
+
+(** 
+ **  ARM pseudo code definition of SHA256hash
+ **  
+ **  bits(128) SHA256hash(bits (128) X, bits(128) Y, bits(128) W, boolean part1)
+ **      bits(32) chs, maj, t;
+ **  
+ **      for e = 0 to 3
+ **          chs = SHAchoose(Y<31:0>, Y<63:32>, Y<95:64>);
+ **          maj = SHAmajority(X<31:0>, X<63:32>, X<95:64>);
+ **          t = Y<127:96> + SHAhashSIGMA1(Y<31:0>) + chs + Elem[W, e, 32];
+ **          X<127:96> = t + X<127:96>;
+ **          Y<127:96> = t + SHAhashSIGMA0(X<31:0>) + maj;
+ **          <Y, X> = ROL(Y : X, 32);
+ **      return (if part1 then X else Y);
+ **)
+
+let sha256hash_loop = new_definition 
+  `sha256hash_loop (e:num) (x:int128) (y:int128) (w:int128) : 256 word =
+          let chs = sha_choose (word_subword y (0,32))
+                               (word_subword y (32,32))
+                               (word_subword y (64,32)) in
+          let maj = sha_maj (word_subword x (0,32))
+                            (word_subword x (32,32))
+                            (word_subword x (64,32)) in
+          let   t = word_add (word_subword y (96,32))
+                             (word_add (sha_hash_sigma_1 (word_subword y (0,32)))
+                                       (word_add chs (elem w e 32))) in
+          let x_upper = word_add t (word_subword x (96, 32)) in
+          let y_upper = word_add t (word_add (sha_hash_sigma_0 (word_subword x (0, 32))) maj) in
+          let       x = (word_join : int32->96 word->int128) x_upper (word_subword x (0, 96)) in
+          let       y = (word_join : int32->96 word->int128) y_upper (word_subword y (0, 96)) in
+          let      xy = word_rol ((word_join : int128->int128->256 word) x y) 32 in
+          xy`;;
+
+let sha256hash = new_definition
+  `sha256hash (x:int128) (y:int128) (w:int128) (part1:bool) : int128 =
+          let xy:256 word = sha256hash_loop 0 x y w in
+          let x:int128 = word_subword xy (128, 128) in
+          let y:int128 = word_subword xy (  0, 128) in
+
+          let xy:256 word = sha256hash_loop 1 x y w in
+          let x:int128 = word_subword xy (128, 128) in
+          let y:int128 = word_subword xy (  0, 128) in
+
+          let xy:256 word = sha256hash_loop 2 x y w in
+          let x:int128 = word_subword xy (128, 128) in
+          let y:int128 = word_subword xy (  0, 128) in
+
+          let xy:256 word = sha256hash_loop 3 x y w in
+          let x:int128 = word_subword xy (128, 128) in
+          let y:int128 = word_subword xy (  0, 128) in
+
+          if part1 then x else y`;;
+
+
+(*************************)
+(**                     **)
+(**  SHA256 INTRINSICS  **)
+(**                     **)
+(*************************)
+
+let sha256h = define
+  `sha256h (d:int128) (n:int128) (m:int128) : int128 =
+          sha256hash d n m T`;;
+
+let sha256h2 = define
+  `sha256h2 (d:int128) (n:int128) (m:int128) : int128 =
+          sha256hash n d m F`;;
+
+(**
+ **  ARM pseudocode of sha256su0
+ **  
+ **    bits(128) operand1 = V[d];
+ **    bits(128) operand2 = V[n];
+ **    bits(128) result;
+ **    bits(128) T = operand2<31:0>:operand1<127:32>;
+ **    bits(32) elt;
+ **    
+ **    for e = 0 to 3
+ **        elt = Elem[T, e, 32];
+ **        elt = ROR(elt, 7) EOR ROR(elt, 18) EOR LSR(elt, 3);
+ **        Elem[result, e, 32] = elt + Elem[operand1, e, 32];
+ **    V[d] = result;
+ **  
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA256SU0--SHA256-schedule-update-0-
+ **)
+
+let sha256su0_loop = define
+  `sha256su0_loop (e:num) (t:int128) (d:int128) : int32 =
+          let elt0 = elem t e 32 in
+          let elt1 = word_xor (word_ror elt0 7)
+                              (word_xor (word_ror elt0 18)
+                                        (word_ushr elt0 3)) in
+          word_add elt1 (elem d e 32)`;;
+
+let sha256su0 = define
+  `sha256su0 (d:int128) (n:int128) : int128 =
+          let t = (word_join:int32->96 word->int128)
+                  (word_subword n (0, 32))
+                  (word_subword d (32, 96)) in
+          let seq0 = sha256su0_loop 0 t d in
+          let seq1 = sha256su0_loop 1 t d in
+          let seq2 = sha256su0_loop 2 t d in
+          let seq3 = sha256su0_loop 3 t d in
+          (word_join:32 word->96 word-> 128 word)
+            seq3
+            ((word_join:32 word->64 word->96 word)
+               seq2
+               ((word_join:32 word->32 word->64 word)
+                  seq1
+                  seq0))`;;
+
+(**  
+ **  ARM SHA256SU1 pseudocode
+ ** 
+ **    Operation
+ **    
+ **    AArch64.CheckFPAdvSIMDEnabled();
+ **    
+ **    bits(128) operand1 = V[d];
+ **    bits(128) operand2 = V[n];
+ **    bits(128) operand3 = V[m];
+ **    bits(128) result;
+ **    bits(128) T0 = operand3<31:0>:operand2<127:32>;
+ **    bits(64) T1;
+ **    bits(32) elt;
+ **    
+ **    T1 = operand3<127:64>;
+ **    for e = 0 to 1
+ **        elt = Elem[T1, e, 32];
+ **        elt = ROR(elt, 17) EOR ROR(elt, 19) EOR LSR(elt, 10);
+ **        elt = elt + Elem[operand1, e, 32] + Elem[T0, e, 32];
+ **        Elem[result, e, 32] = elt;
+ **    
+ **    T1 = result<63:0>;
+ **    for e = 2 to 3
+ **        elt = Elem[T1, e-2, 32];
+ **        elt = ROR(elt, 17) EOR ROR(elt, 19) EOR LSR(elt, 10);
+ **        elt = elt + Elem[operand1, e, 32] + Elem[T0, e, 32];
+ **        Elem[result, e, 32] = elt;
+ **    
+ **    V[d] = result;
+ ** 
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA256SU1--SHA256-schedule-update-1-
+ ** 
+ **)
+
+let sha256su1_loop0 = define
+  `sha256su1_loop0 (e:num) (d:128 word) (t0:128 word) (t1:64 word) : 32 word =
+          let elt0 : 32 word = elem t1 e 32 in
+          let elt1 : 32 word = word_xor (word_ror elt0 17)
+                              (word_xor (word_ror elt0 19)
+                                        (word_ushr elt0 10)) in
+          let elt2 : 32 word = word_add elt1 (word_add (elem d e 32) (elem t0 e 32)) in
+          elt2`;;
+
+let sha256su1_loop1 = define
+  `sha256su1_loop1 (e:num) (d:128 word) (t0:128 word) (t1:64 word) : 32 word =
+          let elt0 : 32 word = elem t1 (e - 2) 32 in
+          let elt1 : 32 word = word_xor (word_ror elt0 17)
+                                        (word_xor (word_ror elt0 19)
+                                                  (word_ushr elt0 10)) in
+          let elt2 : 32 word = word_add elt1 (word_add (elem d e 32) (elem t0 e 32)) in
+          elt2`;;
+
+let sha256su1 = define
+  `sha256su1 (d:128 word) (n:128 word) (m:128 word) : 128 word =
+          let t0   : 128 word = (word_join:32 word->96 word->128 word)
+                                (word_subword m (0, 32))
+                                (word_subword n (32, 96)) in
+          let t1   :  64 word = word_subword m (64, 64) in
+          let seq0 :  32 word = sha256su1_loop0 0 d t0 t1 in
+          let seq1 :  32 word = sha256su1_loop0 1 d t0 t1 in
+          let t1   :  64 word = (word_join:32 word->32 word->64 word) seq1 seq0 in
+          let seq2 :  32 word = sha256su1_loop1 2 d t0 t1 in
+          let seq3 :  32 word = sha256su1_loop1 3 d t0 t1 in
+          (word_join:32 word->96 word->128 word)
+            seq3
+            ((word_join:32 word->64 word->96 word)
+               seq2
+               ((word_join:32 word->32 word->64 word)
+                  seq1
+                  seq0))`;;
+
+(************************************************) 
+(**                                            **)
+(** CONVERSIONS FOR REDUCING SHA256 INTRINSICS **)
+(**                                            **)
+(************************************************)
+
+(** Reduce template for common functions**)
+let SHA_COMMON_REDUCE func =
+        REWR_CONV func THENC
+        DEPTH_CONV (WORD_RED_CONV ORELSEC NUM_RED_CONV);;
+
+let CHOOSE_REDUCE = SHA_COMMON_REDUCE sha_choose ;;
+let MAJ_REDUCE    = SHA_COMMON_REDUCE sha_maj ;;
+let SIGMA0_REDUCE = SHA_COMMON_REDUCE sha_hash_sigma_0 ;;
+let SIGMA1_REDUCE = SHA_COMMON_REDUCE sha_hash_sigma_1 ;;
+let ELEM_REDUCE   = SHA_COMMON_REDUCE elem ;;
+
+let BASE_REDUCE =
+        MAJ_REDUCE ORELSEC
+        CHOOSE_REDUCE ORELSEC
+        SIGMA0_REDUCE ORELSEC
+        SIGMA1_REDUCE ORELSEC
+        ELEM_REDUCE;;
+
+(** 
+ ** Reduce "let x = e in f" by first reducing "e" via conv
+ ** and then expanding the let-term (assuming not "let ... and ... in",
+ ** which would need a more elaborate implementation)
+ **)
+let REDUCE_SUBLET_CONV conv tm =
+  if is_let tm then (RAND_CONV conv THENC let_CONV) tm
+  else failwith "REDUCE_SUBLET_CONV: not a toplevel let-term";;
+
+(** Now use that to reduce the sha256_hash_loop function **)
+let REDUCE_LOOP =
+    REWR_CONV sha256hash_loop THENC
+    DEPTH_CONV (let_CONV ORELSEC BASE_REDUCE ORELSEC NUM_RED_CONV ) THENC
+    WORD_REDUCE_CONV;;
+
+let HASH_REDUCE  =
+    REWR_CONV sha256hash THENC
+    REPEATC (REDUCE_SUBLET_CONV (REDUCE_LOOP ORELSEC WORD_RED_CONV ORELSEC BASE_REDUCE)) THENC
+    ONCE_SIMP_CONV [];;
+
+let REDUCE_SU0_LOOP =
+    REWR_CONV sha256su0_loop THENC
+    DEPTH_CONV (let_CONV ORELSEC BASE_REDUCE ) THENC
+    WORD_REDUCE_CONV;;
+
+let SHA256SU0_RED_CONV =
+    REWR_CONV sha256su0 THENC
+    DEPTH_CONV (let_CONV ORELSEC REDUCE_SU0_LOOP ORELSEC NUM_RED_CONV) THENC
+    WORD_REDUCE_CONV;;
+
+let SHA256SU0_REDUCE_CONV tm = 
+  match tm with 
+    Comb(Comb(Const("sha256su0",_),Comb(Const("word",_),d)), 
+         Comb(Const("word",_),n)) 
+    when is_numeral d && is_numeral n -> SHA256SU0_RED_CONV tm 
+  | _ -> failwith "SHA256SU0_CONV: inapplicable";; 
+
+let REDUCE_SU1_LOOP0 =
+    REWR_CONV sha256su1_loop0 THENC
+    DEPTH_CONV (let_CONV ORELSEC BASE_REDUCE ) THENC
+    WORD_REDUCE_CONV;;
+
+let REDUCE_SU1_LOOP1 =
+    REWR_CONV sha256su1_loop1 THENC
+    DEPTH_CONV (let_CONV ORELSEC BASE_REDUCE ) THENC
+    WORD_REDUCE_CONV;;
+
+let SHA256SU1_RED_CONV =
+    REWR_CONV sha256su1 THENC
+    DEPTH_CONV (let_CONV ORELSEC
+                REDUCE_SU1_LOOP0 ORELSEC
+                REDUCE_SU1_LOOP1) THENC
+    WORD_REDUCE_CONV;;
+
+let SHA256SU1_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha256su1",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA256SU1_RED_CONV tm
+    | _ -> failwith "SHA256SU1_CONV: inapplicable";;
+
+let SHA256H_RED_CONV =
+        REWR_CONV sha256h THENC HASH_REDUCE;;
+
+let SHA256H_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha256h",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA256H_RED_CONV tm
+    | _ -> failwith "SHA256H_CONV: inapplicable";;
+
+let SHA256H2_RED_CONV =
+        REWR_CONV sha256h2 THENC HASH_REDUCE;;
+
+let SHA256H2_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha256h2",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA256H2_RED_CONV tm
+    | _ -> failwith "SHA256H2_CONV: inapplicable";;
+

--- a/arm/proofs/sha512.ml
+++ b/arm/proofs/sha512.ml
@@ -1,0 +1,274 @@
+(** Carl Kwan: ARM SHA512 intrinsics in HOL Light **)
+
+needs "Library/words.ml";;
+
+(*************************)
+(**                     **)
+(**  SHA512 INTRINSICS  **)
+(**                     **)
+(*************************)
+
+(**
+ **  ARM pseudocode of sha512h
+ **
+ **    AArch64.CheckFPAdvSIMDEnabled();
+ **
+ **    bits(128) Vtmp;
+ **    bits(64) MSigma1;
+ **    bits(64) tmp;
+ **    bits(128) X = V[n];
+ **    bits(128) Y = V[m];
+ **    bits(128) W = V[d];
+ **    
+ **    MSigma1 = ROR(Y<127:64>, 14) EOR ROR(Y<127:64>, 18) EOR ROR(Y<127:64>, 41);
+ **    Vtmp<127:64> = (Y<127:64> AND X<63:0>) EOR (NOT(Y<127:64>) AND X<127:64>);
+ **    Vtmp<127:64> = (Vtmp<127:64> + MSigma1 + W<127:64>);
+ **    tmp = Vtmp<127:64> + Y<63:0>;
+ **    MSigma1 = ROR(tmp, 14) EOR ROR(tmp, 18) EOR ROR(tmp, 41);
+ **    Vtmp<63:0> = (tmp AND Y<127:64>) EOR (NOT(tmp) AND X<63:0>);
+ **    Vtmp<63:0> = (Vtmp<63:0> + MSigma1 + W<63:0>);
+ **    V[d] = Vtmp;
+ **
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA512H--SHA512-Hash-update-part-1-
+ **)
+
+let sha512h = define
+  `sha512h (d:int128) (n:int128) (m:int128) : int128 =
+          let x = n in
+          let y = m in
+          let w = d in
+          let msig1 : 64 word = word_xor (word_ror (word_subword y (64, 64)) 14)
+                                         (word_xor (word_ror (word_subword y (64, 64)) 18)
+                                                   (word_ror (word_subword y (64, 64)) 41)) in
+
+          let vtmp1 : 64 word = word_xor (word_and (word_subword y (64, 64))
+                                                   (word_subword x ( 0, 64)))
+                                         (word_and (word_not (word_subword y (64, 64)))
+                                                   (word_subword x (64, 64))) in
+          let vtmp1 : 64 word = word_add vtmp1
+                                         (word_add msig1
+                                                   (word_subword w (64, 64))) in
+
+          let tmp   : 64 word = word_add vtmp1 (word_subword y ( 0, 64)) in
+
+          let msig1 : 64 word = word_xor (word_ror tmp 14) 
+                                         (word_xor (word_ror tmp 18)
+                                                   (word_ror tmp 41)) in
+
+          let vtmp0 : 64 word = word_xor (word_and tmp (word_subword y (64, 64)))
+                                         (word_and (word_not tmp) (word_subword x ( 0, 64))) in
+          let vtmp0 : 64 word = word_add vtmp0 
+                                         (word_add msig1 
+                                                   (word_subword w ( 0, 64))) in
+
+          (word_join:64 word->64 word->128 word) vtmp1 vtmp0`;;
+
+(**
+ **  ARM pseudocode of sha512h2
+ **
+ **    AArch64.CheckFPAdvSIMDEnabled();
+ **    
+ **    bits(128) Vtmp;
+ **    bits(64) NSigma0;
+ **    bits(128) X = V[n];
+ **    bits(128) Y = V[m];
+ **    bits(128) W = V[d];
+ **    
+ **    NSigma0 = ROR(Y<63:0>, 28) EOR ROR(Y<63:0>, 34) EOR ROR(Y<63:0>, 39);
+ **    Vtmp<127:64> = (X<63:0> AND Y<127:64>) EOR (X<63:0> AND Y<63:0>) EOR (Y<127:64> AND Y<63:0>);
+ **    Vtmp<127:64> = (Vtmp<127:64> + NSigma0 + W<127:64>);
+ **    NSigma0 = ROR(Vtmp<127:64>, 28) EOR ROR(Vtmp<127:64>, 34) EOR ROR(Vtmp<127:64>, 39);
+ **    Vtmp<63:0> = (Vtmp<127:64> AND Y<63:0>) EOR (Vtmp<127:64> AND Y<127:64>) EOR (Y<127:64> AND Y<63:0>);
+ **    Vtmp<63:0> = (Vtmp<63:0> + NSigma0 + W<63:0>);
+ **    
+ **    V[d] = Vtmp;
+ **
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA512H2--SHA512-Hash-update-part-2-
+ **)
+
+let sha512h2 = define
+  `sha512h2 (d:int128) (n:int128) (m:int128) : int128 =
+          let x = n in
+          let y = m in
+          let w = d in
+          let nsig0 : 64 word = word_xor (word_ror (word_subword y ( 0, 64)) 28)
+                                         (word_xor (word_ror (word_subword y ( 0, 64)) 34)
+                                                   (word_ror (word_subword y ( 0, 64)) 39)) in
+
+          let vtmp1 : 64 word = word_xor (word_and (word_subword x ( 0, 64))
+                                                   (word_subword y (64, 64)))
+                                         (word_xor (word_and (word_subword x ( 0, 64))
+                                                             (word_subword y ( 0, 64)))
+                                                   (word_and (word_subword y (64, 64))
+                                                             (word_subword y ( 0, 64)))) in
+          let vtmp1 : 64 word = word_add vtmp1
+                                         (word_add nsig0
+                                                   (word_subword w (64, 64))) in
+
+
+          let nsig0 : 64 word = word_xor (word_ror vtmp1 28) 
+                                         (word_xor (word_ror vtmp1 34)
+                                                   (word_ror vtmp1 39)) in
+
+          let vtmp0 : 64 word = word_xor (word_and vtmp1 (word_subword y ( 0, 64)))
+                                         (word_xor (word_and vtmp1
+                                                             (word_subword y (64, 64)))
+                                                   (word_and (word_subword y (64, 64))
+                                                             (word_subword y ( 0, 64)))) in
+          let vtmp0 : 64 word = word_add vtmp0 
+                                         (word_add nsig0
+                                                   (word_subword w ( 0, 64))) in
+
+          (word_join:64 word->64 word->128 word) vtmp1 vtmp0`;;
+
+(**
+ **  ARM pseudocode of sha512su0
+ **  
+ **    AArch64.CheckFPAdvSIMDEnabled();
+ **  
+ **    bits(64) sig0;
+ **    bits(128) Vtmp;
+ **    bits(128) X = V[n];
+ **    bits(128) W = V[d];
+ **    sig0 = ROR(W<127:64>, 1) EOR ROR(W<127:64>, 8) EOR ('0000000':W<127:71>);
+ **    Vtmp<63:0> = W<63:0> + sig0;
+ **    sig0 = ROR(X<63:0>, 1) EOR ROR(X<63:0>, 8) EOR ('0000000':X<63:7>);
+ **    Vtmp<127:64> = W<127:64> + sig0;
+ **    V[d] = Vtmp;
+ **  
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA512SU0--SHA512-Schedule-Update-0-
+ **)
+
+let sha512su0 = define
+  `sha512su0 (d:int128) (n:int128) : int128 = 
+          let w = d in
+          let x = n in
+          let sig0 : 64 word = word_xor (word_ror (word_subword w (64, 64)) 1)
+                                        (word_xor (word_ror (word_subword w (64, 64)) 8)
+                                                  ((word_join:7 word->57 word->64 word)  
+                                                   (word 0 : 7 word)
+                                                   (word_subword w (71, 57)))) in
+          let tmp0 : 64 word = word_add (word_subword w (0, 64)) sig0 in
+
+          let sig0 : 64 word = word_xor (word_ror (word_subword x (0, 64)) 1)
+                                        (word_xor (word_ror (word_subword x ( 0, 64)) 8)
+                                                  ((word_join:7 word->57 word->64 word)
+                                                   (word 0 : 7 word)
+                                                   (word_subword x (7, 57)))) in
+
+          let tmp1 : 64 word = word_add (word_subword w (64, 64)) sig0 in
+
+          (word_join:64 word->64 word->128 word) tmp1 tmp0`;;
+
+(**
+ **  ARM pseudocode of sha512su1
+ **  
+ **    AArch64.CheckFPAdvSIMDEnabled();
+ **    
+ **    bits(64) sig1;
+ **    bits(128) Vtmp;
+ **    bits(128) X = V[n];
+ **    bits(128) Y = V[m];
+ **    bits(128) W = V[d];
+ **    
+ **    sig1 = ROR(X<127:64>, 19) EOR ROR(X<127:64>, 61) EOR ('000000':X<127:70>);
+ **    Vtmp<127:64> = W<127:64> + sig1 + Y<127:64>;
+ **    sig1 = ROR(X<63:0>, 19) EOR ROR(X<63:0>, 61) EOR ('000000':X<63:6>);
+ **    Vtmp<63:0> = W<63:0> + sig1 + Y<63:0>;
+ **    V[d] = Vtmp;
+ **
+ **  See 
+ **    https://developer.arm.com/documentation/ddi0596/2020-12/SIMD-FP-Instructions/SHA512SU1--SHA512-Schedule-Update-1-
+ **)
+
+let sha512su1 = define
+  `sha512su1 (d:int128) (n:int128) (m:int128) : int128 = 
+          let x = n in
+          let y = m in
+          let w = d in
+          let sig1 : 64 word = word_xor (word_ror (word_subword x (64, 64)) 19)
+                                        (word_xor (word_ror (word_subword x (64, 64)) 61)
+                                                  ((word_join:6 word->58 word->64 word)  
+                                                   (word 0 : 6 word)
+                                                   (word_subword x (70, 58)))) in
+
+          let tmp1 : 64 word = word_add (word_subword w (64, 64))
+                                        (word_add sig1
+                                                  (word_subword y (64, 64))) in
+
+          let sig1 : 64 word = word_xor (word_ror (word_subword x (0, 64)) 19)
+                                        (word_xor (word_ror (word_subword x ( 0, 64)) 61)
+                                                  ((word_join:6 word->58 word->64 word)
+                                                   (word 0 : 6 word)
+                                                   (word_subword x (6, 58)))) in
+
+          let tmp0 : 64 word = word_add (word_subword w ( 0, 64))
+                                        (word_add sig1
+                                                  (word_subword y ( 0, 64))) in
+
+          (word_join:64 word->64 word->128 word) tmp1 tmp0`;;
+
+
+(************************************************) 
+(**                                            **)
+(** CONVERSIONS FOR REDUCING SHA512 INTRINSICS **)
+(**                                            **)
+(************************************************)
+
+let SHA512H_RED_CONV = 
+        REWR_CONV sha512h THENC
+        DEPTH_CONV (let_CONV) THENC
+        WORD_REDUCE_CONV;;
+
+let SHA512H_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha512h",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA512H_RED_CONV tm
+    | _ -> failwith "SHA512H_CONV: inapplicable";;
+
+let SHA512H2_RED_CONV = 
+        REWR_CONV sha512h2 THENC
+        DEPTH_CONV (let_CONV) THENC
+        WORD_REDUCE_CONV;;
+
+let SHA512H2_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha512h2",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA512H2_RED_CONV tm
+    | _ -> failwith "SHA512H2_CONV: inapplicable";;
+
+let SHA512SU0_RED_CONV = 
+        REWR_CONV sha512su0 THENC
+        DEPTH_CONV (let_CONV) THENC
+        WORD_REDUCE_CONV;;
+
+let SHA512SU0_REDUCE_CONV tm =
+  match tm with
+    Comb(Comb(Const("sha512su0",_),Comb(Const("word",_),d)),
+         Comb(Const("word",_),n))
+    when is_numeral d && is_numeral n -> SHA512SU0_RED_CONV tm
+  | _ -> failwith "SHA512SU0_CONV: inapplicable";;
+
+let SHA512SU1_RED_CONV = 
+        REWR_CONV sha512su1 THENC
+        DEPTH_CONV (let_CONV) THENC
+        WORD_REDUCE_CONV;;
+
+let SHA512SU1_REDUCE_CONV tm =
+      match tm with
+        Comb(Comb(Comb(Const("sha512su1",_),
+                  Comb(Const("word",_),d)),
+                  Comb(Const("word",_),n)),
+                  Comb(Const("word",_),m))
+      when is_numeral d && is_numeral n && is_numeral m -> SHA512SU1_RED_CONV tm
+    | _ -> failwith "SHA512SU1_CONV: inapplicable";;
+

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -178,6 +178,32 @@ let iclasses =
   "010011100x100000000010xxxxxxxxxx"; (* .h, .b *)
   "0100111010100000000010xxxxxxxxxx"; (* .s *)
 
+  (*** SHA256 Intrinsics ***)
+  (*** SHA256H ***)
+  "01011110000xxxxx010000xxxxxxxxxx"; 
+
+  (*** SHA256H2 ***)
+  "01011110000xxxxx010100xxxxxxxxxx";
+
+  (*** SHA256SU0 ***)
+  "0101111000101000001010xxxxxxxxxx";
+
+  (*** SHA256SU1 ***)
+  "01011110000xxxxx011000xxxxxxxxxx";
+
+  (*** SHA512 Intrinsics 
+  (*** SHA512H ***)
+  "11001110011xxxxx100000xxxxxxxxxx";
+
+  (*** SHA512H2 ***)
+  "11001110011xxxxx100001xxxxxxxxxx";
+
+  (*** SHA512SU0 ***)
+  "1100111011000000100000xxxxxxxxxx";
+
+  (*** SHA512SU1 ***)
+  "11001110011xxxxx100010xxxxxxxxxx";***)
+
   (*** SHL ***)
   "01001111001xxxxx010101xxxxxxxxxx"; (* .s *)
   "0100111101xxxxxx010101xxxxxxxxxx"; (* .d *)

--- a/common/misc.ml
+++ b/common/misc.ml
@@ -1081,6 +1081,12 @@ let (WORD_FORALL_OFFSET_TAC:int->tactic) =
 (* Do some limited simplification in association with symbolic execution.    *)
 (* ------------------------------------------------------------------------- *)
 
+(* Ocaml reference variable for platform specific conversions *)
+let extra_word_CONV = ref [NO_CONV];;
+
+(* Delay introduction of extra conversions *)
+let apply_extra_word_convs tm = FIRST_CONV (!extra_word_CONV) tm;;
+
 let ASSEMBLER_SIMPLIFY_TAC =
   let pth = prove
    (`!a b. a < a + bitval b <=> b`,
@@ -1096,6 +1102,7 @@ let ASSEMBLER_SIMPLIFY_TAC =
     DEPTH_CONV
      (GEN_REWRITE_CONV I [BITVAL_CLAUSES] ORELSEC
       WORD_RED_CONV ORELSEC
+      apply_extra_word_convs ORELSEC
       NORMALIZE_ADD_SUBTRACT_WORD_CONV ORELSEC
       NUM_RED_CONV ORELSEC
       INT_RED_CONV) THENC


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding new sha256.ml and sha512.ml files for definitions and conversions related to SHA256 and SHA512 intrinsics, respectively. Modified misc.ml in common/ and base.ml, decode.ml, instruction.ml, simulator.ml in arm/proofs/ to support simulation of SHA intrinsics on ARM model. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
