### PR TITLE
Check axioms at the end of run-proof.sh

### DIFF
--- a/common/misc.ml
+++ b/common/misc.ml
@@ -15,6 +15,18 @@ needs "Library/rstc.ml";;
 needs "Library/words.ml";;
 
 (* ------------------------------------------------------------------------- *)
+(* A function that checks no axiom was introduced from s2n-bignum            *)
+(* ------------------------------------------------------------------------- *)
+
+let check_axioms () =
+  let basic_axioms = [INFINITY_AX; SELECT_AX; ETA_AX] in
+  let l = filter (fun th -> not (mem th basic_axioms)) (axioms()) in
+  if l <> [] then
+    let msg = "[" ^ (String.concat ", " (map string_of_thm l)) ^ "]" in
+    failwith ("Unknown axiom exists: " ^ msg);;
+
+
+(* ------------------------------------------------------------------------- *)
 (* Additional list operations and conversions on them.                       *)
 (* ------------------------------------------------------------------------- *)
 

--- a/tools/run-proof.sh
+++ b/tools/run-proof.sh
@@ -23,13 +23,14 @@ output_path=${s2n_bignum_arch}/$4
  echo 'let start_time = Unix.time();;'; \
  echo "loadt \"${s2n_bignum_arch}/proofs/base.ml\";;"; \
  echo "loadt \"${s2n_bignum_arch}/proofs/${asm_filename}.ml\";;"; \
+ echo "check_axioms ();;"; \
  echo 'let end_time = Unix.time();;'; \
  echo 'Printf.printf "Running time: %f sec, Start unixtime: %f, End unixtime: %f\n" (end_time -. start_time) start_time end_time;;') | eval "$hol_light_cmd" 2>&1 > "$output_path"
 
 # Revert the exit code option since 'grep' may return non-zero.
 set +e
 
-grep -r -i "error" --include "$output_path"
+grep -r -i "error\|exception" --include "$output_path"
 if [ $? -eq 0 ]; then
   echo "${s2n_bignum_arch}/proofs/${asm_filename}.ml had error(s)"
   exit 1


### PR DESCRIPTION
This patch adds `check_axioms()` and calls it at the end of `run-proofs.sh` to check the absence of newly introduced axioms.

This also adds grepping 'exception' from the output of REPL because `failwith` appears as `Exception: Failure ...`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
