### PR TITLE
Fix GNU-stacz typo

### DIFF
--- a/arm/curve25519/bignum_madd_n25519.S
+++ b/arm/curve25519/bignum_madd_n25519.S
@@ -280,5 +280,5 @@ S2N_BN_SYMBOL(bignum_madd_n25519):
         ret
 
 #if defined(__linux__) && defined(__ELF__)
-.section .note.GNU-stacz,"",%progbits
+.section .note.GNU-stack,"",%progbits
 #endif

--- a/arm/curve25519/bignum_madd_n25519_alt.S
+++ b/arm/curve25519/bignum_madd_n25519_alt.S
@@ -206,5 +206,5 @@ S2N_BN_SYMBOL(bignum_madd_n25519_alt):
         ret
 
 #if defined(__linux__) && defined(__ELF__)
-.section .note.GNU-stacz,"",%progbits
+.section .note.GNU-stack,"",%progbits
 #endif


### PR DESCRIPTION
*Description of changes:*

`.section .note.GNU-stack,"",%progbits` tells the assembler not to use an executable stack. But `.note.GNU-stacz` looks like a typo. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
