### PR TITLE
Avoid duplicate labels in ed25519 x86 implementation

### DIFF
--- a/x86/curve25519/edwards25519_scalarmuldouble.S
+++ b/x86/curve25519/edwards25519_scalarmuldouble.S
@@ -2072,8 +2072,8 @@ edwards25519_scalarmuldouble_loop:
         mov     [rsp+0x78], rax
         mov     QWORD PTR [rsp+0x90], 0xa
         mov     QWORD PTR [rsp+0x98], 0x1
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_midloop
+edwards25519_scalarmuldouble_inverseloop:
         mov     r9, r8
         sar     r9, 0x3f
         xor     r8, r9
@@ -2364,7 +2364,7 @@ curve25519_x25519_inverseloop:
         shl     rax, 0x3f
         add     rsi, rax
         mov     [rsp+0x78], rsi
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_midloop:
         mov     rsi, [rsp+0x98]
         mov     rdx, [rsp]
         mov     rcx, [rsp+0x20]
@@ -3265,7 +3265,7 @@ curve25519_x25519_midloop:
         lea     r12, [rax+rdx]
         mov     [rsp+0x98], rsi
         dec     QWORD PTR [rsp+0x90]
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_inverseloop
         mov     rax, [rsp]
         mov     rcx, [rsp+0x20]
         imul    rax, r8

--- a/x86/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/x86/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -2189,8 +2189,8 @@ edwards25519_scalarmuldouble_alt_loop:
         mov     [rsp+0x78], rax
         mov     QWORD PTR [rsp+0x90], 0xa
         mov     QWORD PTR [rsp+0x98], 0x1
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_alt_midloop
+edwards25519_scalarmuldouble_alt_inverseloop:
         mov     r9, r8
         sar     r9, 0x3f
         xor     r8, r9
@@ -2481,7 +2481,7 @@ curve25519_x25519_inverseloop:
         shl     rax, 0x3f
         add     rsi, rax
         mov     [rsp+0x78], rsi
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_alt_midloop:
         mov     rsi, [rsp+0x98]
         mov     rdx, [rsp]
         mov     rcx, [rsp+0x20]
@@ -3382,7 +3382,7 @@ curve25519_x25519_midloop:
         lea     r12, [rax+rdx]
         mov     [rsp+0x98], rsi
         dec     QWORD PTR [rsp+0x90]
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_alt_inverseloop
         mov     rax, [rsp]
         mov     rcx, [rsp+0x20]
         imul    rax, r8

--- a/x86_att/curve25519/edwards25519_scalarmuldouble.S
+++ b/x86_att/curve25519/edwards25519_scalarmuldouble.S
@@ -2072,8 +2072,8 @@ edwards25519_scalarmuldouble_loop:
         movq    %rax, 0x78(%rsp)
         movq    $0xa,  0x90(%rsp)
         movq    $0x1,  0x98(%rsp)
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_midloop
+edwards25519_scalarmuldouble_inverseloop:
         movq    %r8, %r9
         sarq    $0x3f, %r9
         xorq    %r9, %r8
@@ -2364,7 +2364,7 @@ curve25519_x25519_inverseloop:
         shlq    $0x3f, %rax
         addq    %rax, %rsi
         movq    %rsi, 0x78(%rsp)
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_midloop:
         movq    0x98(%rsp), %rsi
         movq    (%rsp), %rdx
         movq    0x20(%rsp), %rcx
@@ -3265,7 +3265,7 @@ curve25519_x25519_midloop:
         leaq    (%rax,%rdx), %r12
         movq    %rsi, 0x98(%rsp)
         decq     0x90(%rsp)
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_inverseloop
         movq    (%rsp), %rax
         movq    0x20(%rsp), %rcx
         imulq   %r8, %rax

--- a/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/x86_att/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -2189,8 +2189,8 @@ edwards25519_scalarmuldouble_alt_loop:
         movq    %rax, 0x78(%rsp)
         movq    $0xa,  0x90(%rsp)
         movq    $0x1,  0x98(%rsp)
-        jmp     curve25519_x25519_midloop
-curve25519_x25519_inverseloop:
+        jmp     edwards25519_scalarmuldouble_alt_midloop
+edwards25519_scalarmuldouble_alt_inverseloop:
         movq    %r8, %r9
         sarq    $0x3f, %r9
         xorq    %r9, %r8
@@ -2481,7 +2481,7 @@ curve25519_x25519_inverseloop:
         shlq    $0x3f, %rax
         addq    %rax, %rsi
         movq    %rsi, 0x78(%rsp)
-curve25519_x25519_midloop:
+edwards25519_scalarmuldouble_alt_midloop:
         movq    0x98(%rsp), %rsi
         movq    (%rsp), %rdx
         movq    0x20(%rsp), %rcx
@@ -3382,7 +3382,7 @@ curve25519_x25519_midloop:
         leaq    (%rax,%rdx), %r12
         movq    %rsi, 0x98(%rsp)
         decq     0x90(%rsp)
-        jne     curve25519_x25519_inverseloop
+        jne     edwards25519_scalarmuldouble_alt_inverseloop
         movq    (%rsp), %rax
         movq    0x20(%rsp), %rcx
         imulq   %r8, %rax


### PR DESCRIPTION
*Description of changes:*

It makes AWS-LC FIPS build angry when it attempts to join delocated assembly files into one... Hence, just prefix with the file name.

There is already a tool for it https://github.com/awslabs/s2n-bignum/blob/main/tools/per_file_unique_labels.py. Didn't use it, since it was faster just to change the few occurrences. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
