### PR TITLE
Make bignum_emontredc_8n's spec equal to its neon version

### DIFF
--- a/arm/fastmul/bignum_mul_8_16_neon.S
+++ b/arm/fastmul/bignum_mul_8_16_neon.S
@@ -1,3 +1,15 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0 OR ISC
+
+// ----------------------------------------------------------------------------
+// Multiply z := x * y
+// Inputs x[8], y[8]; output z[16]
+//
+//    extern void bignum_mul_8_16_neon
+//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//
+// Standard ARM ABI: X0 = z, X1 = x, X2 = y
+// ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_mul_8_16_neon)

--- a/arm/proofs/bignum_emontredc_8n.ml
+++ b/arm/proofs/bignum_emontredc_8n.ml
@@ -331,7 +331,8 @@ let lemma2 = prove
 let BIGNUM_EMONTREDC_8N_CORRECT = time prove
  (`!k z m w a n pc.
         nonoverlapping (word pc,0x400) (z,8 * 2 * val k) /\
-        nonoverlapping (m,8 * val k) (z,8 * 2 * val k)
+        nonoverlapping (m,8 * val k) (z,8 * 2 * val k) /\
+        8 divides val k
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_emontredc_8n_mc /\
                 read PC s = word(pc + 0x14) /\
@@ -339,8 +340,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
                 bignum_from_memory (z,2 * val k) s = a /\
                 bignum_from_memory (m,val k) s = n)
            (\s. read PC s = word(pc + 0x3e8) /\
-                (8 divides val k /\
-                 (n * val w + 1 == 0) (mod (2 EXP 64))
+                ((n * val w + 1 == 0) (mod (2 EXP 64))
                  ==> n * bignum_from_memory (z,val k) s + a =
                      2 EXP (64 * val k) *
                      (2 EXP (64 * val k) * val(C_RETURN s) +
@@ -367,6 +367,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
   ASM_CASES_TAC `k4 = 0` THENL
    [UNDISCH_THEN `k4 = 0` SUBST_ALL_TAC THEN
     ARM_SIM_TAC BIGNUM_EMONTREDC_8N_EXEC (1--4) THEN
+    UNDISCH_TAC `8 divides k` THEN
     ASM_REWRITE_TAC[VAL_WORD_USHR; NUM_REDUCE_CONV `2 EXP 2`] THEN
     ASM_REWRITE_TAC[DIVIDES_DIV_MULT; MULT_CLAUSES; ARITH_RULE `0 < 1`;
                     DIV_0; ARITH_RULE `k DIV 8 = k DIV 4 DIV 2`] THEN
@@ -413,6 +414,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
   CONJ_TAC THENL
    [ALL_TAC;
     ARM_SIM_TAC BIGNUM_EMONTREDC_8N_EXEC [] THEN REWRITE_TAC[IMP_CONJ] THEN
+    UNDISCH_TAC `8 divides k` THEN
     DISCH_THEN(MP_TAC o SPEC `4` o MATCH_MP (NUMBER_RULE
      `y divides a ==> !x:num. x divides y ==> x divides a`)) THEN
     ANTS_TAC THENL [CONV_TAC DIVIDES_CONV; ALL_TAC] THEN
@@ -1183,11 +1185,12 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
 let BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
  (`!k z m w a n pc stackpointer returnaddress.
         aligned 16 stackpointer /\
-        nonoverlapping (z,8 * 2 * val k)
-                       (word_sub stackpointer (word 80),80) /\
         ALLPAIRS nonoverlapping
          [(z,8 * 2 * val k); (word_sub stackpointer (word 80),80)]
-         [(word pc,0x400); (m,8 * val k)]
+         [(word pc,0x400); (m,8 * val k)] /\
+        nonoverlapping (z,8 * 2 * val k)
+                       (word_sub stackpointer (word 80),80) /\
+        8 divides val k
         ==> ensures arm
              (\s. aligned_bytes_loaded s (word pc) bignum_emontredc_8n_mc /\
                   read PC s = word pc /\
@@ -1197,8 +1200,7 @@ let BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
                   bignum_from_memory (z,2 * val k) s = a /\
                   bignum_from_memory (m,val k) s = n)
              (\s. read PC s = returnaddress /\
-                  (8 divides val k /\
-                   (n * val w + 1 == 0) (mod (2 EXP 64))
+                  ((n * val w + 1 == 0) (mod (2 EXP 64))
                    ==> n * bignum_from_memory (z,val k) s + a =
                        2 EXP (64 * val k) *
                        (2 EXP (64 * val k) * val(C_RETURN s) +

--- a/arm/proofs/bignum_kmul_16_32_neon.ml
+++ b/arm/proofs/bignum_kmul_16_32_neon.ml
@@ -779,131 +779,14 @@ let lemma2 = prove
   ASM_SIMP_TAC[VAL_WORD_SUB_CASES; GSYM REAL_OF_NUM_SUB] THEN
   REAL_ARITH_TAC);;
 
-
-(* A lemma that is useful for extracting a 32-bit field from a 128-bit word. *)
-let WORD_128_SUBWORD_SUBWORD_32 = prove(`!y.
-      word_subword (word_subword (y:(128)word) (0,64):(64)word) (0,32):(32)word =
-        word_subword (y:(128)word) (0,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (64,64):(64)word) (0,32):(32)word =
-        word_subword (y:(128)word) (64,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (0,64):(64)word) (32,32):(32)word =
-        word_subword (y:(128)word) (32,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (64,64):(64)word) (32,32):(32)word =
-        word_subword (y:(128)word) (96,32):(32)word`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 32-bit field from a join of two 32-bit words. *)
-let WORD_SUBWORD_JOIN_64 = prove(`!(x:(32)word) (y:(32)word).
-    word_subword (word_join (x:(32)word) (y:(32)word): (64)word) (0,32) = y /\
-    word_subword (word_join (x:(32)word) (y:(32)word): (64)word) (32,32) = x`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 64-bit field from a join of two 64-bit words. *)
-let WORD_SUBWORD_JOIN_128_64 = prove(`!(x:(64)word) (y:(64)word).
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (0,64) = y /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (64,64) = x`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 32-bit field from a join of two 64-bit words. *)
-let WORD_SUBWORD_JOIN_128_32 = prove(`!(x:(64)word) (y:(64)word).
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (0,32):(32)word =
-      word_subword (y:(64)word) (0,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (32,32):(32)word =
-      word_subword (y:(64)word) (32,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (64,32):(32)word =
-      word_subword (x:(64)word) (0,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (96,32):(32)word =
-      word_subword (x:(64)word) (32,32):(32)word`,
-  CONV_TAC WORD_BLAST);;
+needs "arm/proofs/neon_helper.ml";;
 
 let rewrite_assumptions t tac = SUBGOAL_THEN t
   (fun thm -> RULE_ASSUM_TAC (REWRITE_RULE [thm])) THENL
   [tac; ALL_TAC];;
 
-let lemma4 = prove(`!a b c.
-    ((a + 2 EXP 32 * (b MOD 2 EXP 32 + c MOD 2 EXP 32)) DIV 2 EXP 32) MOD 2 EXP 32 =
-    ((a + 2 EXP 32 * (b + c)) DIV 2 EXP 32) MOD 2 EXP 32`,
-  REPEAT STRIP_TAC THEN
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Ha_" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP
-      (SPECL [`a:num`; `2 EXP 32:num`] DIVISION) (ARITH_RULE `~(2 EXP 32 = 0)`))))
-      ["eq";"lt"]) THEN
-  ABBREV_TAC `ahi = a DIV 2 EXP 32` THEN
-  ABBREV_TAC `alo = a MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  REWRITE_TAC[ARITH_RULE
-    `(ahi * 2 EXP 32 + alo) + 2 EXP 32 * (b MOD 2 EXP 32 + c MOD 2 EXP 32) =
-     (ahi + b MOD 2 EXP 32 + c MOD 2 EXP 32) * 2 EXP 32 + alo`] THEN
-  REWRITE_TAC[ARITH_RULE
-    `(ahi * 2 EXP 32 + alo) + 2 EXP 32 * (b + c) =
-     (ahi + b + c) * 2 EXP 32 + alo`] THEN
-  IMP_REWRITE_TAC[DIV_UNIQ] THEN (* (A * 2^32 + B) / 2^32 => A *)
-  EXISTS_TAC `(ahi + b MOD 2 EXP 32 + c MOD 2 EXP 32)` THEN SIMP_TAC[] THEN
-  EXISTS_TAC `(ahi + b + c)` THEN SIMP_TAC[] THEN
-  CONV_TAC MOD_DOWN_CONV THEN SIMP_TAC[]);;
-
-let WORD_MUL_64_DECOMPOSED_32 = prove(`!(x:(64)word) (y:(64)word).
-  word_add
-    (word_mul (word_zx (word_subword x (0,32):(32)word):(64)word)
-              (word_zx (word_subword y (0,32):(32)word):(64)word))
-    (word_shl
-      (word_add
-        (word_zx (word_mul (word_subword y (32,32):(32)word) (word_subword x (0,32):(32)word)))
-        (word_zx (word_mul (word_subword y (0,32):(32)word) (word_subword x (32,32):(32)word))))
-    32) =
-  word_mul x y`,
-  REPEAT GEN_TAC THEN
-  (* word to num: step 1. x = y to val x = val y *)
-  REWRITE_TAC[GSYM VAL_EQ] THEN
-  (* step 2. remove all word_* *)
-  REWRITE_TAC [VAL_WORD_ADD; VAL_WORD_MUL; VAL_WORD_ZX_GEN; VAL_WORD_SUBWORD;
-               VAL_WORD; VAL_WORD_SHL] THEN
-  (* step 3. add x, y < 2^64 *)
-  ASSUME_TAC (ISPECL [`x:(64)word`] VAL_BOUND) THEN
-  ASSUME_TAC (ISPECL [`y:(64)word`] VAL_BOUND) THEN
-  RULE_ASSUM_TAC (REWRITE_RULE [DIMINDEX_64]) THEN
-  (* step 4. eliminate dimindex (:N) and simplify *)
-  REWRITE_TAC[DIMINDEX_32;DIMINDEX_64;DIMINDEX_128;DIV_1;MOD_MOD_REFL;
-              MOD_MOD_EXP_MIN;ARITH_RULE `2 EXP 0 = 1`; DIV_1] THEN
-  CONV_TAC(DEPTH_CONV NUM_MIN_CONV) THEN
-  CONV_TAC MOD_DOWN_CONV THEN
-  (* split x into [x0h, x0l], and divide y as well *)
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Hx" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP (SPECL [`(val (x:(64)word)):num`; `2 EXP 32:num`] DIVISION)
-      (ARITH_RULE `~(2 EXP 32 = 0)`)))) ["eq";"lt"]) THEN
-  ABBREV_TAC `xhi = (val (x:(64)word)) DIV 2 EXP 32` THEN
-  ABBREV_TAC `xlo = (val (x:(64)word)) MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Hy" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP (SPECL [`(val (y:(64)word)):num`; `2 EXP 32:num`] DIVISION)
-      (ARITH_RULE `~(2 EXP 32 = 0)`)))) ["eq";"lt"]) THEN
-  ABBREV_TAC `yhi = (val (y:(64)word)) DIV 2 EXP 32` THEN
-  ABBREV_TAC `ylo = (val (y:(64)word)) MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  (* lhs *)
-  REWRITE_TAC[LEFT_ADD_DISTRIB; RIGHT_ADD_DISTRIB] THEN
-  REWRITE_TAC[
-    ARITH_RULE `y1hi * x1hi * 2 EXP 32 = 2 EXP 32 * y1hi * x1hi`;
-    ARITH_RULE `(y1hi * 2 EXP 32) * x1hi = 2 EXP 32 * y1hi * x1hi`] THEN
-  REWRITE_TAC[MOD_MULT_ADD] THEN
-  (* rhs *)
-  REWRITE_TAC[MULT_ASSOC; ARITH_RULE `2 EXP 32 * 2 EXP 32 = 2 EXP 64`] THEN
-  REWRITE_TAC[GSYM ADD_ASSOC; GSYM MULT_ASSOC] THEN
-  REWRITE_TAC[MOD_MULT_ADD] THEN
-  (* lhs = rhs *)
-  REWRITE_TAC[ARITH_RULE `2 EXP 64 = 2 EXP 32 * 2 EXP 32`] THEN
-  REWRITE_TAC[MOD_MULT_MOD] THEN
-  REWRITE_TAC[ARITH_RULE `2 EXP 32 * p + 2 EXP 32 * q = 2 EXP 32 * (p + q)`; MOD_MULT_ADD] THEN
-  REWRITE_TAC [lemma4] THEN
-  REWRITE_TAC [ARITH_RULE
-    `(xlo * ylo + 2 EXP 32 * (yhi * xlo + ylo * xhi)) DIV 2 EXP 32 =
-      (2 EXP 32 * xhi * ylo + 2 EXP 32 * xlo * yhi + xlo * ylo) DIV 2 EXP 32`]);;
-
 let simplify_128bit_words =
-  RULE_ASSUM_TAC (REWRITE_RULE [
-      WORD_128_SUBWORD_SUBWORD_32; WORD_SUBWORD_JOIN_64; 
-      WORD_SUBWORD_JOIN_128_64; WORD_SUBWORD_JOIN_128_32;
-      WORD_MUL_64_DECOMPOSED_32]);;
+  RULE_ASSUM_TAC (REWRITE_RULE [WORD_BITMANIP_SIMP_LEMMAS; WORD_MUL64_LO]);;
 
 let simplify_128bit_words_and_accumulate state_name =
   simplify_128bit_words THEN
@@ -913,12 +796,8 @@ let simplify_128bit_words_and_accumulate state_name =
        word (0 + val (a:(64)word) * val (b:(64)word))`]) THEN
   ACCUMULATE_ARITH_TAC state_name THEN CLARIFY_TAC;;
 
-let WORD_ADD_ASSOC_CONSTS = prove(
-  `!(x:(N)word) n m.
-    (word_add (word_add x (word n)) (word m)) = (word_add x (word (n+m)))`,
-  CONV_TAC WORD_RULE);;
-
 let ADK_48_TAC =
+  DISCARD_READ_QREGS THEN
   MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
   MAP_EVERY EXISTS_TAC [`512`; `&0:real`] THEN
   REPLICATE_TAC 2 (CONJ_TAC THENL [BOUNDER_TAC[]; ALL_TAC]) THEN
@@ -1550,13 +1429,10 @@ let BIGNUM_KMUL_16_32_NEON_SUBROUTINE_CORRECT = prove
                    bignum_from_memory (y,16) s = b)
               (\s. read PC s = returnaddress /\
                    bignum_from_memory (z,32) s = a * b)
-              (MAYCHANGE [PC; X0; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10;
-                          X11; X12; X13; X14; X15; X16; X17] ,,
-               MAYCHANGE [Q0; Q1; Q2; Q3; Q4; Q5],,
+              (MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI,,
                MAYCHANGE [memory :> bytes(z,8 * 32);
                           memory :> bytes(t,8 * 32);
-                     memory :> bytes(word_sub stackpointer (word 96),96)] ,,
-               MAYCHANGE SOME_FLAGS)`,
+                     memory :> bytes(word_sub stackpointer (word 96),96)])`,
   ARM_ADD_RETURN_STACK_TAC
    BIGNUM_KMUL_16_32_NEON_EXEC BIGNUM_KMUL_16_32_NEON_CORRECT
     `[X19;X20;X21;X22;X23;X24;X25;X26;X27;X28;X29;X30]` 96);;

--- a/arm/proofs/bignum_mul_8_16_neon.ml
+++ b/arm/proofs/bignum_mul_8_16_neon.ml
@@ -546,126 +546,10 @@ let lemma2 = prove
   ASM_SIMP_TAC[VAL_WORD_SUB_CASES; GSYM REAL_OF_NUM_SUB] THEN
   REAL_ARITH_TAC);;
 
-(* A lemma that is useful for extracting a 32-bit field from a 128-bit word. *)
-let WORD_128_SUBWORD_SUBWORD_32 = prove(`!y.
-      word_subword (word_subword (y:(128)word) (0,64):(64)word) (0,32):(32)word =
-        word_subword (y:(128)word) (0,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (64,64):(64)word) (0,32):(32)word =
-        word_subword (y:(128)word) (64,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (0,64):(64)word) (32,32):(32)word =
-        word_subword (y:(128)word) (32,32):(32)word /\
-      word_subword (word_subword (y:(128)word) (64,64):(64)word) (32,32):(32)word =
-        word_subword (y:(128)word) (96,32):(32)word`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 32-bit field from a join of two 32-bit words. *)
-let WORD_SUBWORD_JOIN_64 = prove(`!(x:(32)word) (y:(32)word).
-    word_subword (word_join (x:(32)word) (y:(32)word): (64)word) (0,32) = y /\
-    word_subword (word_join (x:(32)word) (y:(32)word): (64)word) (32,32) = x`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 64-bit field from a join of two 64-bit words. *)
-let WORD_SUBWORD_JOIN_128_64 = prove(`!(x:(64)word) (y:(64)word).
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (0,64) = y /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (64,64) = x`,
-  CONV_TAC WORD_BLAST);;
-
-(* A lemma that is useful for extracting a 32-bit field from a join of two 64-bit words. *)
-let WORD_SUBWORD_JOIN_128_32 = prove(`!(x:(64)word) (y:(64)word).
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (0,32):(32)word =
-      word_subword (y:(64)word) (0,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (32,32):(32)word =
-      word_subword (y:(64)word) (32,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (64,32):(32)word =
-      word_subword (x:(64)word) (0,32):(32)word /\
-    word_subword (word_join (x:(64)word) (y:(64)word): (128)word) (96,32):(32)word =
-      word_subword (x:(64)word) (32,32):(32)word`,
-  CONV_TAC WORD_BLAST);;
-
-let lemma4 = prove(`!a b c.
-    ((a + 2 EXP 32 * (b MOD 2 EXP 32 + c MOD 2 EXP 32)) DIV 2 EXP 32) MOD 2 EXP 32 =
-    ((a + 2 EXP 32 * (b + c)) DIV 2 EXP 32) MOD 2 EXP 32`,
-  REPEAT STRIP_TAC THEN
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Ha_" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP
-      (SPECL [`a:num`; `2 EXP 32:num`] DIVISION) (ARITH_RULE `~(2 EXP 32 = 0)`))))
-      ["eq";"lt"]) THEN
-  ABBREV_TAC `ahi = a DIV 2 EXP 32` THEN
-  ABBREV_TAC `alo = a MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  REWRITE_TAC[ARITH_RULE
-    `(ahi * 2 EXP 32 + alo) + 2 EXP 32 * (b MOD 2 EXP 32 + c MOD 2 EXP 32) =
-     (ahi + b MOD 2 EXP 32 + c MOD 2 EXP 32) * 2 EXP 32 + alo`] THEN
-  REWRITE_TAC[ARITH_RULE
-    `(ahi * 2 EXP 32 + alo) + 2 EXP 32 * (b + c) =
-     (ahi + b + c) * 2 EXP 32 + alo`] THEN
-  IMP_REWRITE_TAC[DIV_UNIQ] THEN (* (A * 2^32 + B) / 2^32 => A *)
-  EXISTS_TAC `(ahi + b MOD 2 EXP 32 + c MOD 2 EXP 32)` THEN SIMP_TAC[] THEN
-  EXISTS_TAC `(ahi + b + c)` THEN SIMP_TAC[] THEN
-  CONV_TAC MOD_DOWN_CONV THEN SIMP_TAC[]);;
-
-let WORD_MUL_64_DECOMPOSED_32 = prove(`!(x:(64)word) (y:(64)word).
-  word_add
-    (word_mul (word_zx (word_subword x (0,32):(32)word):(64)word)
-              (word_zx (word_subword y (0,32):(32)word):(64)word))
-    (word_shl
-      (word_add
-        (word_zx (word_mul (word_subword y (32,32):(32)word) (word_subword x (0,32):(32)word)))
-        (word_zx (word_mul (word_subword y (0,32):(32)word) (word_subword x (32,32):(32)word))))
-    32) =
-  word_mul x y`,
-  REPEAT GEN_TAC THEN
-  (* word to num: step 1. x = y to val x = val y *)
-  REWRITE_TAC[GSYM VAL_EQ] THEN
-  (* step 2. remove all word_* *)
-  REWRITE_TAC [VAL_WORD_ADD; VAL_WORD_MUL; VAL_WORD_ZX_GEN; VAL_WORD_SUBWORD;
-               VAL_WORD; VAL_WORD_SHL] THEN
-  (* step 3. add x, y < 2^64 *)
-  ASSUME_TAC (ISPECL [`x:(64)word`] VAL_BOUND) THEN
-  ASSUME_TAC (ISPECL [`y:(64)word`] VAL_BOUND) THEN
-  RULE_ASSUM_TAC (REWRITE_RULE [DIMINDEX_64]) THEN
-  (* step 4. eliminate dimindex (:N) and simplify *)
-  REWRITE_TAC[DIMINDEX_32;DIMINDEX_64;DIMINDEX_128;DIV_1;MOD_MOD_REFL;
-              MOD_MOD_EXP_MIN;ARITH_RULE `2 EXP 0 = 1`; DIV_1] THEN
-  CONV_TAC(DEPTH_CONV NUM_MIN_CONV) THEN
-  CONV_TAC MOD_DOWN_CONV THEN
-  (* split x into [x0h, x0l], and divide y as well *)
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Hx" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP (SPECL [`(val (x:(64)word)):num`; `2 EXP 32:num`] DIVISION)
-      (ARITH_RULE `~(2 EXP 32 = 0)`)))) ["eq";"lt"]) THEN
-  ABBREV_TAC `xhi = (val (x:(64)word)) DIV 2 EXP 32` THEN
-  ABBREV_TAC `xlo = (val (x:(64)word)) MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  MAP_EVERY (fun (thm, suffix) -> LABEL_TAC ("Hy" ^ suffix) thm)
-    (zip (CONJUNCTS ((MP (SPECL [`(val (y:(64)word)):num`; `2 EXP 32:num`] DIVISION)
-      (ARITH_RULE `~(2 EXP 32 = 0)`)))) ["eq";"lt"]) THEN
-  ABBREV_TAC `yhi = (val (y:(64)word)) DIV 2 EXP 32` THEN
-  ABBREV_TAC `ylo = (val (y:(64)word)) MOD 2 EXP 32` THEN
-  ASM_REWRITE_TAC[] THEN
-  (* lhs *)
-  REWRITE_TAC[LEFT_ADD_DISTRIB; RIGHT_ADD_DISTRIB] THEN
-  REWRITE_TAC[
-    ARITH_RULE `y1hi * x1hi * 2 EXP 32 = 2 EXP 32 * y1hi * x1hi`;
-    ARITH_RULE `(y1hi * 2 EXP 32) * x1hi = 2 EXP 32 * y1hi * x1hi`] THEN
-  REWRITE_TAC[MOD_MULT_ADD] THEN
-  (* rhs *)
-  REWRITE_TAC[MULT_ASSOC; ARITH_RULE `2 EXP 32 * 2 EXP 32 = 2 EXP 64`] THEN
-  REWRITE_TAC[GSYM ADD_ASSOC; GSYM MULT_ASSOC] THEN
-  REWRITE_TAC[MOD_MULT_ADD] THEN
-  (* lhs = rhs *)
-  REWRITE_TAC[ARITH_RULE `2 EXP 64 = 2 EXP 32 * 2 EXP 32`] THEN
-  REWRITE_TAC[MOD_MULT_MOD] THEN
-  REWRITE_TAC[ARITH_RULE `2 EXP 32 * p + 2 EXP 32 * q = 2 EXP 32 * (p + q)`; MOD_MULT_ADD] THEN
-  REWRITE_TAC [lemma4] THEN
-  REWRITE_TAC [ARITH_RULE
-    `(xlo * ylo + 2 EXP 32 * (yhi * xlo + ylo * xhi)) DIV 2 EXP 32 =
-      (2 EXP 32 * xhi * ylo + 2 EXP 32 * xlo * yhi + xlo * ylo) DIV 2 EXP 32`]);;
+needs "arm/proofs/neon_helper.ml";;
 
 let simplify_128bit_words =
-  RULE_ASSUM_TAC (REWRITE_RULE [
-      WORD_128_SUBWORD_SUBWORD_32; WORD_SUBWORD_JOIN_64; 
-      WORD_SUBWORD_JOIN_128_64; WORD_SUBWORD_JOIN_128_32;
-      WORD_MUL_64_DECOMPOSED_32]);;
+  RULE_ASSUM_TAC (REWRITE_RULE [WORD_BITMANIP_SIMP_LEMMAS;WORD_MUL64_LO]);;
 
 let simplify_128bit_words_and_preproc_accumulate =
   simplify_128bit_words THEN
@@ -673,11 +557,6 @@ let simplify_128bit_words_and_preproc_accumulate =
   RULE_ASSUM_TAC (REWRITE_RULE [WORD_RULE
       `word_mul (a:(64)word) (b:(64)word) =
        word (0 + val (a:(64)word) * val (b:(64)word))`]);;
-
-let WORD_ADD_ASSOC_CONSTS = prove(
-  `!(x:(N)word) n m.
-    (word_add (word_add x (word n)) (word m)) = (word_add x (word (n+m)))`,
-  CONV_TAC WORD_RULE);;
 
 let BYTES128_EQ_JOIN64_TAC lhs128 hi64 lo64 =
   let hivar = mk_var (hi64, `:(64)word`) in
@@ -696,6 +575,7 @@ let BYTES128_EQ_JOIN64_TAC lhs128 hi64 lo64 =
 (* ------------------------------------------------------------------------- *)
 
 let ADK_48_TAC =
+  DISCARD_READ_QREGS THEN
   MATCH_MP_TAC EQUAL_FROM_CONGRUENT_REAL THEN
   MAP_EVERY EXISTS_TAC [`512`; `&0:real`] THEN
   REPLICATE_TAC 2 (CONJ_TAC THENL [BOUNDER_TAC[]; ALL_TAC]) THEN
@@ -715,17 +595,6 @@ let ADK_48_TAC =
              DECARRY_RULE o CONJUNCTS) THEN
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;;
 
-(* Caller-save Q registers:
-  <Procedure Call Standard for the Arm® 64-bit Architecture (AArch64)>
-The first eight registers, v0-v7, are used to pass argument values into a
-subroutine and to return result values from a function. They may also be
-used to hold intermediate values within a routine (but, in general, only
-between subroutine calls).
-Registers v8-v15 must be preserved by a callee across subroutine calls; the
-remaining registers (v0-v7, v16-v31) do not need to be preserved (or should be
-preserved by the caller). Additionally, only the bottom 64 bits of each value
-stored in v8-v15 need to be preserved 8; it is the responsibility of the caller
-to preserve larger values*)
 let BIGNUM_MUL_8_16_NEON_CORRECT = prove(
   `!z x y a b pc.
       ALL (nonoverlapping (z,8 * 16))

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -1,3 +1,8 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC
+ *)
+
 (* ------------------------------------------------------------------------- *)
 (* Encoding the registers and flags as a 32-element list of numbers.         *)
 (* ------------------------------------------------------------------------- *)

--- a/x86/proofs/bignum_emontredc_8n.ml
+++ b/x86/proofs/bignum_emontredc_8n.ml
@@ -1008,7 +1008,8 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
       nonoverlapping (z,8 * 2 * val k) (word_sub stackpointer (word 32),32) /\
       ALLPAIRS nonoverlapping
          [(z,8 * 2 * val k); (word_sub stackpointer (word 32),32)]
-         [(word pc,0xb32); (m,8 * val k)]
+         [(word pc,0xb32); (m,8 * val k)] /\
+      8 divides val k
       ==> ensures x86
            (\s. bytes_loaded s (word pc) (BUTLAST bignum_emontredc_8n_mc) /\
                 read RIP s = word(pc + 0xa) /\
@@ -1017,8 +1018,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
                 bignum_from_memory (z,2 * val k) s = a /\
                 bignum_from_memory (m,val k) s = n)
            (\s. read RIP s = word(pc + 0xb27) /\
-                (8 divides val k /\
-                 (n * val w + 1 == 0) (mod (2 EXP 64))
+                ((n * val w + 1 == 0) (mod (2 EXP 64))
                  ==> n * bignum_from_memory (z,val k) s + a =
                      2 EXP (64 * val k) *
                      (2 EXP (64 * val k) * val(C_RETURN s) +
@@ -1049,6 +1049,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
      [ASM_REWRITE_TAC[VAL_WORD_USHR; NUM_REDUCE_CONV `2 EXP 3`];
       ALL_TAC] THEN
     X86_SIM_TAC BIGNUM_EMONTREDC_8N_EXEC (1--3) THEN
+    UNDISCH_TAC `8 divides k` THEN
     ASM_REWRITE_TAC[DIVIDES_DIV_MULT; MULT_CLAUSES] THEN
     ASM_CASES_TAC `k = 0` THEN ASM_REWRITE_TAC[] THEN
     EXPAND_TAC "a" THEN
@@ -1091,6 +1092,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
   CONJ_TAC THENL
    [ALL_TAC;
     X86_SIM_TAC BIGNUM_EMONTREDC_8N_EXEC [] THEN
+    UNDISCH_TAC `8 divides k` THEN
     ASM_REWRITE_TAC[ONCE_REWRITE_RULE[MULT_SYM] DIVIDES_DIV_MULT] THEN
     ASM_CASES_TAC `k':num = k` THEN ASM_REWRITE_TAC[] THEN
     UNDISCH_THEN `k':num = k` SUBST_ALL_TAC THEN
@@ -1877,7 +1879,8 @@ let BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
       nonoverlapping (z,8 * 2 * val k) (word_sub stackpointer (word 80),88) /\
       ALLPAIRS nonoverlapping
          [(z,8 * 2 * val k); (word_sub stackpointer (word 80),80)]
-         [(word pc,0xb32); (m,8 * val k)]
+         [(word pc,0xb32); (m,8 * val k)] /\
+      8 divides val k
       ==> ensures x86
            (\s. bytes_loaded s (word pc) bignum_emontredc_8n_mc /\
                 read RIP s = word pc /\
@@ -1888,8 +1891,7 @@ let BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
                 bignum_from_memory (m,val k) s = n)
            (\s. read RIP s = returnaddress /\
                 read RSP s = word_add stackpointer (word 8) /\
-                (8 divides val k /\
-                 (n * val w + 1 == 0) (mod (2 EXP 64))
+                ((n * val w + 1 == 0) (mod (2 EXP 64))
                  ==> n * bignum_from_memory (z,val k) s + a =
                      2 EXP (64 * val k) *
                      (2 EXP (64 * val k) * val(C_RETURN s) +
@@ -1942,7 +1944,8 @@ let WINDOWS_BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
       nonoverlapping (z,8 * 2 * val k) (word_sub stackpointer (word 96),104) /\
       ALLPAIRS nonoverlapping
          [(z,8 * 2 * val k); (word_sub stackpointer (word 96),96)]
-         [(word pc,0xb42); (m,8 * val k)]
+         [(word pc,0xb42); (m,8 * val k)] /\
+      8 divides val k
       ==> ensures x86
            (\s. bytes_loaded s (word pc) windows_bignum_emontredc_8n_mc /\
                 read RIP s = word pc /\
@@ -1953,8 +1956,7 @@ let WINDOWS_BIGNUM_EMONTREDC_8N_SUBROUTINE_CORRECT = time prove
                 bignum_from_memory (m,val k) s = n)
            (\s. read RIP s = returnaddress /\
                 read RSP s = word_add stackpointer (word 8) /\
-                (8 divides val k /\
-                 (n * val w + 1 == 0) (mod (2 EXP 64))
+                ((n * val w + 1 == 0) (mod (2 EXP 64))
                  ==> n * bignum_from_memory (z,val k) s + a =
                      2 EXP (64 * val k) *
                      (2 EXP (64 * val k) * val(WINDOWS_C_RETURN s) +


### PR DESCRIPTION
This patch makes bignum_emontredc_8n's proof equal to its neon version, by moving `8 divides val k` out from the postcondition. Also, some assembly' specs are updated to use
`MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI`.

And this patch includes these minor non-functional changes as well:

- Multiplication functions' auxiliary lemma definitions are removed
- A copyright text is added to `simulator.ml` and `bignum_mul_8_16_neon.S`.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
