### PR TITLE
Make _input_ parameter to ed25519 decode function const

### DIFF
--- a/arm/curve25519/edwards25519_decode.S
+++ b/arm/curve25519/edwards25519_decode.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as

--- a/arm/curve25519/edwards25519_decode_alt.S
+++ b/arm/curve25519/edwards25519_decode_alt.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as

--- a/include/s2n-bignum.h
+++ b/include/s2n-bignum.h
@@ -923,8 +923,8 @@ extern void curve25519_x25519base_byte_alt(uint8_t res[S2N_BIGNUM_STATIC 32],uin
 
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
-extern uint64_t edwards25519_decode(uint64_t z[S2N_BIGNUM_STATIC 8],uint8_t c[S2N_BIGNUM_STATIC 32]);
-extern uint64_t edwards25519_decode_alt(uint64_t z[S2N_BIGNUM_STATIC 8],uint8_t c[S2N_BIGNUM_STATIC 32]);
+extern uint64_t edwards25519_decode(uint64_t z[S2N_BIGNUM_STATIC 8], const uint8_t c[S2N_BIGNUM_STATIC 32]);
+extern uint64_t edwards25519_decode_alt(uint64_t z[S2N_BIGNUM_STATIC 8], const uint8_t c[S2N_BIGNUM_STATIC 32]);
 
 // Encode edwards25519 point into compressed form as 256-bit number
 // Input p[8]; output z[32] (bytes)

--- a/x86/curve25519/edwards25519_decode.S
+++ b/x86/curve25519/edwards25519_decode.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as

--- a/x86/curve25519/edwards25519_decode_alt.S
+++ b/x86/curve25519/edwards25519_decode_alt.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as

--- a/x86_att/curve25519/edwards25519_decode.S
+++ b/x86_att/curve25519/edwards25519_decode.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as

--- a/x86_att/curve25519/edwards25519_decode_alt.S
+++ b/x86_att/curve25519/edwards25519_decode_alt.S
@@ -5,7 +5,7 @@
 // Decode compressed 256-bit form of edwards25519 point
 // Input c[32] (bytes); output function return and z[8]
 //
-// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8],uint8_t c[static 32]);
+// extern uint64_t edwards25519_decode_alt(uint64_t z[static 8], const uint8_t c[static 32]);
 //
 // This interprets the input byte string as a little-endian number
 // representing a point (x,y) on the edwards25519 curve, encoded as


### PR DESCRIPTION
*Description of changes:*

AWS-LC expects the "input" parameter to be `const`. This assumption is already embedded in aws-lc's s2n-bignum copy: https://github.com/aws/aws-lc/blob/main/third_party/s2n-bignum/include/s2n-bignum_aws-lc.h#L302-L303.

This is just to upstream to s2n-bignum such that we can eventually directly consume the s2n-bignum project header file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
