### PR TITLE
Let NONOVERLAPPING_TAC deal with more cases, improvements for speed 

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -394,18 +394,6 @@ let ARM_VERBOSE_SUBSTEP_TAC exths sname g =
 (* Throw away assumptions according to patterns.                             *)
 (* ------------------------------------------------------------------------- *)
 
-let DISCARD_ASSUMPTIONS_TAC P =
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check P));;
-
-let DISCARD_MATCHING_ASSUMPTIONS pats =
-  DISCARD_ASSUMPTIONS_TAC
-   (fun th -> exists (fun ptm -> can (term_match [] ptm) (concl th)) pats);;
-
-let DISCARD_NONMATCHING_ASSUMPTIONS pats =
-  DISCARD_ASSUMPTIONS_TAC
-   (fun th ->
-      not(exists (fun ptm -> can (term_match [] ptm) (concl th)) pats));;
-
 let DISCARD_FLAGS_TAC =
   DISCARD_MATCHING_ASSUMPTIONS
    [`read CF s = y`; `read ZF s = y`;

--- a/common/misc.ml
+++ b/common/misc.ml
@@ -1151,11 +1151,25 @@ let W64_GEN_TAC =
   fun w -> tac THEN X_GEN_TAC w THEN STRIP_TAC;;
 
 (* ------------------------------------------------------------------------- *)
-(* Handy to pick out matching assumptions.                                   *)
+(* Handy to pick out or discard matching assumptions.                        *)
 (* ------------------------------------------------------------------------- *)
 
 let FIND_ASM_THEN part pat ttac =
   FIRST_X_ASSUM (ttac o check (fun th -> part(concl th) = pat));;
+
+let DISCARD_ASSUMPTIONS_TAC (P:thm -> bool):tactic =
+  fun (asl,w) ->
+    let asl' = filter (fun (_,th) -> not (P th)) asl in
+    ALL_TAC (asl',w);;
+
+let DISCARD_MATCHING_ASSUMPTIONS pats =
+  DISCARD_ASSUMPTIONS_TAC
+   (fun th -> exists (fun ptm -> can (term_match [] ptm) (concl th)) pats);;
+
+let DISCARD_NONMATCHING_ASSUMPTIONS pats =
+  DISCARD_ASSUMPTIONS_TAC
+   (fun th ->
+      not(exists (fun ptm -> can (term_match [] ptm) (concl th)) pats));;
 
 (* ------------------------------------------------------------------------- *)
 (* Re-abbreviating a state component, replacing existing expansion.          *)

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -2454,18 +2454,6 @@ let X86_VERBOSE_SUBSTEP_TAC exths sname g =
 (* Throw away assumptions according to patterns.                             *)
 (* ------------------------------------------------------------------------- *)
 
-let DISCARD_ASSUMPTIONS_TAC P =
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check P));;
-
-let DISCARD_MATCHING_ASSUMPTIONS pats =
-  DISCARD_ASSUMPTIONS_TAC
-   (fun th -> exists (fun ptm -> can (term_match [] ptm) (concl th)) pats);;
-
-let DISCARD_NONMATCHING_ASSUMPTIONS pats =
-  DISCARD_ASSUMPTIONS_TAC
-   (fun th ->
-      not(exists (fun ptm -> can (term_match [] ptm) (concl th)) pats));;
-
 let DISCARD_FLAGS_TAC =
   DISCARD_MATCHING_ASSUMPTIONS
    [`read CF s = y`; `read PF s = y`; `read AF s = y`;


### PR DESCRIPTION
*Description of changes:*

This commit fixes `cmp` in `NONOVERLAPPING_TAC` so that it accepts more
expressions having operands of distinct constants, reducing a class of
possible failures from `NONOVERLAPPING_TAC`.

Also, this commit performs various optimizations to reduce the latency
of running proofs:

- Unuse `VALID` in `NONOVERLAPPING_TAC` because `VALID` is slow
- Fix `DISCARD_ASSUMPTIONS_TAC` to have linear complexity
- Add a cache to `ORTHOGONAL_COMPONENTS_CONV` so that it does not run
  `prove()` for a once-proven goal. Also, make it fail early when the goal
  is not `orthogonal_components _ _`; this is important in Arm because
  `ARM_CONV` invokes `COMPONENT_READ_OVER_WRITE_CONV` which uses
  `ORTHOGONAL_COMPONENTS_CONV` this may traverse
  non-`orthogonal_components` terms.
- Add a cache to `ASSIGNS_SWAP_CONV`.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
