### PR TITLE
Upgrade OCaml version to 4.14, fix an error in Arm simulator

### DIFF
--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -412,7 +412,7 @@ let run_random_simulation () =
       REWRITE_TAC[SOME_FLAGS] THEN
       ARM_SIM_TAC execth [1] THEN
       CONV_TAC(DEPTH_CONV WORD_NUM_RED_CONV) THEN REWRITE_TAC[] THEN
-      PRINT_GOAL_TAC "result mismatch" THEN
+      PRINT_GOAL_TAC THEN
       NO_TAC) in
     (decoded,result)
   else

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -5,9 +5,19 @@ phases:
       - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
       - wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | sudo apt-key add - # To resolve apt update GPG error about https://dl.google.com/linux/chrome/deb
       - apt-get update
-      - apt-get -y install ocaml camlp5 binutils-aarch64-linux-gnu binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu
-      - echo $(camlp5 -v)
+      - apt-get -y install ocaml binutils-aarch64-linux-gnu binutils-aarch64-linux-gnu binutils-x86-64-linux-gnu libstring-shellquote-perl
+      # Install OPAM
+      - wget https://raw.githubusercontent.com/ocaml/opam/master/shell/install.sh
+      - chmod +x install.sh
+      - echo "/usr/local/bin" | sh ./install.sh
+      - opam init --disable-sandboxing
+      - opam switch create 4.14.0
+      - eval $(opam env --switch=4.14.0)
       - echo $(ocamlc -version)
+      - opam pin -y add camlp5 8.00.03
+      - opam install -y num
+      - echo $(camlp5 -v)
+      # Build s2n-bignum
       - cd ${CODEBUILD_SRC_DIR_hol_light}
       - make
   build:
@@ -15,5 +25,6 @@ phases:
       - CORE_COUNT=$(nproc --all)
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
+      - eval $(opam env --switch=4.14.0)
       - make -j ${CORE_COUNT} proofs
       - ../tools/collect-times.sh ${S2N_BIGNUM_ARCH}

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -12,10 +12,10 @@ phases:
       - chmod +x install.sh
       - echo "/usr/local/bin" | sh ./install.sh
       - opam init --disable-sandboxing
-      - opam switch create 4.05.0
-      - eval $(opam env --switch=4.05.0)
+      - opam switch create 4.14.0
+      - eval $(opam env --switch=4.14.0)
       - echo $(ocamlc -version)
-      - opam pin -y add camlp5 7.10
+      - opam pin -y add camlp5 8.00.03
       - opam install -y num
       - echo $(camlp5 -v)
       # Build s2n-bignum
@@ -26,6 +26,6 @@ phases:
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
       - echo $HOLDIR
-      - eval $(opam env --switch=4.05.0)
+      - eval $(opam env --switch=4.14.0)
       - echo "`camlp5 -where`"
       - make sematest


### PR DESCRIPTION
*Description of changes:*

This patch upgrades OCaml version to 4.14, and also fixes an error in Arm simulator.

This patch is made on top of #114; the patch must be merged first.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
