### PR TITLE
Use vfree_in instead of free_in if valid

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -272,7 +272,7 @@ let (ALIGNED_16_TAC:tactic) =
     CONV_TAC(ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV) THEN
     ASSUM_LIST(fun thl ->
       REWRITE_TAC(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) thl))
-  and trigger = free_in `aligned:num->int64->bool` in
+  and trigger = vfree_in `aligned:num->int64->bool` in
   fun (asl,w) -> if trigger w then basetac (asl,w) else ALL_TAC (asl,w);;
 
 let ALIGNED_16_CONV ths =
@@ -281,7 +281,7 @@ let ALIGNED_16_CONV ths =
     GEN_REWRITE_CONV (SUB_ALIGNED_16_CONV o TOP_DEPTH_CONV) ths THENC
     ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV THENC
     REWRITE_CONV(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) ths)
-  and trigger = free_in `aligned:num->int64->bool` in
+  and trigger = vfree_in `aligned:num->int64->bool` in
   fun tm -> if trigger tm then baseconv tm else REFL tm;;
 
 (* ------------------------------------------------------------------------- *)
@@ -400,7 +400,7 @@ let DISCARD_FLAGS_TAC =
     `read NF s = y`; `read VF s = y`];;
 
 let DISCARD_STATE_TAC s =
-  DISCARD_ASSUMPTIONS_TAC (free_in (mk_var(s,`:armstate`)) o concl);;
+  DISCARD_ASSUMPTIONS_TAC (vfree_in (mk_var(s,`:armstate`)) o concl);;
 
 let DISCARD_OLDSTATE_TAC s =
   let v = mk_var(s,`:armstate`) in
@@ -768,7 +768,7 @@ let ARM_ADD_RETURN_STACK_TAC =
     MP_TAC coreth THEN
     REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI] THEN
     REPEAT(MATCH_MP_TAC mono2lemma THEN GEN_TAC) THEN
-    (if free_in sp_tm (concl coreth) then
+    (if vfree_in sp_tm (concl coreth) then
       DISCH_THEN(fun th -> WORD_FORALL_OFFSET_TAC stackoff THEN MP_TAC th) THEN
       MATCH_MP_TAC MONO_FORALL THEN GEN_TAC
      else

--- a/arm/proofs/bignum_amontifier.ml
+++ b/arm/proofs/bignum_amontifier.ml
@@ -1634,8 +1634,8 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -1974,7 +1974,7 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read X6 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2295,7 +2295,7 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
     REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
     REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
     ALL_TAC] THEN
-  REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
   REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
               GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
   SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN

--- a/arm/proofs/bignum_cdiv.ml
+++ b/arm/proofs/bignum_cdiv.ml
@@ -236,7 +236,7 @@ let BIGNUM_CDIV_CORRECT = prove
 
     (*** Rename n -> k to allow even easier reuse of bignum_cmod proof ***)
 
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num` o concl))) THEN
     POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
     SPEC_TAC(`n:num`,`k:num`) THEN REPEAT STRIP_TAC THEN
 
@@ -736,7 +736,7 @@ let BIGNUM_CDIV_CORRECT = prove
         `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
        CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
        REPEAT(FIRST_X_ASSUM(K ALL_TAC o check
-          (free_in `b:int64` o concl)))] THEN
+          (vfree_in `b:int64` o concl)))] THEN
 
       (*** Observe this, which implies the result is not exact ***)
 

--- a/arm/proofs/bignum_cmod.ml
+++ b/arm/proofs/bignum_cmod.ml
@@ -601,7 +601,7 @@ let BIGNUM_CMOD_CORRECT = prove
        `a / &2 pow 16 - e + &1 = b ==> a = &2 pow 16 * (b + e - &1)`)) THEN
      REWRITE_TAC[REAL_ARITH `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
      CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
-     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `b:int64` o concl)))] THEN
+     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `b:int64` o concl)))] THEN
 
     (*** Observe this, which implies in particular the result is not exact ***)
 

--- a/arm/proofs/bignum_cmul_p521.ml
+++ b/arm/proofs/bignum_cmul_p521.ml
@@ -133,8 +133,8 @@ let BIGNUM_CMUL_P521_CORRECT = time prove
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC;
     DISCARD_MATCHING_ASSUMPTIONS [`word(a):int64 = c`] THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `c:int64` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `c:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 

--- a/arm/proofs/bignum_coprime.ml
+++ b/arm/proofs/bignum_coprime.ml
@@ -598,10 +598,10 @@ let BIGNUM_COPRIME_CORRECT = prove
   SUBGOAL_THEN `64 <= t /\ t <= 128 * k` STRIP_ASSUME_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SUBGOAL_THEN `k < 2 EXP 57` ASSUME_TAC THENL [SIMPLE_ARITH_TAC; ALL_TAC] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `y:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `y:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   MAP_EVERY (BIGNUM_TERMRANGE_TAC `k:num`) [`a:num`; `b:num`] THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN STRIP_TAC THEN
 
@@ -827,7 +827,7 @@ let BIGNUM_COPRIME_CORRECT = prove
   SUBGOAL_THEN `t - 58 * icount <= 128 * k` MP_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SPEC_TAC(`t - 58 * icount`,`t':num`) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:num` o concl))) THEN
   X_GEN_TAC `t:num` THEN REPEAT DISCH_TAC THEN
   GHOST_INTRO_TAC `m0:num` `bignum_from_memory(mm,k)` THEN
   GHOST_INTRO_TAC `n0:num` `bignum_from_memory(nn,k)` THEN
@@ -2407,10 +2407,10 @@ let BIGNUM_COPRIME_CORRECT = prove
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
   REPEAT(FIRST_X_ASSUM(CONJUNCTS_THEN ASSUME_TAC)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `lowerr:num->real` o concl))) THEN
+    check (vfree_in `lowerr:num->real` o concl))) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `upperr:num->real` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `base:int` o concl))) THEN
+    check (vfree_in `upperr:num->real` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `base:int` o concl))) THEN
 
   (*** The cross-multiplications loop updating m and n ***)
 

--- a/arm/proofs/bignum_copy.ml
+++ b/arm/proofs/bignum_copy.ml
@@ -76,7 +76,7 @@ let BIGNUM_COPY_CORRECT = prove
     ARM_SIM_TAC BIGNUM_COPY_EXEC (1--3) THEN
     REWRITE_TAC[ARITH_RULE `MIN n k = if k < n then k else n`] THEN
     MESON_TAC[];
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `k:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `k:num` o concl))) THEN
     POP_ASSUM_LIST(K ALL_TAC) THEN MP_TAC(ARITH_RULE `MIN n k <= k`) THEN
     SPEC_TAC(`lowdigits a k`,`a:num`) THEN SPEC_TAC(`MIN n k`,`n:num`) THEN
     REPEAT GEN_TAC THEN REPEAT DISCH_TAC THEN

--- a/arm/proofs/bignum_demont.ml
+++ b/arm/proofs/bignum_demont.ml
@@ -230,7 +230,7 @@ let BIGNUM_DEMONT_CORRECT = time prove
 
   (*** Forget everything about x, no longer used (for efficiency only) ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Setup of the main loop with corrective part at the end included ***)
 

--- a/arm/proofs/bignum_emontredc_8n.ml
+++ b/arm/proofs/bignum_emontredc_8n.ml
@@ -444,9 +444,9 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
     MAP_EVERY EXPAND_TAC ["k'"; "k4"] THEN SUBSUMED_MAYCHANGE_TAC;
     ALL_TAC] THEN
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`a':num`,`a:num`); (`n':num`,`n:num`); (`k':num`,`k:num`)] THEN
@@ -672,10 +672,10 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
 
   (*** Now forget more things; back up a few steps and forget i as well ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z:int64`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q1:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z:int64`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r1:num`) o concl)) THEN
 
   ENSURES_SEQUENCE_TAC `pc + 0x3d0`
    `\s. read X2 s = word_add m (word(32 * (k4 - 1))) /\
@@ -702,7 +702,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
       CONV_TAC WORD_RULE]] THEN
 
   ABBREV_TAC `wouter:int64 = word (k4 - i)` THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `i:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `i:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`z1:num`,`a:num`); (`z':int64`,`z:int64`)] THEN

--- a/arm/proofs/bignum_emontredc_8n_neon.ml
+++ b/arm/proofs/bignum_emontredc_8n_neon.ml
@@ -1257,9 +1257,9 @@ let BIGNUM_EMONTREDC_8N_NEON_CORRECT = time prove
     ALL_TAC] THEN
   SUBGOAL_THEN `8 <= k'` ASSUME_TAC THENL [ASM_ARITH_TAC; ALL_TAC] THEN
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`a':num`,`a:num`); (`n':num`,`n:num`); (`k':num`,`k:num`)] THEN
@@ -1504,10 +1504,10 @@ let BIGNUM_EMONTREDC_8N_NEON_CORRECT = time prove
 
   (*** Now forget more things; back up a few steps and forget i as well ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z:int64`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q1:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z:int64`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r1:num`) o concl)) THEN
 
   ENSURES_SEQUENCE_TAC `pc + 0xd54`
    `\s. read X2 s = word_add m (word(32 * (k4 - 1))) /\
@@ -1536,7 +1536,7 @@ let BIGNUM_EMONTREDC_8N_NEON_CORRECT = time prove
       ASM_REWRITE_TAC[ARITH_RULE `1 <= k - j <=> j < k`]]] THEN
 
   ABBREV_TAC `wouter:int64 = word (k4 - i)` THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `i:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `i:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`z1:num`,`a:num`); (`z':int64`,`z:int64`)] THEN

--- a/arm/proofs/bignum_kmul_16_32.ml
+++ b/arm/proofs/bignum_kmul_16_32.ml
@@ -1253,7 +1253,7 @@ let BIGNUM_KMUL_16_32_CORRECT = prove
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s212:bool` o concl))
+    filter (vfree_in `carry_s212:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s212:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN

--- a/arm/proofs/bignum_kmul_16_32_neon.ml
+++ b/arm/proofs/bignum_kmul_16_32_neon.ml
@@ -1403,7 +1403,7 @@ let BIGNUM_KMUL_16_32_NEON_CORRECT = prove
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s212:bool` o concl))
+    filter (vfree_in `carry_s212:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s212:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN

--- a/arm/proofs/bignum_kmul_32_64.ml
+++ b/arm/proofs/bignum_kmul_32_64.ml
@@ -1721,7 +1721,7 @@ let LOCAL_KMUL_16_32_CORRECT = prove
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s212:bool` o concl))
+    filter (vfree_in `carry_s212:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s212:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN
@@ -1934,7 +1934,7 @@ let BIGNUM_KMUL_32_64_SUBROUTINE_CORRECT = prove
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
 
   (*** Sign-difference computation for y, then discard y stuff ***)
@@ -1994,7 +1994,7 @@ let BIGNUM_KMUL_32_64_SUBROUTINE_CORRECT = prove
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `y:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `y:int64` o concl))) THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
 
   (*** The combined sign ***)
@@ -2062,7 +2062,7 @@ let BIGNUM_KMUL_32_64_SUBROUTINE_CORRECT = prove
 
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
   UNDISCH_THEN `h = ahi * bhi` SUBST1_TAC THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
   ABBREV_TAC `h = ahi * bhi + ltop` THEN DISCH_TAC THEN
 
   (*** Third and final nested multiplication: absolute differences ***)
@@ -2138,7 +2138,7 @@ let BIGNUM_KMUL_32_64_SUBROUTINE_CORRECT = prove
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s434:bool` o concl))
+    filter (vfree_in `carry_s434:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s434:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN

--- a/arm/proofs/bignum_kmul_32_64_neon.ml
+++ b/arm/proofs/bignum_kmul_32_64_neon.ml
@@ -1871,7 +1871,7 @@ let LOCAL_KMUL_16_32_NEON_CORRECT = prove
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s212:bool` o concl))
+    filter (vfree_in `carry_s212:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s212:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN
@@ -2086,7 +2086,7 @@ let BIGNUM_KMUL_32_64_NEON_SUBROUTINE_CORRECT = prove(
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
 
   (*** Sign-difference computation for y, then discard y stuff ***)
@@ -2146,7 +2146,7 @@ let BIGNUM_KMUL_32_64_NEON_SUBROUTINE_CORRECT = prove(
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `y:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `y:int64` o concl))) THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC)] THEN
 
   (*** The combined sign ***)
@@ -2214,7 +2214,7 @@ let BIGNUM_KMUL_32_64_NEON_SUBROUTINE_CORRECT = prove(
 
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
   UNDISCH_THEN `h = ahi * bhi` SUBST1_TAC THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
   ABBREV_TAC `h = ahi * bhi + ltop` THEN DISCH_TAC THEN
 
   (*** Third and final nested multiplication: absolute differences ***)
@@ -2291,7 +2291,7 @@ let BIGNUM_KMUL_32_64_NEON_SUBROUTINE_CORRECT = prove(
   DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN
   CONV_TAC(RAND_CONV REAL_POLY_CONV) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o
-    filter (free_in `carry_s434:bool` o concl))
+    filter (vfree_in `carry_s434:bool` o concl))
   THENL
    [ASM_CASES_TAC `carry_s434:bool` THEN ASM_REWRITE_TAC[BITVAL_CLAUSES];
     ALL_TAC] THEN

--- a/arm/proofs/bignum_ksqr_32_64.ml
+++ b/arm/proofs/bignum_ksqr_32_64.ml
@@ -1441,7 +1441,7 @@ let BIGNUM_KSQR_32_64_SUBROUTINE_CORRECT = prove
 
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
   DISCARD_MATCHING_ASSUMPTIONS [`bignum_of_wordlist l = n`] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Third and final nested squaring ***)
 

--- a/arm/proofs/bignum_ksqr_32_64_neon.ml
+++ b/arm/proofs/bignum_ksqr_32_64_neon.ml
@@ -1580,7 +1580,7 @@ let BIGNUM_KSQR_32_64_NEON_SUBROUTINE_CORRECT = prove
 
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
   DISCARD_MATCHING_ASSUMPTIONS [`bignum_of_wordlist l = n`] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Third and final nested squaring ***)
 

--- a/arm/proofs/bignum_modifier.ml
+++ b/arm/proofs/bignum_modifier.ml
@@ -1678,8 +1678,8 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -2018,7 +2018,7 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read X6 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2358,7 +2358,7 @@ let BIGNUM_MODIFIER_CORRECT = time prove
       REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
       REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
       ALL_TAC] THEN
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
     REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
                 GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
     SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN
@@ -2387,13 +2387,13 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** Clean away some things we no longer need from first chapter ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z2:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z1:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z2:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z1:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r:num` o concl))) THEN
 
   (*** Ghost the intermediate value of z as "a" ***)
 

--- a/arm/proofs/bignum_modinv.ml
+++ b/arm/proofs/bignum_modinv.ml
@@ -499,7 +499,7 @@ let CORE_MODINV_CORRECT = prove
 
   UNDISCH_THEN `word_add ww (word (8 * k)):int64 = mm` (K ALL_TAC) THEN
   UNDISCH_THEN `word_add ww (word (16 * k)):int64 = nn` (K ALL_TAC) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Further initialization including modular inverse ***)
 
@@ -654,7 +654,7 @@ let CORE_MODINV_CORRECT = prove
   SUBGOAL_THEN `t - 58 * icount <= 128 * k` MP_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SPEC_TAC(`t - 58 * icount`,`t':num`) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:num` o concl))) THEN
   X_GEN_TAC `t:num` THEN REPEAT DISCH_TAC THEN
   GHOST_INTRO_TAC `m0:num` `bignum_from_memory(mm,k)` THEN
   GHOST_INTRO_TAC `n0:num` `bignum_from_memory(nn,k)` THEN
@@ -2257,10 +2257,10 @@ let CORE_MODINV_CORRECT = prove
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
   REPEAT(FIRST_X_ASSUM(CONJUNCTS_THEN ASSUME_TAC)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `lowerr:num->real` o concl))) THEN
+    check (vfree_in `lowerr:num->real` o concl))) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `upperr:num->real` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `base:int` o concl))) THEN
+    check (vfree_in `upperr:num->real` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `base:int` o concl))) THEN
 
  (*** Congruence cross-multiplication and shift-by-6 "congloop" ***)
 

--- a/arm/proofs/bignum_montifier.ml
+++ b/arm/proofs/bignum_montifier.ml
@@ -1678,8 +1678,8 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -2022,7 +2022,7 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read X6 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2362,7 +2362,7 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
       REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
       REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
       ALL_TAC] THEN
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
     REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
                 GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
     SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN
@@ -2391,13 +2391,13 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** Clean away some things we no longer need from first chapter ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z2:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z1:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z2:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z1:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r:num` o concl))) THEN
 
   (*** Ghost the intermediate value of z as "a" ***)
 

--- a/arm/proofs/bignum_montmul_p521.ml
+++ b/arm/proofs/bignum_montmul_p521.ml
@@ -920,7 +920,7 @@ let BIGNUM_MONTMUL_P521_CORRECT = prove
       ACCUMULATOR_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
       DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC];
      ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl)))] THEN
+     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl)))] THEN
 
   (*** The sign-magnitude difference computation ***)
 
@@ -1161,9 +1161,9 @@ let BIGNUM_MONTMUL_P521_CORRECT = prove
     DISCARD_MATCHING_ASSUMPTIONS
      [`(a:int == b) (mod n)`; `(a:num == b) (mod n)`; `x:real = y`;
       `a:num = b * c`; `word_add a b = c`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `hl:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `hlm':num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `sgn:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `hl:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `hlm':num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `sgn:bool` o concl))) THEN
     DISCH_TAC] THEN
 
   (*** The intricate augmentation of the product with top words ***)

--- a/arm/proofs/bignum_montsqr_p521.ml
+++ b/arm/proofs/bignum_montsqr_p521.ml
@@ -1074,7 +1074,7 @@ let BIGNUM_MONTSQR_P521_CORRECT = time prove
   ARM_STEPS_TAC BIGNUM_MONTSQR_P521_EXEC (392--394) THEN
   RULE_ASSUM_TAC(REWRITE_RULE[GSYM WORD_AND_ASSOC; DIMINDEX_64;
       NUM_REDUCE_CONV `9 MOD 64`]) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
   MAP_EVERY ABBREV_TAC
    [`h:int64 = word_ushr sum_s391 9`;
     `d:int64 = word_or sum_s391 (word 18446744073709551104)`;

--- a/arm/proofs/bignum_mul_p521.ml
+++ b/arm/proofs/bignum_mul_p521.ml
@@ -924,7 +924,7 @@ let BIGNUM_MUL_P521_CORRECT = prove
       ACCUMULATOR_ASSUM_LIST(MP_TAC o end_itlist CONJ o DESUM_RULE) THEN
       DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC];
      ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl)))] THEN
+     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl)))] THEN
 
   (*** The sign-magnitude difference computation ***)
 
@@ -1165,9 +1165,9 @@ let BIGNUM_MUL_P521_CORRECT = prove
     DISCARD_MATCHING_ASSUMPTIONS
      [`(a:int == b) (mod n)`; `(a:num == b) (mod n)`; `x:real = y`;
       `a:num = b * c`; `word_add a b = c`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `hl:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `hlm':num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `sgn:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `hl:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `hlm':num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `sgn:bool` o concl))) THEN
     DISCH_TAC] THEN
 
   (*** The intricate augmentation of the product with top words ***)

--- a/arm/proofs/bignum_negmodinv.ml
+++ b/arm/proofs/bignum_negmodinv.ml
@@ -459,10 +459,10 @@ let BIGNUM_NEGMODINV_CORRECT = prove
   SUBGOAL_THEN `2 <= p /\ p < 2 EXP 61` STRIP_ASSUME_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `i:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `i:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num` o concl))) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
 
   SPEC_TAC(`m':num`,`m:num`) THEN SPEC_TAC(`z':int64`,`z:int64`) THEN

--- a/arm/proofs/bignum_sqr_p521.ml
+++ b/arm/proofs/bignum_sqr_p521.ml
@@ -1005,7 +1005,7 @@ let BIGNUM_SQR_P521_CORRECT = time prove
   ARM_STEPS_TAC BIGNUM_SQR_P521_EXEC (392--394) THEN
   RULE_ASSUM_TAC(REWRITE_RULE[GSYM WORD_AND_ASSOC; DIMINDEX_64;
       NUM_REDUCE_CONV `9 MOD 64`]) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
   MAP_EVERY ABBREV_TAC
    [`h:int64 = word_ushr sum_s391 9`;
     `d:int64 = word_or sum_s391 (word 18446744073709551104)`;

--- a/arm/proofs/bignum_tomont_p256.ml
+++ b/arm/proofs/bignum_tomont_p256.ml
@@ -293,8 +293,8 @@ let modstep256_tac regs topw n =
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN ASM_REWRITE_TAC[]] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
   DISCARD_MATCHING_ASSUMPTIONS [`read (rvalue y) s = x`] THEN
   DISCARD_FLAGS_TAC THEN
   SUBGOAL_THEN `(2 EXP 64 * a) MOD p_256 < p_256` MP_TAC THENL
@@ -369,7 +369,7 @@ let BIGNUM_TOMONT_P256_CORRECT = time prove
     MAP_EVERY UNDISCH_TAC
      [`read X0 s13 = z`; `read PC s13 = word (pc + 52)`] THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read Xnn s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
     DISCH_TAC THEN DISCH_TAC] THEN
 
   SUBGOAL_THEN

--- a/arm/proofs/bignum_tomont_p384.ml
+++ b/arm/proofs/bignum_tomont_p384.ml
@@ -377,8 +377,8 @@ let modstep384_tac regs topw n =
     DISCH_THEN(MP_TAC o end_itlist CONJ o DESUM_RULE o CONJUNCTS) THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN ASM_REWRITE_TAC[]] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
   DISCARD_MATCHING_ASSUMPTIONS [`read (rvalue y) s = x`] THEN
   DISCARD_FLAGS_TAC THEN
   SUBGOAL_THEN `(2 EXP 64 * a) MOD p_384 < p_384` MP_TAC THENL
@@ -451,7 +451,7 @@ let BIGNUM_TOMONT_P384_CORRECT = time prove
     MAP_EVERY UNDISCH_TAC
      [`read X0 s18 = z`; `read PC s18 = word (pc + 72)`] THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read Xnn s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
     DISCH_TAC THEN DISCH_TAC] THEN
 
   SUBGOAL_THEN

--- a/arm/proofs/bignum_tomont_sm2.ml
+++ b/arm/proofs/bignum_tomont_sm2.ml
@@ -199,7 +199,7 @@ let BIGNUM_TOMONT_SM2_CORRECT = time prove
     MAP_EVERY UNDISCH_TAC
      [`read X0 s12 = z`; `read PC s12 = word (pc + 48)`] THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read Xnn s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
     DISCH_TAC THEN DISCH_TAC] THEN
 
   SUBGOAL_THEN
@@ -347,9 +347,9 @@ let BIGNUM_TOMONT_SM2_CORRECT = time prove
 
   (*** Reset all the variables to match the initial expectations ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `w:int64`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `w:int64`) o concl)) THEN
 
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   SPEC_TAC(`s33:armstate`,`s12:armstate`) THEN

--- a/arm/proofs/curve25519_x25519.ml
+++ b/arm/proofs/curve25519_x25519.ml
@@ -8058,9 +8058,9 @@ let CURVE25519_X25519_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/arm/proofs/curve25519_x25519_alt.ml
+++ b/arm/proofs/curve25519_x25519_alt.ml
@@ -5396,9 +5396,9 @@ let CURVE25519_X25519_ALT_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/arm/proofs/curve25519_x25519_byte.ml
+++ b/arm/proofs/curve25519_x25519_byte.ml
@@ -8264,9 +8264,9 @@ let CURVE25519_X25519_BYTE_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/arm/proofs/curve25519_x25519_byte_alt.ml
+++ b/arm/proofs/curve25519_x25519_byte_alt.ml
@@ -5601,9 +5601,9 @@ let CURVE25519_X25519_BYTE_ALT_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/arm/proofs/p256_montjdouble.ml
+++ b/arm/proofs/p256_montjdouble.ml
@@ -1976,7 +1976,7 @@ let LOCAL_CMSUB41_P256_TAC =
 
   ABBREV_TAC `q:int64 = sum_s15` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s15:int64` o concl))) THEN
+    check (vfree_in `sum_s15:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/arm/proofs/p384_montjdouble.ml
+++ b/arm/proofs/p384_montjdouble.ml
@@ -3080,7 +3080,7 @@ let LOCAL_CMSUBC9_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s62` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s46:int64` o concl))) THEN
+    check (vfree_in `sum_s46:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 384 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;
@@ -3243,7 +3243,7 @@ let LOCAL_CMSUB41_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s20` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s20:int64` o concl))) THEN
+    check (vfree_in `sum_s20:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 384 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
@@ -3438,7 +3438,7 @@ let LOCAL_CMSUB38_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s50` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s50:int64` o concl))) THEN
+    check (vfree_in `sum_s50:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 384 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;

--- a/arm/proofs/p521_jdouble.ml
+++ b/arm/proofs/p521_jdouble.ml
@@ -3747,9 +3747,9 @@ let LOCAL_CMSUBC9_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 
@@ -4053,9 +4053,9 @@ let LOCAL_CMSUB41_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 
@@ -4377,9 +4377,9 @@ let LOCAL_CMSUB38_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 

--- a/arm/proofs/secp256k1_jdouble.ml
+++ b/arm/proofs/secp256k1_jdouble.ml
@@ -1913,7 +1913,7 @@ let LOCAL_CMSUB41_P256K1_TAC =
 
   ABBREV_TAC `q:int64 = sum_s16` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s16:int64` o concl))) THEN
+    check (vfree_in `sum_s16:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/arm/proofs/sm2_montjdouble.ml
+++ b/arm/proofs/sm2_montjdouble.ml
@@ -1944,7 +1944,7 @@ let LOCAL_CMSUB41_SM2_TAC =
 
   ABBREV_TAC `q:int64 = sum_s15` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s15:int64` o concl))) THEN
+    check (vfree_in `sum_s15:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/arm/proofs/word_recip.ml
+++ b/arm/proofs/word_recip.ml
@@ -463,7 +463,7 @@ let WORD_RECIP_CORRECT = prove
      `a / &2 pow 16 - e + &1 = b ==> a = &2 pow 16 * (b + e - &1)`)) THEN
    REWRITE_TAC[REAL_ARITH `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
    CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
-   REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `b:int64` o concl)))] THEN
+   REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `b:int64` o concl)))] THEN
 
   (*** Observe this, which implies in particular the result is not exact ***)
 

--- a/x86/proofs/bignum_amontifier.ml
+++ b/x86/proofs/bignum_amontifier.ml
@@ -1773,8 +1773,8 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -2141,7 +2141,7 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read R11 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2488,7 +2488,7 @@ let BIGNUM_AMONTIFIER_CORRECT = time prove
     REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
     REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
     ALL_TAC] THEN
-  REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
   REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
               GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
   SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN

--- a/x86/proofs/bignum_cdiv.ml
+++ b/x86/proofs/bignum_cdiv.ml
@@ -319,7 +319,7 @@ let BIGNUM_CDIV_CORRECT = prove
 
     (*** Rename n -> k to allow even easier reuse of bignum_cmod proof ***)
 
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num` o concl))) THEN
     POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
     SPEC_TAC(`n:num`,`k:num`) THEN REPEAT STRIP_TAC THEN
 
@@ -836,7 +836,7 @@ let BIGNUM_CDIV_CORRECT = prove
         `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
        CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
        REPEAT(FIRST_X_ASSUM(K ALL_TAC o check
-        (free_in `b:int64` o concl)))] THEN
+        (vfree_in `b:int64` o concl)))] THEN
 
       (*** Observe this, which implies the result is not exact ***)
 

--- a/x86/proofs/bignum_cmod.ml
+++ b/x86/proofs/bignum_cmod.ml
@@ -664,7 +664,7 @@ let BIGNUM_CMOD_CORRECT = prove
      REWRITE_TAC[REAL_ARITH
       `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
      CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
-     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `b:int64` o concl)))] THEN
+     REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `b:int64` o concl)))] THEN
 
     (*** Observe this, which implies in particular the result is not exact ***)
 

--- a/x86/proofs/bignum_cmul_p521.ml
+++ b/x86/proofs/bignum_cmul_p521.ml
@@ -153,8 +153,8 @@ let BIGNUM_CMUL_P521_CORRECT = time prove
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC;
     DISCARD_MATCHING_ASSUMPTIONS [`word(a):int64 = c`] THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `c:int64` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `c:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 

--- a/x86/proofs/bignum_cmul_p521_alt.ml
+++ b/x86/proofs/bignum_cmul_p521_alt.ml
@@ -170,8 +170,8 @@ let BIGNUM_CMUL_P521_ALT_CORRECT = time prove
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_ARITH_TAC;
     DISCARD_MATCHING_ASSUMPTIONS [`word(a):int64 = c`] THEN
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `c:int64` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `c:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 

--- a/x86/proofs/bignum_coprime.ml
+++ b/x86/proofs/bignum_coprime.ml
@@ -690,10 +690,10 @@ let BIGNUM_COPRIME_CORRECT = prove
   SUBGOAL_THEN `64 <= t /\ t <= 128 * k` STRIP_ASSUME_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SUBGOAL_THEN `k < 2 EXP 57` ASSUME_TAC THENL [SIMPLE_ARITH_TAC; ALL_TAC] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `y:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `y:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   MAP_EVERY (BIGNUM_TERMRANGE_TAC `k:num`) [`a:num`; `b:num`] THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN STRIP_TAC THEN
 
@@ -938,7 +938,7 @@ let BIGNUM_COPRIME_CORRECT = prove
   SUBGOAL_THEN `t - 58 * icount <= 128 * k` MP_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SPEC_TAC(`t - 58 * icount`,`t':num`) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:num` o concl))) THEN
   X_GEN_TAC `t:num` THEN REPEAT DISCH_TAC THEN
   GHOST_INTRO_TAC `m0:num` `bignum_from_memory(mm,k)` THEN
   GHOST_INTRO_TAC `n0:num` `bignum_from_memory(nn,k)` THEN
@@ -2511,10 +2511,10 @@ let BIGNUM_COPRIME_CORRECT = prove
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
   REPEAT(FIRST_X_ASSUM(CONJUNCTS_THEN ASSUME_TAC)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `lowerr:num->real` o concl))) THEN
+    check (vfree_in `lowerr:num->real` o concl))) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `upperr:num->real` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `base:int` o concl))) THEN
+    check (vfree_in `upperr:num->real` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `base:int` o concl))) THEN
 
   (*** Cross-multiplication "crossloop" and duplex negation "optnegloop" ***)
 

--- a/x86/proofs/bignum_copy.ml
+++ b/x86/proofs/bignum_copy.ml
@@ -78,7 +78,7 @@ let BIGNUM_COPY_CORRECT = prove
     X86_SIM_TAC BIGNUM_COPY_EXEC (1--3) THEN
     REWRITE_TAC[ARITH_RULE `MIN n k = if k < n then k else n`] THEN
     MESON_TAC[];
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `k:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `k:num` o concl))) THEN
     POP_ASSUM_LIST(K ALL_TAC) THEN MP_TAC(ARITH_RULE `MIN n k <= k`) THEN
     SPEC_TAC(`lowdigits a k`,`a:num`) THEN SPEC_TAC(`MIN n k`,`n:num`) THEN
     REPEAT GEN_TAC THEN REPEAT DISCH_TAC THEN

--- a/x86/proofs/bignum_demont.ml
+++ b/x86/proofs/bignum_demont.ml
@@ -259,7 +259,7 @@ let BIGNUM_DEMONT_CORRECT = time prove
 
   (*** Forget everything about x, no longer used (for efficiency only) ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Setup of the main loop with corrective part at the end included ***)
 

--- a/x86/proofs/bignum_emontredc_8n.ml
+++ b/x86/proofs/bignum_emontredc_8n.ml
@@ -1122,9 +1122,9 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
     MAP_EVERY EXPAND_TAC ["k'"; "k8"] THEN SUBSUMED_MAYCHANGE_TAC;
     ALL_TAC] THEN
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`a':num`,`a:num`); (`n':num`,`n:num`); (`k':num`,`k:num`)] THEN
@@ -1393,10 +1393,10 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
 
   (*** Now forget more things; back up a few steps and forget i as well ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z:int64`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q1:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z:int64`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q1:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r1:num`) o concl)) THEN
 
   ENSURES_SEQUENCE_TAC `pc + 0xb0e`
    `\s. read RSP s = stackpointer /\
@@ -1426,7 +1426,7 @@ let BIGNUM_EMONTREDC_8N_CORRECT = time prove
       CONV_TAC WORD_RULE]] THEN
 
   ABBREV_TAC `wouter:int64 = word (k8 - i)` THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `i:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `i:num`) o concl)) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
   MAP_EVERY SPEC_TAC
     [(`z1:num`,`a:num`); (`z':int64`,`z:int64`)] THEN

--- a/x86/proofs/bignum_kmul_32_64.ml
+++ b/x86/proofs/bignum_kmul_32_64.ml
@@ -2865,7 +2865,7 @@ let tac mc execth pcinst =
     UNDISCH_TAC
      `read (memory :> bytes64 (word_add stackpointer (word 8))) s159 = z` THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
     DISCH_TAC] THEN
 
   (*** Second absolute difference computation, then throw away y data ***)
@@ -2916,7 +2916,7 @@ let tac mc execth pcinst =
     UNDISCH_TAC
      `read (memory :> bytes64 (word_add stackpointer (word 8))) s305 = z` THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
     DISCH_TAC] THEN
 
   (*** Stashing the combined sign ***)
@@ -3001,7 +3001,7 @@ let tac mc execth pcinst =
   UNDISCH_THEN
   `&(val(sum_s445:int64)):real = &(bitval carry_s442) + &(bitval carry_s441)`
   SUBST_ALL_TAC THEN
-  FIRST_X_ASSUM(MP_TAC o check (free_in `carry_s641:bool` o concl)) THEN
+  FIRST_X_ASSUM(MP_TAC o check (vfree_in `carry_s641:bool` o concl)) THEN
   DISCH_THEN(MP_TAC o SPEC `&(bitval sgn):real` o MATCH_MP (REAL_ARITH
    `&2 pow 64 * c + s = x
     ==> !c'. (&2 pow 64 * c + s = x ==> c = c')

--- a/x86/proofs/bignum_ksqr_32_64.ml
+++ b/x86/proofs/bignum_ksqr_32_64.ml
@@ -1880,7 +1880,7 @@ let tac mc execth pcinst =
   (*** Discard elementwise assignments and things to do with x ***)
 
   DISCARD_MATCHING_ASSUMPTIONS [`read (memory :> bytes64 x) s = y`] THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Digitize low and high products ***)
 

--- a/x86/proofs/bignum_modifier.ml
+++ b/x86/proofs/bignum_modifier.ml
@@ -1823,8 +1823,8 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -2191,7 +2191,7 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read R11 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2557,7 +2557,7 @@ let BIGNUM_MODIFIER_CORRECT = time prove
       REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
       REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
       ALL_TAC] THEN
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
     REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
                 GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
     SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN
@@ -2586,13 +2586,13 @@ let BIGNUM_MODIFIER_CORRECT = time prove
 
   (*** Clean away some things we no longer need from first chapter ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z2:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z1:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z2:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z1:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r:num` o concl))) THEN
 
   (*** Ghost the intermediate value of z as "a" ***)
 

--- a/x86/proofs/bignum_modinv.ml
+++ b/x86/proofs/bignum_modinv.ml
@@ -647,7 +647,7 @@ let CORE_MODINV_CORRECT = prove
 
   UNDISCH_THEN `word_add ww (word (8 * k)):int64 = mm` (K ALL_TAC) THEN
   UNDISCH_THEN `word_add ww (word (16 * k)):int64 = nn` (K ALL_TAC) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `x:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `x:int64` o concl))) THEN
 
   (*** Further initialization including modular inverse ***)
 
@@ -807,7 +807,7 @@ let CORE_MODINV_CORRECT = prove
   SUBGOAL_THEN `t - 58 * icount <= 128 * k` MP_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
   SPEC_TAC(`t - 58 * icount`,`t':num`) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:num` o concl))) THEN
   X_GEN_TAC `t:num` THEN REPEAT DISCH_TAC THEN
   GHOST_INTRO_TAC `m0:num` `bignum_from_memory(mm,k)` THEN
   GHOST_INTRO_TAC `n0:num` `bignum_from_memory(nn,k)` THEN
@@ -2401,10 +2401,10 @@ let CORE_MODINV_CORRECT = prove
   GLOBALIZE_PRECONDITION_TAC THEN ASM_REWRITE_TAC[] THEN
   REPEAT(FIRST_X_ASSUM(CONJUNCTS_THEN ASSUME_TAC)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `lowerr:num->real` o concl))) THEN
+    check (vfree_in `lowerr:num->real` o concl))) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `upperr:num->real` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `base:int` o concl))) THEN
+    check (vfree_in `upperr:num->real` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `base:int` o concl))) THEN
 
   (*** Congruence cross-multiplication and shift-by-6 "congloop" ***)
 

--- a/x86/proofs/bignum_montifier.ml
+++ b/x86/proofs/bignum_montifier.ml
@@ -1823,8 +1823,8 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** A bit of cleanup ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `l:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `l:num` o concl))) THEN
   REWRITE_TAC[TAUT `p ==> q /\ r <=> (p ==> q) /\ (p ==> r)`] THEN
   GHOST_INTRO_TAC `r:num` `bignum_from_memory (z,k)` THEN
   BIGNUM_TERMRANGE_TAC `k:num` `r:num` THEN GLOBALIZE_PRECONDITION_TAC THEN
@@ -2195,7 +2195,7 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** More cleanup and setup of Montgomery multiplier ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
   GHOST_INTRO_TAC `h:num` `\s. val(read R11 s)` THEN
   REWRITE_TAC[VAL_WORD_GALOIS; DIMINDEX_64] THEN
   GHOST_INTRO_TAC `z1:num` `bignum_from_memory (t,k)` THEN
@@ -2561,7 +2561,7 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
       REWRITE_TAC[REAL_OF_NUM_CLAUSES; GSYM BIGNUM_FROM_MEMORY_BYTES] THEN
       REWRITE_TAC[BIGNUM_FROM_MEMORY_BOUND; LE_0];
       ALL_TAC] THEN
-    REPEAT(FIRST_X_ASSUM(MP_TAC o check (free_in `cf:bool` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(MP_TAC o check (vfree_in `cf:bool` o concl))) THEN
     REWRITE_TAC[GSYM int_of_num_th; GSYM int_pow_th; GSYM int_mul_th;
                 GSYM int_add_th; GSYM int_sub_th; GSYM int_eq] THEN
     SIMP_TAC[num_congruent; GSYM INT_OF_NUM_CLAUSES] THEN
@@ -2590,13 +2590,13 @@ let BIGNUM_MONTIFIER_CORRECT = time prove
 
   (*** Clean away some things we no longer need from first chapter ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `t:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z2:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z1:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `q0:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `h:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `r:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `t:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z2:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z1:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `q0:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `h:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `r:num` o concl))) THEN
 
   (*** Ghost the intermediate value of z as "a" ***)
 

--- a/x86/proofs/bignum_negmodinv.ml
+++ b/x86/proofs/bignum_negmodinv.ml
@@ -497,10 +497,10 @@ let BIGNUM_NEGMODINV_CORRECT = prove
   SUBGOAL_THEN `2 <= p /\ p < 2 EXP 61` STRIP_ASSUME_TAC THENL
    [SIMPLE_ARITH_TAC; ALL_TAC] THEN
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `z:int64` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `i:num` o concl))) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `k:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `z:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `i:num` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `k:num` o concl))) THEN
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN
 
   SPEC_TAC(`m':num`,`m:num`) THEN SPEC_TAC(`z':int64`,`z:int64`) THEN

--- a/x86/proofs/bignum_tomont_p256k1.ml
+++ b/x86/proofs/bignum_tomont_p256k1.ml
@@ -118,7 +118,7 @@ let BIGNUM_TOMONT_P256K1_CORRECT = time prove
   (*** Quotient estimate is just the top word after the +1 ***)
 
   ABBREV_TAC `q:int64 = sum_s9` THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `sum_s9:int64` o concl))) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `sum_s9:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 256 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;

--- a/x86/proofs/bignum_tomont_sm2.ml
+++ b/x86/proofs/bignum_tomont_sm2.ml
@@ -250,7 +250,7 @@ let BIGNUM_TOMONT_SM2_CORRECT = time prove
     MAP_EVERY UNDISCH_TAC
      [`read RDI s17 = z`; `read RIP s17 = word (pc + 70)`] THEN
     DISCARD_MATCHING_ASSUMPTIONS [`read Xnn s = y`] THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num` o concl))) THEN
     DISCH_TAC THEN DISCH_TAC] THEN
   SUBGOAL_THEN
    `(2 EXP 256 * a) MOD p_sm2 = (2 EXP 256 * a MOD p_sm2) MOD p_sm2`
@@ -398,9 +398,9 @@ let BIGNUM_TOMONT_SM2_CORRECT = time prove
 
   (*** Reset all the variables to match the initial expectations ***)
 
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `a:num`) o concl)) THEN
-  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `w:int64`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `a:num`) o concl)) THEN
+  REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `w:int64`) o concl)) THEN
   DISCARD_MATCHING_ASSUMPTIONS [`read (rvalue w) s = y`] THEN
 
   POP_ASSUM_LIST(MP_TAC o end_itlist CONJ o rev) THEN

--- a/x86/proofs/bignum_triple_p256k1.ml
+++ b/x86/proofs/bignum_triple_p256k1.ml
@@ -129,7 +129,7 @@ let BIGNUM_TRIPLE_P256K1_CORRECT = time prove
 
   ABBREV_TAC `q:int64 = sum_s20` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s20:int64` o concl))) THEN
+    check (vfree_in `sum_s20:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 256 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;

--- a/x86/proofs/bignum_triple_p256k1_alt.ml
+++ b/x86/proofs/bignum_triple_p256k1_alt.ml
@@ -118,7 +118,7 @@ let BIGNUM_TRIPLE_P256K1_ALT_CORRECT = time prove
 
   ABBREV_TAC `q:int64 = sum_s19` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s19:int64` o concl))) THEN
+    check (vfree_in `sum_s19:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 256 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;

--- a/x86/proofs/curve25519_x25519.ml
+++ b/x86/proofs/curve25519_x25519.ml
@@ -8359,9 +8359,9 @@ let CURVE25519_X25519_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/x86/proofs/curve25519_x25519_alt.ml
+++ b/x86/proofs/curve25519_x25519_alt.ml
@@ -8578,9 +8578,9 @@ let CURVE25519_X25519_ALT_CORRECT = time prove
     ALL_TAC] THEN
 
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `n_input:num`) o concl)) THEN
+   check (vfree_in `n_input:num`) o concl)) THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-   check (free_in `X_input:num`) o concl)) THEN
+   check (vfree_in `X_input:num`) o concl)) THEN
 
   (*** The inlining of modular inverse ***)
 

--- a/x86/proofs/p256_montjdouble.ml
+++ b/x86/proofs/p256_montjdouble.ml
@@ -2728,7 +2728,7 @@ let LOCAL_CMSUB41_P256_TAC =
 
   ABBREV_TAC `q:int64 = sum_s16` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s16:int64` o concl))) THEN
+    check (vfree_in `sum_s16:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/x86/proofs/p384_montjdouble.ml
+++ b/x86/proofs/p384_montjdouble.ml
@@ -4346,7 +4346,7 @@ let LOCAL_CMSUBC9_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s46` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s46:int64` o concl))) THEN
+    check (vfree_in `sum_s46:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 384 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;
@@ -4496,7 +4496,7 @@ let LOCAL_CMSUB41_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s22` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s22:int64` o concl))) THEN
+    check (vfree_in `sum_s22:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 384 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
@@ -4677,7 +4677,7 @@ let LOCAL_CMSUB38_P384_TAC =
 
   ABBREV_TAC `q:int64 = sum_s42` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s42:int64` o concl))) THEN
+    check (vfree_in `sum_s42:int64` o concl))) THEN
   SUBGOAL_THEN `ca DIV 2 EXP 384 = val(q:int64)` SUBST_ALL_TAC THENL
    [EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN
     REFL_TAC;

--- a/x86/proofs/p521_jdouble.ml
+++ b/x86/proofs/p521_jdouble.ml
@@ -5659,9 +5659,9 @@ let LOCAL_CMSUBC9_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 
@@ -5971,9 +5971,9 @@ let LOCAL_CMSUB41_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 
@@ -6262,9 +6262,9 @@ let LOCAL_CMSUB38_P521_TAC =
     REWRITE_TAC[REAL_VAL_WORD_NOT; DIMINDEX_64] THEN
     DISCH_THEN(fun th -> REWRITE_TAC[th]) THEN REAL_INTEGER_TAC;
     ACCUMULATOR_POP_ASSUM_LIST(K ALL_TAC) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `m:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n:num` o concl))) THEN
-    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `n':num` o concl)))] THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `m:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n:num` o concl))) THEN
+    REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `n':num` o concl)))] THEN
 
   (*** Breaking the problem down to (h + l) MOD p_521 ***)
 

--- a/x86/proofs/secp256k1_jdouble.ml
+++ b/x86/proofs/secp256k1_jdouble.ml
@@ -2236,7 +2236,7 @@ let LOCAL_CMSUB41_P256K1_TAC =
 
   ABBREV_TAC `q:int64 = sum_s16` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s16:int64` o concl))) THEN
+    check (vfree_in `sum_s16:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/x86/proofs/sm2_montjdouble.ml
+++ b/x86/proofs/sm2_montjdouble.ml
@@ -2579,7 +2579,7 @@ let LOCAL_CMSUB41_SM2_TAC =
 
   ABBREV_TAC `q:int64 = sum_s16` THEN
   REPEAT(FIRST_X_ASSUM(K ALL_TAC o
-    check (free_in `sum_s16:int64` o concl))) THEN
+    check (vfree_in `sum_s16:int64` o concl))) THEN
   SUBGOAL_THEN `&ca div &2 pow 256 = &(val(q:int64))` SUBST_ALL_TAC THENL
    [REWRITE_TAC[INT_OF_NUM_CLAUSES; INT_OF_NUM_DIV] THEN
     EXPAND_TAC "ca" THEN CONV_TAC(LAND_CONV BIGNUM_OF_WORDLIST_DIV_CONV) THEN

--- a/x86/proofs/word_recip.ml
+++ b/x86/proofs/word_recip.ml
@@ -505,7 +505,7 @@ let WORD_RECIP_CORRECT = prove
      `a / &2 pow 16 - e + &1 = b ==> a = &2 pow 16 * (b + e - &1)`)) THEN
    REWRITE_TAC[REAL_ARITH `(c * (b + x)) * z:real = c * (b * z + x * z)`] THEN
    CONJ_TAC THEN ASM PURE_BOUNDER_TAC[];
-   REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (free_in `b:int64` o concl)))] THEN
+   REPEAT(FIRST_X_ASSUM(K ALL_TAC o check (vfree_in `b:int64` o concl)))] THEN
 
   (*** Observe this, which implies in particular the result is not exact ***)
 

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -1888,7 +1888,7 @@ let BSID_NORMALIZE_TAC =
             let th = rule tm in
             MP th (siderule_1 asl (lhand(concl th)))) rules in
   let fullconv(asl,w) tm =
-    if not(free_in tm w) then failwith "rule" else
+    if not(vfree_in tm w) then failwith "rule" else
     let th = rule_spc tm in
     MP th (siderule (map snd asl) (lhand(concl th))) in
   GEN_REWRITE_TAC ONCE_DEPTH_CONV [pth_gen] THEN
@@ -2477,7 +2477,7 @@ let DISCARD_FLAGS_TAC =
     `read ZF s = y`; `read SF s = y`; `read OF s = y`];;
 
 let DISCARD_STATE_TAC s =
-  DISCARD_ASSUMPTIONS_TAC (free_in (mk_var(s,`:x86state`)) o concl);;
+  DISCARD_ASSUMPTIONS_TAC (vfree_in (mk_var(s,`:x86state`)) o concl);;
 
 let DISCARD_OLDSTATE_TAC s =
   let v = mk_var(s,`:x86state`) in
@@ -2837,7 +2837,7 @@ let GEN_X86_ADD_RETURN_STACK_TAC =
     REWRITE_TAC [MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI;
                  WINDOWS_MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI] THEN
     REPEAT(MATCH_MP_TAC mono2lemma THEN GEN_TAC) THEN
-    (if free_in `RSP` (concl coreth) then
+    (if vfree_in `RSP` (concl coreth) then
       DISCH_THEN(fun th -> WORD_FORALL_OFFSET_TAC stackoff THEN MP_TAC th) THEN
       MATCH_MP_TAC MONO_FORALL THEN GEN_TAC
      else
@@ -3039,7 +3039,7 @@ let WINDOWS_X86_WRAP_STACK_TAC =
     MATCH_MP_TAC pcofflemma THEN
     EXISTS_TAC (mk_small_numeral pcoff) THEN GEN_TAC THEN
     CONV_TAC(LAND_CONV(ONCE_DEPTH_CONV pcplusplus_conv)) THEN
-    (if free_in `RSP` (concl coreth) then
+    (if vfree_in `RSP` (concl coreth) then
      DISCH_THEN(fun th -> WORD_FORALL_OFFSET_TAC stackoff THEN MP_TAC th) THEN
      MATCH_MP_TAC MONO_FORALL THEN GEN_TAC
     else


### PR DESCRIPTION
This patch uses `vfree_in` instead of `free_in` if valid.
Actually, for the .ml files in `{arm,x86}/proofs` directory all occurrences of `free_in` could be replaced with `vfree_in` because their first operand was a variable.

This does not shorten the running time of CI, but for some proofs small speedups ~5% have been observed.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
