### PR TITLE
Document that x25519 function does not implement zero-check

### DIFF
--- a/arm/curve25519/curve25519_x25519.S
+++ b/arm/curve25519/curve25519_x25519.S
@@ -13,7 +13,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard ARM ABI: X0 = res, X1 = scalar, X2 = point
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/curve25519_x25519_alt.S
+++ b/arm/curve25519/curve25519_x25519_alt.S
@@ -13,7 +13,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard ARM ABI: X0 = res, X1 = scalar, X2 = point
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/curve25519_x25519_byte.S
+++ b/arm/curve25519/curve25519_x25519_byte.S
@@ -13,7 +13,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard ARM ABI: X0 = res, X1 = scalar, X2 = point
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/curve25519_x25519_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519_byte_alt.S
@@ -13,7 +13,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard ARM ABI: X0 = res, X1 = scalar, X2 = point
 // ----------------------------------------------------------------------------

--- a/x86/curve25519/curve25519_x25519.S
+++ b/x86/curve25519/curve25519_x25519.S
@@ -20,7 +20,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard x86-64 ABI: RDI = res, RSI = scalar, RDX = point
 // Microsoft x64 ABI:   RCX = res, RDX = scalar, R8 = point

--- a/x86/curve25519/curve25519_x25519_alt.S
+++ b/x86/curve25519/curve25519_x25519_alt.S
@@ -20,7 +20,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard x86-64 ABI: RDI = res, RSI = scalar, RDX = point
 // Microsoft x64 ABI:   RCX = res, RDX = scalar, R8 = point

--- a/x86_att/curve25519/curve25519_x25519.S
+++ b/x86_att/curve25519/curve25519_x25519.S
@@ -20,7 +20,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard x86-64 ABI: RDI = res, RSI = scalar, RDX = point
 // Microsoft x64 ABI:   RCX = res, RDX = scalar, R8 = point

--- a/x86_att/curve25519/curve25519_x25519_alt.S
+++ b/x86_att/curve25519/curve25519_x25519_alt.S
@@ -20,7 +20,8 @@
 // this returns the X coordinate of n * P = (X, Y), or 0 when n * P is the
 // point at infinity. Both n and X inputs are first slightly modified/mangled
 // as specified in the relevant RFC (https://www.rfc-editor.org/rfc/rfc7748);
-// in particular the lower three bits of n are set to zero.
+// in particular the lower three bits of n are set to zero. Does not implement
+// the zero-check specified in Section 6.1.
 //
 // Standard x86-64 ABI: RDI = res, RSI = scalar, RDX = point
 // Microsoft x64 ABI:   RCX = res, RDX = scalar, R8 = point


### PR DESCRIPTION
*Description of changes:*

Section 6.1 of [rfc7748](https://www.rfc-editor.org/rfc/rfc7748#section-6.1) specifies that x25519 implementations MAY perform a zero-check to eliminate a risk; avoid bad actor from voiding a peer contribution to shared secret.

Simply document that this is **not** performed by this implementation (which could really be deduced by `void` return type. But just make it explicit in function documentations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
