### PR TITLE
Simplify Arm's SIMD instruction semantics

### DIFF
--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1963,7 +1963,9 @@ let arm_MOVK_ALT =
 (* ------------------------------------------------------------------------- *)
 
 let all_simd_rules = [usimd16;usimd8;usimd4;usimd2;simd16;simd8;simd4;simd2;
-    word_interleave8;word_interleave4;word_interleave2;word_split_lohi];;
+    word_interleave8;word_interleave4;word_interleave2;word_split_lohi;
+    DIMINDEX_8;DIMINDEX_16;DIMINDEX_32;DIMINDEX_64;DIMINDEX_128;
+    WORD_BITMANIP_SIMP_LEMMAS];;
 let arm_ADD_VEC_ALT =   REWRITE_RULE all_simd_rules arm_ADD_VEC;;
 let arm_MUL_VEC_ALT =   REWRITE_RULE all_simd_rules arm_MUL_VEC;;
 let arm_REV64_VEC_ALT = REWRITE_RULE all_simd_rules arm_REV64_VEC;;


### PR DESCRIPTION
*Description of changes:*

`all_simd_rules` is a list of rules for expanding high-level word operations in Arm's NEON instructions' semantics.
This patch adds `WORD_BITMANIP_SIMP_LEMMAS` to `all_simd_rules` so that they are expanded and then immediately simplified.
The goal of this patch is to shorten the Arm proof CI time.
Marked as a draft to see whether this makes any proof fail.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
