### PR TITLE
Add support for UZP2, XTN

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -430,11 +430,25 @@ let decode = new_definition `!w:int32. decode w =
       SOME (arm_UMULL_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) esize)
 
   | [0:1; q; 0b001110:6; size:2; 0b0:1; Rm:5; 0b000110:6; Rn:5; Rd:5] ->
-    // UZIP1
+    // UZP1
     if ~q then NONE // datasize = 64 is unsupported yet
     else
       let esize: (64)word = word_shl (word 8: (64)word) (val size) in
       SOME (arm_UZP1 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
+  | [0:1; q; 0b001110:6; size:2; 0b0:1; Rm:5; 0b010110:6; Rn:5; Rd:5] ->
+    // UZP2
+    if ~q then NONE // datasize = 64 is unsupported yet
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      SOME (arm_UZP2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
+  | [0:1; 0:1; 0b001110:6; size:2; 0b100001001010:12; Rn:5; Rd:5] ->
+    // XTN
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      SOME (arm_XTN (QREG' Rd) (QREG' Rn) (val esize))
 
   | [0:1; q; 0b001110:6; size:2; 0:1; Rm:5; 0b001110:6; Rn:5; Rd:5] ->
     // ZIP1

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1307,6 +1307,40 @@ let arm_UZP1 = define
           let meven:(64)word = usimd8 (\x. word_subword x (0,8): (8)word) m in
           (Rd := (word_join meven neven:(128)word)) s`;;
 
+let arm_UZP2 = define
+ `arm_UZP2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        if esize = 64 then
+          let nodd:(64)word = word_subword n (64,64) in
+          let modd:(64)word = word_subword m (64,64) in
+          (Rd := (word_join modd nodd:(128)word)) s
+        else if esize = 32 then
+          let nodd:(64)word = usimd2 (\x. word_subword x (32,32): (32)word) n in
+          let modd:(64)word = usimd2 (\x. word_subword x (32,32): (32)word) m in
+          (Rd := (word_join modd nodd:(128)word)) s
+        else if esize = 16 then
+          let nodd:(64)word = usimd4 (\x. word_subword x (16,16): (16)word) n in
+          let modd:(64)word = usimd4 (\x. word_subword x (16,16): (16)word) m in
+          (Rd := (word_join modd nodd:(128)word)) s
+        else // esize=8
+          let nodd:(64)word = usimd8 (\x. word_subword x (8,8): (8)word) n in
+          let modd:(64)word = usimd8 (\x. word_subword x (8,8): (8)word) m in
+          (Rd := (word_join modd nodd:(128)word)) s`;;
+
+let arm_XTN = define
+ `arm_XTN Rd Rn esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        if esize = 32 then
+          let nlow:(64)word = usimd2 (\x. word_subword x (0,32): (32)word) n in
+          (Rd := (word_zx nlow:(128)word)) s
+        else if esize = 16 then
+          let nlow:(64)word = usimd4 (\x. word_subword x (0,16): (16)word) n in
+          (Rd := (word_zx nlow:(128)word)) s
+        else // esize=8
+          let nlow:(64)word = usimd8 (\x. word_subword x (0,8): (8)word) n in
+          (Rd := (word_zx nlow:(128)word)) s`;;
+
 
 let word_split_lohi = new_definition
  `(word_split_lohi:(N tybit0)word->((N)word # (N)word)) x =
@@ -1855,6 +1889,8 @@ let arm_UMLAL_VEC_ALT = REWRITE_RULE all_simd_rules arm_UMLAL_VEC;;
 let arm_UMULL_VEC_ALT = REWRITE_RULE all_simd_rules arm_UMULL_VEC;;
 let arm_USRA_VEC_ALT =  REWRITE_RULE all_simd_rules arm_USRA_VEC;;
 let arm_UZP1_ALT =      REWRITE_RULE all_simd_rules arm_UZP1;;
+let arm_UZP2_ALT =      REWRITE_RULE all_simd_rules arm_UZP2;;
+let arm_XTN_ALT =       REWRITE_RULE all_simd_rules arm_XTN;;
 let arm_ZIP1_ALT =      REWRITE_RULE all_simd_rules arm_ZIP1;;
 
 (* ------------------------------------------------------------------------- *)
@@ -1881,6 +1917,8 @@ let ARM_OPERATION_CLAUSES =
        arm_SLI_VEC_ALT; arm_SUB; arm_SUBS_ALT;
        arm_UADDLP_ALT; arm_UBFM; arm_UMOV; arm_UMADDL; arm_UMLAL_VEC_ALT;
        arm_UMSUBL; arm_UMULL_VEC_ALT; arm_UMULH; arm_USRA_VEC_ALT; arm_UZP1_ALT;
+       arm_UZP2_ALT;
+       arm_XTN_ALT;
        arm_ZIP1_ALT;
     (*** 32-bit backups since the ALT forms are 64-bit only ***)
        INST_TYPE[`:32`,`:N`] arm_ADCS;

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -224,6 +224,13 @@ let iclasses =
   (*** UZP1 ***)
   "01001110xx0xxxxx000110xxxxxxxxxx";
 
+  (*** UZP2 ***)
+  "01001110xx0xxxxx010110xxxxxxxxxx"; (* q=1 *)
+
+  (*** XTN ***)
+  "000011100x100001001010xxxxxxxxxx"; (* size!=11 *)
+  "0000111010100001001010xxxxxxxxxx"; (* size!=11 *)
+
   (*** ZIP1 ***)
   "01001110xx0xxxxx001110xxxxxxxxxx"; (* q=1 *)
   "000011100x0xxxxx001110xxxxxxxxxx"; (* q=0, size!=3 *)


### PR DESCRIPTION
*Description of changes:*

This PR adds formalization of two more NEON instructions - UZP2 and XTN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
