### PR TITLE
Add s2n-bignum-x86-sematests build project to CI

### DIFF
--- a/codebuild/cloudformation.yml
+++ b/codebuild/cloudformation.yml
@@ -85,6 +85,72 @@ Resources:
           Status: "DISABLED"
           EncryptionDisabled: false
 
+  CodeBuildProjectX86SemaTests:
+    Type: "AWS::CodeBuild::Project"
+    Properties:
+      Name: !Sub ${ProjectName}-x86-sematests
+      Description: !Ref ProjectDescription
+      Source:
+        Location: !Ref SourceLocation
+        BuildSpec: codebuild/sematests.yml
+        GitCloneDepth: 1
+        GitSubmodulesConfig:
+          FetchSubmodules: true
+        InsecureSsl: false
+        ReportBuildStatus: true
+        Type: "GITHUB"
+      SecondarySources:
+        -
+          Type: "GITHUB"
+          Location: https://github.com/jrh13/hol-light
+          ReportBuildStatus: false
+          SourceIdentifier: hol_light
+      Artifacts:
+        Type: "NO_ARTIFACTS"
+      Cache:
+        Type: "NO_CACHE"
+      Environment:
+        ComputeType: "BUILD_GENERAL1_LARGE"
+        Image: "aws/codebuild/amazonlinux2-x86_64-standard:4.0"
+        ImagePullCredentialsType: "CODEBUILD"
+        PrivilegedMode: false
+        Type: "LINUX_CONTAINER"
+        EnvironmentVariables:
+          - Name: S2N_BIGNUM_ARCH
+            Type: PLAINTEXT
+            Value: x86
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      EncryptionKey: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/s3"
+      BadgeEnabled: true
+      Triggers:
+        Webhook: true
+        BuildType: "BUILD"
+        FilterGroups:
+          - - Type: EVENT # Standard builds
+              Pattern: PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED
+            - Type: BASE_REF
+              Pattern: ^refs/heads/main$
+              ExcludeMatchedPattern: false
+            - Type: FILE_PATH # Don't allow arbitrary users to change build configuration
+              Pattern: codebuild
+              ExcludeMatchedPattern: true
+          - - Type: EVENT # Builds which change build configuration are restricted
+              Pattern: PULL_REQUEST_CREATED,PULL_REQUEST_UPDATED
+            - Type: BASE_REF
+              Pattern: ^refs/heads/main$
+              ExcludeMatchedPattern: false
+            - Type: FILE_PATH # Don't allow arbitrary users to change build configuration
+              Pattern: codebuild
+              ExcludeMatchedPattern: false
+      LogsConfig:
+        CloudWatchLogs:
+          Status: "ENABLED"
+        S3Logs:
+          Status: "DISABLED"
+          EncryptionDisabled: false
+
   CodeBuildProjectArmTests:
     Type: "AWS::CodeBuild::Project"
     Properties:


### PR DESCRIPTION
*Description of changes:*

This patch adds a new build project to CI.

This is supposed to run a random simulator for x86 that @jargh has implemented. I will make a follow-up PR that invokes it after this new CI is incorporated smoothly.
At the moment, this build only runs an empty Makefile target `sematest`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
