### PR TITLE
Add `needs "{arm,x86}/proofs/base.ml"` to proofs

### DIFF
--- a/arm/proofs/bignum_add.ml
+++ b/arm/proofs/bignum_add.ml
@@ -7,6 +7,8 @@
 (* Addition of bignums.                                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_add.o";;
  ****)
 

--- a/arm/proofs/bignum_add_p25519.ml
+++ b/arm/proofs/bignum_add_p25519.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_add_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_add_p256.ml
+++ b/arm/proofs/bignum_add_p256.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_add_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_add_p256k1.ml
+++ b/arm/proofs/bignum_add_p256k1.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_add_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_add_p384.ml
+++ b/arm/proofs/bignum_add_p384.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_add_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_add_p521.ml
+++ b/arm/proofs/bignum_add_p521.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_add_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_add_sm2.ml
+++ b/arm/proofs/bignum_add_sm2.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_add_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_amontifier.ml
+++ b/arm/proofs/bignum_amontifier.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomerifier computation.                                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_amontifier.o";;
  ****)
 

--- a/arm/proofs/bignum_amontmul.ml
+++ b/arm/proofs/bignum_amontmul.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery multiplication of arbitrary bignums.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_amontmul.o";;
  ****)
 

--- a/arm/proofs/bignum_amontredc.ml
+++ b/arm/proofs/bignum_amontredc.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery reduction of arbitrary bignum.                          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_amontredc.o";;
  ****)
 

--- a/arm/proofs/bignum_amontsqr.ml
+++ b/arm/proofs/bignum_amontsqr.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery squaring of arbitrary bignum.                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_amontsqr.o";;
  ****)
 

--- a/arm/proofs/bignum_bigendian_4.ml
+++ b/arm/proofs/bignum_bigendian_4.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (bigendian, frombebytes and tobebytes).      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_bigendian_4.o";;
  ****)
 

--- a/arm/proofs/bignum_bigendian_6.ml
+++ b/arm/proofs/bignum_bigendian_6.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (bigendian, frombebytes and tobebytes).      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_bigendian_6.o";;
  ****)
 

--- a/arm/proofs/bignum_bitfield.ml
+++ b/arm/proofs/bignum_bitfield.ml
@@ -7,6 +7,8 @@
 (* Constant-time bitfield selection from bignum.                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_bitfield.o";;
  ****)
 

--- a/arm/proofs/bignum_bitsize.ml
+++ b/arm/proofs/bignum_bitsize.ml
@@ -7,6 +7,8 @@
 (* Size in bits of a bignum                                                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_bitsize.o";;
  ****)
 

--- a/arm/proofs/bignum_cdiv.ml
+++ b/arm/proofs/bignum_cdiv.ml
@@ -7,6 +7,8 @@
 (* Division and remainder of bignum by a single (nonzero) word.              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cdiv.o";;
  ****)
 

--- a/arm/proofs/bignum_cdiv_exact.ml
+++ b/arm/proofs/bignum_cdiv_exact.ml
@@ -7,6 +7,8 @@
 (* Division of bignum by a single word when known a priori to be exact.      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cdiv_exact.o";;
  ****)
 

--- a/arm/proofs/bignum_cld.ml
+++ b/arm/proofs/bignum_cld.ml
@@ -7,6 +7,8 @@
 (* Counting leading zero digits of a bignum.                                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cld.o";;
  ****)
 

--- a/arm/proofs/bignum_clz.ml
+++ b/arm/proofs/bignum_clz.ml
@@ -7,6 +7,8 @@
 (* Counting leading zero bits in a bignum.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_clz.o";;
  ****)
 

--- a/arm/proofs/bignum_cmadd.ml
+++ b/arm/proofs/bignum_cmadd.ml
@@ -7,6 +7,8 @@
 (* Multiply-accumulate of bignum by a single word.                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cmadd.o";;
  ****)
 

--- a/arm/proofs/bignum_cmnegadd.ml
+++ b/arm/proofs/bignum_cmnegadd.ml
@@ -7,6 +7,8 @@
 (* Negating multiply-accumulate of bignum by a single word.                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cmnegadd.o";;
  ****)
 

--- a/arm/proofs/bignum_cmod.ml
+++ b/arm/proofs/bignum_cmod.ml
@@ -7,6 +7,8 @@
 (* Modulus of bignum by a single word.                                       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cmod.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul.ml
+++ b/arm/proofs/bignum_cmul.ml
@@ -7,6 +7,8 @@
 (* Multiplication of bignum by a single word.                                *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_cmul.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_p25519.ml
+++ b/arm/proofs/bignum_cmul_p25519.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519 of a single word and a bignum < p_25519.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_cmul_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_p256.ml
+++ b/arm/proofs/bignum_cmul_p256.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256 of a single word and a bignum < p_256.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_cmul_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_p256k1.ml
+++ b/arm/proofs/bignum_cmul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1 of a single word and a bignum < p_256k1.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_cmul_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_p384.ml
+++ b/arm/proofs/bignum_cmul_p384.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_384 of a single word and a bignum < p_384.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_cmul_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_p521.ml
+++ b/arm/proofs/bignum_cmul_p521.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521 of a single word and a bignum < p_521.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_cmul_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_cmul_sm2.ml
+++ b/arm/proofs/bignum_cmul_sm2.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_sm2 of a single word and a bignum < p_sm2.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_cmul_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_coprime.ml
+++ b/arm/proofs/bignum_coprime.ml
@@ -7,6 +7,8 @@
 (* Coprimality test for two arbitrary bignums.                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_coprime.o";;
  ****)
 

--- a/arm/proofs/bignum_copy.ml
+++ b/arm/proofs/bignum_copy.ml
@@ -7,6 +7,8 @@
 (* Copying (with truncation or extension) bignums                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_copy.o";;
  ****)
 

--- a/arm/proofs/bignum_copy_row_from_table.ml
+++ b/arm/proofs/bignum_copy_row_from_table.ml
@@ -7,6 +7,8 @@
 (* Constant-time table lookup.                                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 let bignum_copy_row_from_table_mc =
   define_assert_from_elf "bignum_copy_row_from_table_mc"
                          "arm/generic/bignum_copy_row_from_table.o"

--- a/arm/proofs/bignum_copy_row_from_table_16_neon.ml
+++ b/arm/proofs/bignum_copy_row_from_table_16_neon.ml
@@ -7,6 +7,8 @@
 (* Constant-time table lookup.                                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 let bignum_copy_row_from_table_16_neon_mc =
   define_assert_from_elf "bignum_copy_row_from_table_16_neon_mc"
                          "arm/generic/bignum_copy_row_from_table_16_neon.o"

--- a/arm/proofs/bignum_copy_row_from_table_32_neon.ml
+++ b/arm/proofs/bignum_copy_row_from_table_32_neon.ml
@@ -7,6 +7,8 @@
 (* Constant-time table lookup.                                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 let bignum_copy_row_from_table_32_neon_mc =
   define_assert_from_elf "bignum_copy_row_from_table_32_neon_mc"
                          "arm/generic/bignum_copy_row_from_table_32_neon.o"

--- a/arm/proofs/bignum_copy_row_from_table_8n_neon.ml
+++ b/arm/proofs/bignum_copy_row_from_table_8n_neon.ml
@@ -7,6 +7,8 @@
 (* Constant-time table lookup.                                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 let bignum_copy_row_from_table_8n_neon_mc =
   define_assert_from_elf "bignum_copy_row_from_table_8n_neon_mc"
                          "arm/generic/bignum_copy_row_from_table_8n_neon.o"

--- a/arm/proofs/bignum_ctd.ml
+++ b/arm/proofs/bignum_ctd.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zero digits in a bignum.                                *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_ctd.o";;
  ****)
 

--- a/arm/proofs/bignum_ctz.ml
+++ b/arm/proofs/bignum_ctz.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zero bits in a bignum.                                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_ctz.o";;
  ****)
 

--- a/arm/proofs/bignum_deamont_p256.ml
+++ b/arm/proofs/bignum_deamont_p256.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_256.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_deamont_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_deamont_p256k1.ml
+++ b/arm/proofs/bignum_deamont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_256k1.           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_deamont_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_deamont_p384.ml
+++ b/arm/proofs/bignum_deamont_p384.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_384.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_deamont_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_deamont_p521.ml
+++ b/arm/proofs/bignum_deamont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_521.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_deamont_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_deamont_sm2.ml
+++ b/arm/proofs/bignum_deamont_sm2.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_sm2.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_deamont_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_demont.ml
+++ b/arm/proofs/bignum_demont.ml
@@ -7,6 +7,8 @@
 (* de-Montgomerification, i.e. "short" Mongomery reduction.                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_demont.o";;
  ****)
 

--- a/arm/proofs/bignum_demont_p256.ml
+++ b/arm/proofs/bignum_demont_p256.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_256.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_demont_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_demont_p256k1.ml
+++ b/arm/proofs/bignum_demont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_256k1.                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_demont_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_demont_p384.ml
+++ b/arm/proofs/bignum_demont_p384.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_384.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_demont_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_demont_p521.ml
+++ b/arm/proofs/bignum_demont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping out of reduced Montgomery representation mod p_521.               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_demont_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_demont_sm2.ml
+++ b/arm/proofs/bignum_demont_sm2.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_sm2.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_demont_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_digit.ml
+++ b/arm/proofs/bignum_digit.ml
@@ -7,6 +7,8 @@
 (* Constant-time digit selection from bignum.                                *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_digit.o";;
  ****)
 

--- a/arm/proofs/bignum_digitsize.ml
+++ b/arm/proofs/bignum_digitsize.ml
@@ -7,6 +7,8 @@
 (* Size in digits of a bignum                                                *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_digitsize.o";;
  ****)
 

--- a/arm/proofs/bignum_divmod10.ml
+++ b/arm/proofs/bignum_divmod10.ml
@@ -7,6 +7,8 @@
 (* Division by 10 with remainder.                                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_divmod10.o";;
  ****)
 

--- a/arm/proofs/bignum_double_p25519.ml
+++ b/arm/proofs/bignum_double_p25519.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_double_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_double_p256.ml
+++ b/arm/proofs/bignum_double_p256.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_double_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_double_p256k1.ml
+++ b/arm/proofs/bignum_double_p256k1.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_double_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_double_p384.ml
+++ b/arm/proofs/bignum_double_p384.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_double_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_double_p521.ml
+++ b/arm/proofs/bignum_double_p521.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_double_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_double_sm2.ml
+++ b/arm/proofs/bignum_double_sm2.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_double_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_emontredc.ml
+++ b/arm/proofs/bignum_emontredc.ml
@@ -7,6 +7,8 @@
 (* Extended Montgomery reduction of arbitrary bignum.                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_emontredc.o";;
  ****)
 

--- a/arm/proofs/bignum_emontredc_8n.ml
+++ b/arm/proofs/bignum_emontredc_8n.ml
@@ -7,6 +7,8 @@
 (* Extended Montgomery reduction of arbitrary bignum.                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_emontredc_8n.o";;
  ****)
 

--- a/arm/proofs/bignum_emontredc_8n_neon.ml
+++ b/arm/proofs/bignum_emontredc_8n_neon.ml
@@ -7,6 +7,8 @@
 (* Extended Montgomery reduction of arbitrary bignum.                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_emontredc_8n_neon.o";;
  ****)
 

--- a/arm/proofs/bignum_eq.ml
+++ b/arm/proofs/bignum_eq.ml
@@ -7,6 +7,8 @@
 (* Equality test on bignums.                                                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_eq.o";;
  ****)
 

--- a/arm/proofs/bignum_even.ml
+++ b/arm/proofs/bignum_even.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is even or odd.                                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_even.o";;
  ****)
 

--- a/arm/proofs/bignum_fromlebytes_p521.ml
+++ b/arm/proofs/bignum_fromlebytes_p521.ml
@@ -7,6 +7,8 @@
 (* Translation from little-endian byte sequence, 66 bytes -> 9 digits.       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_fromlebytes_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_ge.ml
+++ b/arm/proofs/bignum_ge.ml
@@ -7,6 +7,8 @@
 (* Comparison >= test on bignums.                                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_ge.o";;
  ****)
 

--- a/arm/proofs/bignum_gt.ml
+++ b/arm/proofs/bignum_gt.ml
@@ -7,6 +7,8 @@
 (* Comparison > test on bignums.                                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_gt.o";;
  ****)
 

--- a/arm/proofs/bignum_half_p256.ml
+++ b/arm/proofs/bignum_half_p256.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_256, the field characteristic for the NIST P-256 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_half_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_half_p256k1.ml
+++ b/arm/proofs/bignum_half_p256k1.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_256k1, the field characteristic for secp256k1.           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_half_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_half_p384.ml
+++ b/arm/proofs/bignum_half_p384.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_384, the field characteristic for the NIST P-384 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_half_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_half_p521.ml
+++ b/arm/proofs/bignum_half_p521.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_521, the field characteristic for the NIST P-521 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_half_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_half_sm2.ml
+++ b/arm/proofs/bignum_half_sm2.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_sm2, the field characteristic for the CC SM2 curve.      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_half_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_invsqrt_p25519_alt.ml
+++ b/arm/proofs/bignum_invsqrt_p25519_alt.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/arm/proofs/bignum_iszero.ml
+++ b/arm/proofs/bignum_iszero.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is zero.                                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_iszero.o";;
  ****)
 

--- a/arm/proofs/bignum_kmul_16_32.ml
+++ b/arm/proofs/bignum_kmul_16_32.ml
@@ -7,6 +7,8 @@
 (* 16x16 -> 32 multiplication, using Karatsuba reduction.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_kmul_16_32.o";;
  ****)
 

--- a/arm/proofs/bignum_kmul_16_32_neon.ml
+++ b/arm/proofs/bignum_kmul_16_32_neon.ml
@@ -7,6 +7,8 @@
 (* 16x16 -> 32 multiplication, using Karatsuba reduction.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_kmul_16_32_neon.o";;
  ****)
 

--- a/arm/proofs/bignum_kmul_32_64.ml
+++ b/arm/proofs/bignum_kmul_32_64.ml
@@ -7,6 +7,8 @@
 (* 32x32 -> 64 multiplication, using Karatsuba reduction.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_kmul_32_64.o";;
  ****)
 

--- a/arm/proofs/bignum_kmul_32_64_neon.ml
+++ b/arm/proofs/bignum_kmul_32_64_neon.ml
@@ -7,6 +7,8 @@
 (* 32x32 -> 64 multiplication, using Karatsuba reduction.                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_kmul_32_64_neon.o";;
  ****)
 

--- a/arm/proofs/bignum_ksqr_16_32.ml
+++ b/arm/proofs/bignum_ksqr_16_32.ml
@@ -7,6 +7,8 @@
 (* 16x16 -> 32 squaring, using Karatsuba reduction.                          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_ksqr_16_32.o";;
  ****)
 

--- a/arm/proofs/bignum_ksqr_16_32_neon.ml
+++ b/arm/proofs/bignum_ksqr_16_32_neon.ml
@@ -7,6 +7,8 @@
 (* 16x16 -> 32 squaring, using Karatsuba reduction.                          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_ksqr_16_32_neon.o";;
  ****)
 

--- a/arm/proofs/bignum_ksqr_32_64.ml
+++ b/arm/proofs/bignum_ksqr_32_64.ml
@@ -7,6 +7,8 @@
 (* Karatsuba (multi-level) 32x32->64 squaring.                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_ksqr_32_64.o";;
  ****)
 

--- a/arm/proofs/bignum_ksqr_32_64_neon.ml
+++ b/arm/proofs/bignum_ksqr_32_64_neon.ml
@@ -7,6 +7,8 @@
 (* Karatsuba (multi-level) 32x32->64 squaring.                               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_ksqr_32_64_neon.o";;
  ****)
 

--- a/arm/proofs/bignum_le.ml
+++ b/arm/proofs/bignum_le.ml
@@ -7,6 +7,8 @@
 (* Comparison <= test on bignums.                                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_le.o";;
  ****)
 

--- a/arm/proofs/bignum_littleendian_4.ml
+++ b/arm/proofs/bignum_littleendian_4.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (littleendian, fromlebytes and tolebytes).   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_littleendian_4.o";;
  ****)
 

--- a/arm/proofs/bignum_littleendian_6.ml
+++ b/arm/proofs/bignum_littleendian_6.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (littleendian, fromlebytes and tolebytes).   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_littleendian_6.o";;
  ****)
 

--- a/arm/proofs/bignum_lt.ml
+++ b/arm/proofs/bignum_lt.ml
@@ -7,6 +7,8 @@
 (* Comparison < test on bignums.                                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_lt.o";;
  ****)
 

--- a/arm/proofs/bignum_madd.ml
+++ b/arm/proofs/bignum_madd.ml
@@ -7,6 +7,8 @@
 (* Multiplication-and-addition with (careful!) carry/remainder term.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_madd.o";;
  ****)
 

--- a/arm/proofs/bignum_madd_n25519.ml
+++ b/arm/proofs/bignum_madd_n25519.ml
@@ -7,6 +7,8 @@
 (* Multiply-add mod n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_madd_n25519.o";;
  ****)
 

--- a/arm/proofs/bignum_madd_n25519_alt.ml
+++ b/arm/proofs/bignum_madd_n25519_alt.ml
@@ -7,6 +7,8 @@
 (* Multiply-add mod n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_madd_n25519_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_m25519_4.ml
+++ b/arm/proofs/bignum_mod_m25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo m_25519, the full group order for curve25519.            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mod_m25519_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n25519.ml
+++ b/arm/proofs/bignum_mod_n25519.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mod_n25519.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n25519_4.ml
+++ b/arm/proofs/bignum_mod_n25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_25519, the basepoint order for curve25519.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mod_n25519_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n256.ml
+++ b/arm/proofs/bignum_mod_n256.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_mod_n256.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n256_4.ml
+++ b/arm/proofs/bignum_mod_n256_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_mod_n256_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n256k1_4.ml
+++ b/arm/proofs/bignum_mod_n256k1_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256k1, the order of the secp256k1 curve.               *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_mod_n256k1_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n384.ml
+++ b/arm/proofs/bignum_mod_n384.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_mod_n384.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n384_6.ml
+++ b/arm/proofs/bignum_mod_n384_6.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_mod_n384_6.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_n521_9.ml
+++ b/arm/proofs/bignum_mod_n521_9.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_521, the order of the NIST curve P-521                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_mod_n521_9.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_nsm2.ml
+++ b/arm/proofs/bignum_mod_nsm2.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_sm2, the order of the GM/T 0003-2012 curve SM2         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_mod_nsm2.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_nsm2_4.ml
+++ b/arm/proofs/bignum_mod_nsm2_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_sm2, the order of the GM/T 0003-2012 curve SM2         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_mod_nsm2_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p25519_4.ml
+++ b/arm/proofs/bignum_mod_p25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_25519, the field characteristic for curve25519.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mod_p25519_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p256.ml
+++ b/arm/proofs/bignum_mod_p256.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256, the field characteristic for NIST curve P-256.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_mod_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p256_4.ml
+++ b/arm/proofs/bignum_mod_p256_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_mod_p256_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p256k1_4.ml
+++ b/arm/proofs/bignum_mod_p256k1_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256k1, the field characteristic for secp256k1.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_mod_p256k1_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p384.ml
+++ b/arm/proofs/bignum_mod_p384.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_384, the field characteristic for NIST curve P-384.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_mod_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p384_6.ml
+++ b/arm/proofs/bignum_mod_p384_6.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_mod_p384_6.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_p521_9.ml
+++ b/arm/proofs/bignum_mod_p521_9.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_521, the field characteristic of the NIST curve P-521. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_mod_p521_9.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_sm2.ml
+++ b/arm/proofs/bignum_mod_sm2.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_sm2, the field characteristic for CC curve SM2.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_mod_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_mod_sm2_4.ml
+++ b/arm/proofs/bignum_mod_sm2_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_sm2, the order of the GM/T 0003-2012 curve SM2         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_mod_sm2_4.o";;
  ****)
 

--- a/arm/proofs/bignum_modadd.ml
+++ b/arm/proofs/bignum_modadd.ml
@@ -7,6 +7,8 @@
 (* Modular addition of bignums.                                              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modadd.o";;
  ****)
 

--- a/arm/proofs/bignum_moddouble.ml
+++ b/arm/proofs/bignum_moddouble.ml
@@ -7,6 +7,8 @@
 (* Modular doubling of bignums.                                              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_moddouble.o";;
  ****)
 

--- a/arm/proofs/bignum_modexp.ml
+++ b/arm/proofs/bignum_modexp.ml
@@ -7,6 +7,8 @@
 (* Modular exponentiation for bignums (with odd modulus).                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modexp.o";;
  ****)
 

--- a/arm/proofs/bignum_modifier.ml
+++ b/arm/proofs/bignum_modifier.ml
@@ -7,6 +7,8 @@
 (* Mod-ifier computation.                                                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modifier.o";;
  ****)
 

--- a/arm/proofs/bignum_modinv.ml
+++ b/arm/proofs/bignum_modinv.ml
@@ -7,6 +7,8 @@
 (* Modular inverse for bignums (with odd modulus).                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modinv.o";;
  ****)
 

--- a/arm/proofs/bignum_modoptneg.ml
+++ b/arm/proofs/bignum_modoptneg.ml
@@ -7,6 +7,8 @@
 (* Optional modular negation of bignum.                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modoptneg.o";;
  ****)
 

--- a/arm/proofs/bignum_modsub.ml
+++ b/arm/proofs/bignum_modsub.ml
@@ -7,6 +7,8 @@
 (* Modular subtraction of bignums.                                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_modsub.o";;
  ****)
 

--- a/arm/proofs/bignum_montifier.ml
+++ b/arm/proofs/bignum_montifier.ml
@@ -7,6 +7,8 @@
 (* Montifier computation.                                                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_montifier.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul.ml
+++ b/arm/proofs/bignum_montmul.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication of arbitrary bignums.                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_montmul.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p256.ml
+++ b/arm/proofs/bignum_montmul_p256.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_256.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_montmul_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p256_alt.ml
+++ b/arm/proofs/bignum_montmul_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_256.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_montmul_p256_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p256_neon.ml
+++ b/arm/proofs/bignum_montmul_p256_neon.ml
@@ -8,6 +8,7 @@
   its SIMD-vectorized but not instruction-unscheduled program
 ******************************************************************************)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_montmul_p256.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_montmul_p256k1.ml
+++ b/arm/proofs/bignum_montmul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiply mod p_256k1, the field characteristic for secp256k1.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_montmul_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p256k1_alt.ml
+++ b/arm/proofs/bignum_montmul_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiply mod p_256k1, the field characteristic for secp256k1.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_montmul_p256k1_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p384.ml
+++ b/arm/proofs/bignum_montmul_p384.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_384.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_montmul_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p384_alt.ml
+++ b/arm/proofs/bignum_montmul_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_384.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_montmul_p384_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p384_neon.ml
+++ b/arm/proofs/bignum_montmul_p384_neon.ml
@@ -8,6 +8,7 @@
   its SIMD-vectorized but not instruction-unscheduled program
 ******************************************************************************)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_montmul_p384.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_montmul_p521.ml
+++ b/arm/proofs/bignum_montmul_p521.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521.                                              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_montmul_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_p521_alt.ml
+++ b/arm/proofs/bignum_montmul_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_521.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_montmul_p521_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_sm2.ml
+++ b/arm/proofs/bignum_montmul_sm2.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_sm2.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_montmul_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_montmul_sm2_alt.ml
+++ b/arm/proofs/bignum_montmul_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_sm2.                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_montmul_sm2_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montredc.ml
+++ b/arm/proofs/bignum_montredc.ml
@@ -7,6 +7,8 @@
 (* Montgomery reduction of arbitrary bignum.                                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_montredc.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr.ml
+++ b/arm/proofs/bignum_montsqr.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring of arbitrary bignum.                                  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_montsqr.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p256.ml
+++ b/arm/proofs/bignum_montsqr_p256.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_256.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_montsqr_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p256_alt.ml
+++ b/arm/proofs/bignum_montsqr_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_256.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_montsqr_p256_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p256_neon.ml
+++ b/arm/proofs/bignum_montsqr_p256_neon.ml
@@ -8,6 +8,7 @@
   its SIMD-vectorized but not instruction-unscheduled program
 ******************************************************************************)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_montsqr_p256.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_montsqr_p256k1.ml
+++ b/arm/proofs/bignum_montsqr_p256k1.ml
@@ -7,6 +7,8 @@
 (* Montgomery square mod p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_montsqr_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p256k1_alt.ml
+++ b/arm/proofs/bignum_montsqr_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery square mod p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_montsqr_p256k1_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p384.ml
+++ b/arm/proofs/bignum_montsqr_p384.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_384.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_montsqr_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p384_alt.ml
+++ b/arm/proofs/bignum_montsqr_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_384.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_montsqr_p384_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p384_neon.ml
+++ b/arm/proofs/bignum_montsqr_p384_neon.ml
@@ -8,6 +8,7 @@
   its SIMD-vectorized but not instruction-unscheduled program
 ******************************************************************************)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_montsqr_p384.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_montsqr_p521.ml
+++ b/arm/proofs/bignum_montsqr_p521.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_521.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_montsqr_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_p521_alt.ml
+++ b/arm/proofs/bignum_montsqr_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_521.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_montsqr_p521_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_sm2.ml
+++ b/arm/proofs/bignum_montsqr_sm2.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_sm2.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_montsqr_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_montsqr_sm2_alt.ml
+++ b/arm/proofs/bignum_montsqr_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_sm2.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_montsqr_sm2_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul.ml
+++ b/arm/proofs/bignum_mul.ml
@@ -7,6 +7,8 @@
 (* Multiplication.                                                           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_mul.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_4_8.ml
+++ b/arm/proofs/bignum_mul_4_8.ml
@@ -7,6 +7,8 @@
 (* 4x4 -> 8 multiply (2-level Karatsuba even at this small size).            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_4_8.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_4_8_alt.ml
+++ b/arm/proofs/bignum_mul_4_8_alt.ml
@@ -7,6 +7,8 @@
 (* 4x4->8 multiply optimized for uarchs with higher multiplier throughput.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_4_8_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_6_12.ml
+++ b/arm/proofs/bignum_mul_6_12.ml
@@ -7,6 +7,8 @@
 (* 6x6 -> 12 multiply (pure Karatsuba and then ADK for the 3x3 bits).        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_6_12.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_6_12_alt.ml
+++ b/arm/proofs/bignum_mul_6_12_alt.ml
@@ -7,6 +7,8 @@
 (* 6x6->12 multiply optimized for uarchs with higher multiplier throughput.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_6_12_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_8_16.ml
+++ b/arm/proofs/bignum_mul_8_16.ml
@@ -7,6 +7,8 @@
 (* 8x8 -> 16 multiply (pure Karatsuba and then ADK for the 4x4 bits).        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_8_16.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_8_16_alt.ml
+++ b/arm/proofs/bignum_mul_8_16_alt.ml
@@ -7,6 +7,8 @@
 (* 8x8->16 multiply optimized for uarchs with higher multiplier throughput.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_mul_8_16_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_8_16_neon.ml
+++ b/arm/proofs/bignum_mul_8_16_neon.ml
@@ -7,6 +7,7 @@
 (* 8x8 -> 16 multiply (pure Karatsuba and then ADK for the 4x4 bits).        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_mul_8_16.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_mul_p25519.ml
+++ b/arm/proofs/bignum_mul_p25519.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519, the field characteristic for curve25519.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mul_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_p25519_alt.ml
+++ b/arm/proofs/bignum_mul_p25519_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519, the field characteristic for curve25519.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_mul_p25519_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_p256k1.ml
+++ b/arm/proofs/bignum_mul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_mul_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_p256k1_alt.ml
+++ b/arm/proofs/bignum_mul_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_mul_p256k1_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_p521.ml
+++ b/arm/proofs/bignum_mul_p521.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521.                                              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_mul_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_mul_p521_alt.ml
+++ b/arm/proofs/bignum_mul_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521.                                              *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_mul_p521_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_muladd10.ml
+++ b/arm/proofs/bignum_muladd10.ml
@@ -7,6 +7,8 @@
 (* Multiply by 10 and add another word.                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_muladd10.o";;
  ****)
 

--- a/arm/proofs/bignum_mux.ml
+++ b/arm/proofs/bignum_mux.ml
@@ -7,6 +7,8 @@
 (* Multiplexing for raw bignums with same length.                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_mux.o";;
  ****)
 

--- a/arm/proofs/bignum_mux16.ml
+++ b/arm/proofs/bignum_mux16.ml
@@ -7,6 +7,8 @@
 (* 16-way multiplexing for k-length bignums.                                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_mux16.o";;
  ****)
 

--- a/arm/proofs/bignum_mux_4.ml
+++ b/arm/proofs/bignum_mux_4.ml
@@ -7,6 +7,8 @@
 (* Multiplexing (selection, if-then-else) for 4-digit (256-bit) bignums.     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_mux_4.o";;
  ****)
 

--- a/arm/proofs/bignum_mux_6.ml
+++ b/arm/proofs/bignum_mux_6.ml
@@ -7,6 +7,8 @@
 (* Multiplexing (selection, if-then-else) for 6-digit (384-bit) bignums.     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_mux_6.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_p25519.ml
+++ b/arm/proofs/bignum_neg_p25519.ml
@@ -7,6 +7,8 @@
 (* Negation modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_neg_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_p256.ml
+++ b/arm/proofs/bignum_neg_p256.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_256, field characteristic for NIST P-256 curve.            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_neg_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_p256k1.ml
+++ b/arm/proofs/bignum_neg_p256k1.ml
@@ -7,6 +7,8 @@
 (* Negation modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_neg_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_p384.ml
+++ b/arm/proofs/bignum_neg_p384.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_384, field characteristic for NIST P-384 curve.            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_neg_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_p521.ml
+++ b/arm/proofs/bignum_neg_p521.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_521, field characteristic for NIST P-521 curve.            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_neg_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_neg_sm2.ml
+++ b/arm/proofs/bignum_neg_sm2.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_sm2, field characteristic for CC SM2 curve.                *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_neg_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_negmodinv.ml
+++ b/arm/proofs/bignum_negmodinv.ml
@@ -7,6 +7,8 @@
 (* Bignum negated modular inversion.                                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_negmodinv.o";;
  ****)
 

--- a/arm/proofs/bignum_nonzero.ml
+++ b/arm/proofs/bignum_nonzero.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is nonzero.                                            *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_nonzero.o";;
  ****)
 

--- a/arm/proofs/bignum_nonzero_4.ml
+++ b/arm/proofs/bignum_nonzero_4.ml
@@ -7,6 +7,8 @@
 (* Deduce if a 256-bit bignum is nonzero.                                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_nonzero_4.o";;
  ****)
 

--- a/arm/proofs/bignum_nonzero_6.ml
+++ b/arm/proofs/bignum_nonzero_6.ml
@@ -7,6 +7,8 @@
 (* Deduce if a 384-bit bignum is nonzero.                                    *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_nonzero_6.o";;
  ****)
 

--- a/arm/proofs/bignum_normalize.ml
+++ b/arm/proofs/bignum_normalize.ml
@@ -7,6 +7,8 @@
 (* Normalization of a bignum in-place in constant time.                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_normalize.o";;
  ****)
 

--- a/arm/proofs/bignum_odd.ml
+++ b/arm/proofs/bignum_odd.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is odd or even.                                        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_odd.o";;
  ****)
 

--- a/arm/proofs/bignum_of_word.ml
+++ b/arm/proofs/bignum_of_word.ml
@@ -7,6 +7,8 @@
 (* Conversion of a single word (digit) to a bignum.                          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 let bignum_of_word_mc =
   define_assert_from_elf "bignum_of_word_mc" "arm/generic/bignum_of_word.o"
 [

--- a/arm/proofs/bignum_optadd.ml
+++ b/arm/proofs/bignum_optadd.ml
@@ -7,6 +7,8 @@
 (* Optional addition of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_optadd.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg.ml
+++ b/arm/proofs/bignum_optneg.ml
@@ -7,6 +7,8 @@
 (* Optional negation of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_optneg.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_p25519.ml
+++ b/arm/proofs/bignum_optneg_p25519.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_25519, field characteristic curve25519.           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_optneg_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_p256.ml
+++ b/arm/proofs/bignum_optneg_p256.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_256, field characteristic for NIST P-256 curve.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_optneg_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_p256k1.ml
+++ b/arm/proofs/bignum_optneg_p256k1.ml
@@ -7,6 +7,8 @@
 (* Optional negation modulo p_256k1, the field characteristic for secp256k1. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_optneg_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_p384.ml
+++ b/arm/proofs/bignum_optneg_p384.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_384, field characteristic for NIST P-384 curve.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_optneg_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_p521.ml
+++ b/arm/proofs/bignum_optneg_p521.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_521, field characteristic for NIST P-521 curve.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_optneg_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_optneg_sm2.ml
+++ b/arm/proofs/bignum_optneg_sm2.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_sm2, field characteristic for CC SM2 curve.       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_optneg_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_optsub.ml
+++ b/arm/proofs/bignum_optsub.ml
@@ -7,6 +7,8 @@
 (* "Optional subtraction" function, subtracting iff a flag is nonzero.       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_optsub.o";;
  ****)
 

--- a/arm/proofs/bignum_optsubadd.ml
+++ b/arm/proofs/bignum_optsubadd.ml
@@ -7,6 +7,8 @@
 (* Optional addition of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_optsubadd.o";;
  ****)
 

--- a/arm/proofs/bignum_pow2.ml
+++ b/arm/proofs/bignum_pow2.ml
@@ -7,6 +7,8 @@
 (* Creation of a power-of-2 bignum using the input word as the index.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_pow2.o";;
  ****)
 

--- a/arm/proofs/bignum_shl_small.ml
+++ b/arm/proofs/bignum_shl_small.ml
@@ -7,6 +7,8 @@
 (* Shifting of a bignum left < 64 bits.                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_shl_small.o";;
  ****)
 

--- a/arm/proofs/bignum_shr_small.ml
+++ b/arm/proofs/bignum_shr_small.ml
@@ -7,6 +7,8 @@
 (* Shifting of a bignum right < 64 bits.                                     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_shr_small.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr.ml
+++ b/arm/proofs/bignum_sqr.ml
@@ -7,6 +7,8 @@
 (* Squaring.                                                                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_sqr.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_4_8.ml
+++ b/arm/proofs/bignum_sqr_4_8.ml
@@ -7,6 +7,8 @@
 (* 4x4 -> 8 squaring, Karatsuba then simple recursion to schoolbook.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_4_8.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_4_8_alt.ml
+++ b/arm/proofs/bignum_sqr_4_8_alt.ml
@@ -7,6 +7,8 @@
 (* 4x4->8 squaring optimized for uarchs with higher multiplier throughput.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_4_8_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_6_12.ml
+++ b/arm/proofs/bignum_sqr_6_12.ml
@@ -7,6 +7,8 @@
 (* 6x6 -> 12 squaring, schoolbook sub-squares plus ADK cross-product.        *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_6_12.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_6_12_alt.ml
+++ b/arm/proofs/bignum_sqr_6_12_alt.ml
@@ -7,6 +7,8 @@
 (* 6x6 -> 12 squaring, for uarchs with higher multiplier throughput.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_6_12_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_8_16.ml
+++ b/arm/proofs/bignum_sqr_8_16.ml
@@ -7,6 +7,8 @@
 (* 8x8 -> 16 squaring, using Karatsuba reduction and nested ADK.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_8_16.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_8_16_alt.ml
+++ b/arm/proofs/bignum_sqr_8_16_alt.ml
@@ -7,6 +7,8 @@
 (* 8x8 -> 16 squaring, for uarchs with higher multiplier throughput.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/fastmul/bignum_sqr_8_16_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_8_16_neon.ml
+++ b/arm/proofs/bignum_sqr_8_16_neon.ml
@@ -7,6 +7,7 @@
 (* 8x8 -> 16 squaring, using Karatsuba reduction and nested ADK.             *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
 needs "arm/proofs/bignum_sqr_8_16.ml";;
 needs "arm/proofs/equiv.ml";;
 needs "arm/proofs/neon_helper.ml";;

--- a/arm/proofs/bignum_sqr_p25519.ml
+++ b/arm/proofs/bignum_sqr_p25519.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_25519, the field characteristic for curve25519.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_sqr_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_p25519_alt.ml
+++ b/arm/proofs/bignum_sqr_p25519_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_sqr_p25519_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_p256k1.ml
+++ b/arm/proofs/bignum_sqr_p256k1.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_sqr_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_p256k1_alt.ml
+++ b/arm/proofs/bignum_sqr_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_sqr_p256k1_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_p521.ml
+++ b/arm/proofs/bignum_sqr_p521.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_sqr_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_sqr_p521_alt.ml
+++ b/arm/proofs/bignum_sqr_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_sqr_p521_alt.o";;
  ****)
 

--- a/arm/proofs/bignum_sqrt_p25519.ml
+++ b/arm/proofs/bignum_sqrt_p25519.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/arm/proofs/bignum_sqrt_p25519_alt.ml
+++ b/arm/proofs/bignum_sqrt_p25519_alt.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/arm/proofs/bignum_sub.ml
+++ b/arm/proofs/bignum_sub.ml
@@ -7,6 +7,8 @@
 (* Subtraction of bignums.                                                   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/bignum_sub.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_p25519.ml
+++ b/arm/proofs/bignum_sub_p25519.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_25519, the field characteristic for curve25519.      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/curve25519/bignum_sub_p25519.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_p256.ml
+++ b/arm/proofs/bignum_sub_p256.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_256, the field characteristic for NIST P-256 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_sub_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_p256k1.ml
+++ b/arm/proofs/bignum_sub_p256k1.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_256k1, the field characteristic for secp256k1.       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_sub_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_p384.ml
+++ b/arm/proofs/bignum_sub_p384.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_384, the field characteristic for NIST P-384 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_sub_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_p521.ml
+++ b/arm/proofs/bignum_sub_p521.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_521, the field characteristic for NIST P-521 curve.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_sub_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_sub_sm2.ml
+++ b/arm/proofs/bignum_sub_sm2.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_sm2, the field characteristic for CC SM2 curve.      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_sub_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_tolebytes_p521.ml
+++ b/arm/proofs/bignum_tolebytes_p521.ml
@@ -7,6 +7,8 @@
 (* Translation to little-endian byte sequence, 9 digits -> 66 bytes.         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_tolebytes_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_tomont_p256.ml
+++ b/arm/proofs/bignum_tomont_p256.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form modulo p_256.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_tomont_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_tomont_p256k1.ml
+++ b/arm/proofs/bignum_tomont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form mod p_256k1.   *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_tomont_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_tomont_p384.ml
+++ b/arm/proofs/bignum_tomont_p384.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 6-word (384-bit) bignum to Montgomery form modulo p_384.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_tomont_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_tomont_p521.ml
+++ b/arm/proofs/bignum_tomont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping into Montgomery representation for p_521.                         *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_tomont_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_tomont_sm2.ml
+++ b/arm/proofs/bignum_tomont_sm2.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form modulo p_sm2.  *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_tomont_sm2.o";;
  ****)
 

--- a/arm/proofs/bignum_triple_p256.ml
+++ b/arm/proofs/bignum_triple_p256.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p256/bignum_triple_p256.o";;
  ****)
 

--- a/arm/proofs/bignum_triple_p256k1.ml
+++ b/arm/proofs/bignum_triple_p256k1.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/secp256k1/bignum_triple_p256k1.o";;
  ****)
 

--- a/arm/proofs/bignum_triple_p384.ml
+++ b/arm/proofs/bignum_triple_p384.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p384/bignum_triple_p384.o";;
  ****)
 

--- a/arm/proofs/bignum_triple_p521.ml
+++ b/arm/proofs/bignum_triple_p521.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/p521/bignum_triple_p521.o";;
  ****)
 

--- a/arm/proofs/bignum_triple_sm2.ml
+++ b/arm/proofs/bignum_triple_sm2.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/sm2/bignum_triple_sm2.o";;
  ****)
 

--- a/arm/proofs/word_bytereverse.ml
+++ b/arm/proofs/word_bytereverse.ml
@@ -7,6 +7,8 @@
 (* Reversing the order of the bytes in a single 64-bit word.                 *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_bytereverse.o";;
  ****)
 

--- a/arm/proofs/word_clz.ml
+++ b/arm/proofs/word_clz.ml
@@ -7,6 +7,8 @@
 (* Counting leading zeros in a well-defined way for a single word.           *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_clz.o";;
  ****)
 

--- a/arm/proofs/word_ctz.ml
+++ b/arm/proofs/word_ctz.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zeros in a well-defined way for a single word.          *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_ctz.o";;
  ****)
 

--- a/arm/proofs/word_max.ml
+++ b/arm/proofs/word_max.ml
@@ -7,6 +7,8 @@
 (* Finding maximum of two 64-bit words.                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_max.o";;
  ****)
 

--- a/arm/proofs/word_min.ml
+++ b/arm/proofs/word_min.ml
@@ -7,6 +7,8 @@
 (* Finding minimum of two 64-bit words.                                      *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_min.o";;
  ****)
 

--- a/arm/proofs/word_negmodinv.ml
+++ b/arm/proofs/word_negmodinv.ml
@@ -7,6 +7,8 @@
 (* Word-level negated modular inverse.                                       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_negmodinv.o";;
  ****)
 

--- a/arm/proofs/word_recip.ml
+++ b/arm/proofs/word_recip.ml
@@ -7,6 +7,8 @@
 (* Word-level negated modular inverse.                                       *)
 (* ========================================================================= *)
 
+needs "arm/proofs/base.ml";;
+
 (**** print_literal_from_elf "arm/generic/word_recip.o";;
  ****)
 

--- a/tools/run-proof.sh
+++ b/tools/run-proof.sh
@@ -21,7 +21,6 @@ output_path=${s2n_bignum_arch}/$4
 (echo 'Topdirs.dir_directory "+unix";;'; \
  echo 'Topdirs.dir_load Format.std_formatter "unix.cma";;'; \
  echo 'let start_time = Unix.time();;'; \
- echo "loadt \"${s2n_bignum_arch}/proofs/base.ml\";;"; \
  echo "loadt \"${s2n_bignum_arch}/proofs/${asm_filename}.ml\";;"; \
  echo "check_axioms ();;"; \
  echo 'let end_time = Unix.time();;'; \

--- a/x86/proofs/bignum_add.ml
+++ b/x86/proofs/bignum_add.ml
@@ -7,6 +7,8 @@
 (* Addition of bignums.                                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_add.o";;
  ****)
 

--- a/x86/proofs/bignum_add_p25519.ml
+++ b/x86/proofs/bignum_add_p25519.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_add_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_add_p256.ml
+++ b/x86/proofs/bignum_add_p256.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_add_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_add_p256k1.ml
+++ b/x86/proofs/bignum_add_p256k1.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_add_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_add_p384.ml
+++ b/x86/proofs/bignum_add_p384.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_add_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_add_p521.ml
+++ b/x86/proofs/bignum_add_p521.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_add_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_add_sm2.ml
+++ b/x86/proofs/bignum_add_sm2.ml
@@ -7,6 +7,8 @@
 (* Addition modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_add_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_amontifier.ml
+++ b/x86/proofs/bignum_amontifier.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomerifier computation.                                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_amontifier.o";;
  ****)
 

--- a/x86/proofs/bignum_amontmul.ml
+++ b/x86/proofs/bignum_amontmul.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery multiplication of arbitrary bignums.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_amontmul.o";;
  ****)
 

--- a/x86/proofs/bignum_amontredc.ml
+++ b/x86/proofs/bignum_amontredc.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery reduction of arbitrary bignum.                          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_amontredc.o";;
  ****)
 

--- a/x86/proofs/bignum_amontsqr.ml
+++ b/x86/proofs/bignum_amontsqr.ml
@@ -7,6 +7,8 @@
 (* Almost-Montgomery squaring of arbitrary bignum.                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_amontsqr.o";;
  ****)
 

--- a/x86/proofs/bignum_bigendian_4.ml
+++ b/x86/proofs/bignum_bigendian_4.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (bigendian, frombebytes and tobebytes).      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_bigendian_4.o";;
  ****)
 

--- a/x86/proofs/bignum_bigendian_6.ml
+++ b/x86/proofs/bignum_bigendian_6.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (bigendian, frombebytes and tobebytes).      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_bigendian_6.o";;
  ****)
 

--- a/x86/proofs/bignum_bitfield.ml
+++ b/x86/proofs/bignum_bitfield.ml
@@ -7,6 +7,8 @@
 (* Constant-time bitfield selection from bignum.                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_bitfield.o";;
  ****)
 

--- a/x86/proofs/bignum_bitsize.ml
+++ b/x86/proofs/bignum_bitsize.ml
@@ -7,6 +7,8 @@
 (* Size in bits of a bignum.                                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_bitsize.o";;
  ****)
 

--- a/x86/proofs/bignum_cdiv.ml
+++ b/x86/proofs/bignum_cdiv.ml
@@ -7,6 +7,8 @@
 (* Division and remainder of bignum by a single (nonzero) word.              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cdiv.o";;
  ****)
 

--- a/x86/proofs/bignum_cdiv_exact.ml
+++ b/x86/proofs/bignum_cdiv_exact.ml
@@ -7,6 +7,8 @@
 (* Division of bignum by a single word when known a priori to be exact.      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cdiv_exact.o";;
  ****)
 

--- a/x86/proofs/bignum_cld.ml
+++ b/x86/proofs/bignum_cld.ml
@@ -7,6 +7,8 @@
 (* Counting leading zero digits of a bignum.                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cld.o";;
  ****)
 

--- a/x86/proofs/bignum_clz.ml
+++ b/x86/proofs/bignum_clz.ml
@@ -7,6 +7,8 @@
 (* Counting leading zero bits in a bignum.                                   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_clz.o";;
  ****)
 

--- a/x86/proofs/bignum_cmadd.ml
+++ b/x86/proofs/bignum_cmadd.ml
@@ -7,6 +7,8 @@
 (* Multiply-accumulate of bignum by a single word.                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cmadd.o";;
  ****)
 

--- a/x86/proofs/bignum_cmnegadd.ml
+++ b/x86/proofs/bignum_cmnegadd.ml
@@ -7,6 +7,8 @@
 (* Negating multiply-accumulate of bignum by a single word.                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cmnegadd.o";;
  ****)
 

--- a/x86/proofs/bignum_cmod.ml
+++ b/x86/proofs/bignum_cmod.ml
@@ -7,6 +7,8 @@
 (* Modulus of bignum by a single word.                                       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cmod.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul.ml
+++ b/x86/proofs/bignum_cmul.ml
@@ -7,6 +7,8 @@
 (* Multiplication of bignum by a single word.                                *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_cmul.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p25519.ml
+++ b/x86/proofs/bignum_cmul_p25519.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519 of a single word and a bignum < p_25519.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_cmul_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p25519_alt.ml
+++ b/x86/proofs/bignum_cmul_p25519_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519 of a single word and a bignum < p_25519.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_cmul_p25519_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p256.ml
+++ b/x86/proofs/bignum_cmul_p256.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256 of a single word and a bignum < p_256.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_cmul_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p256_alt.ml
+++ b/x86/proofs/bignum_cmul_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256 of a single word and a bignum < p_256.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_cmul_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p256k1.ml
+++ b/x86/proofs/bignum_cmul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1 of a single word and a bignum < p_256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_cmul_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p256k1_alt.ml
+++ b/x86/proofs/bignum_cmul_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1 of a single word and a bignum < p_256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_cmul_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p384.ml
+++ b/x86/proofs/bignum_cmul_p384.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_384 of a single word and a bignum < p_384.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_cmul_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p384_alt.ml
+++ b/x86/proofs/bignum_cmul_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_384 of a single word and a bignum < p_384.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_cmul_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p521.ml
+++ b/x86/proofs/bignum_cmul_p521.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521 of a single word and a bignum < p_521.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_cmul_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_p521_alt.ml
+++ b/x86/proofs/bignum_cmul_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521 of a single word and a bignum < p_521.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_cmul_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_sm2.ml
+++ b/x86/proofs/bignum_cmul_sm2.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_sm2 of a single word and a bignum < p_sm2.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_cmul_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_cmul_sm2_alt.ml
+++ b/x86/proofs/bignum_cmul_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_sm2 of a single word and a bignum < p_sm2.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_cmul_sm2_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_coprime.ml
+++ b/x86/proofs/bignum_coprime.ml
@@ -7,6 +7,8 @@
 (* Coprimality test for two arbitrary bignums.                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_coprime.o";;
  ****)
 

--- a/x86/proofs/bignum_copy.ml
+++ b/x86/proofs/bignum_copy.ml
@@ -7,6 +7,8 @@
 (* Copying (with truncation or extension) bignums                            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_copy.o";;
  ****)
 

--- a/x86/proofs/bignum_copy_row_from_table.ml
+++ b/x86/proofs/bignum_copy_row_from_table.ml
@@ -7,6 +7,8 @@
 (* Constant-time table lookup.                                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 let bignum_copy_row_from_table_mc =
   define_assert_from_elf "bignum_copy_row_from_table_mc"
                          "x86/generic/bignum_copy_row_from_table.o"

--- a/x86/proofs/bignum_ctd.ml
+++ b/x86/proofs/bignum_ctd.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zero digits in a bignum.                                *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_ctd.o";;
  ****)
 

--- a/x86/proofs/bignum_ctz.ml
+++ b/x86/proofs/bignum_ctz.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zero bits in a bignum.                                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_ctz.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p256.ml
+++ b/x86/proofs/bignum_deamont_p256.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_256.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_deamont_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p256_alt.ml
+++ b/x86/proofs/bignum_deamont_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_256.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_deamont_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p256k1.ml
+++ b/x86/proofs/bignum_deamont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_256k1.           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_deamont_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p384.ml
+++ b/x86/proofs/bignum_deamont_p384.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_384.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_deamont_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p384_alt.ml
+++ b/x86/proofs/bignum_deamont_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_384.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_deamont_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_p521.ml
+++ b/x86/proofs/bignum_deamont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_521.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_deamont_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_deamont_sm2.ml
+++ b/x86/proofs/bignum_deamont_sm2.ml
@@ -7,6 +7,8 @@
 (* Mapping out of almost-Montgomery representation modulo p_sm2.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_deamont_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_demont.ml
+++ b/x86/proofs/bignum_demont.ml
@@ -7,6 +7,8 @@
 (* de-Montgomerification, i.e. "short" Mongomery reduction.                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_demont.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p256.ml
+++ b/x86/proofs/bignum_demont_p256.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_256.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_demont_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p256_alt.ml
+++ b/x86/proofs/bignum_demont_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_256.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_demont_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p256k1.ml
+++ b/x86/proofs/bignum_demont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_256k1.                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_demont_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p384.ml
+++ b/x86/proofs/bignum_demont_p384.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_384.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_demont_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p384_alt.ml
+++ b/x86/proofs/bignum_demont_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_384.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_demont_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_p521.ml
+++ b/x86/proofs/bignum_demont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping out of reduced Montgomery representation mod p_521.               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_demont_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_demont_sm2.ml
+++ b/x86/proofs/bignum_demont_sm2.ml
@@ -7,6 +7,8 @@
 (* Mapping out of Montgomery representation modulo p_sm2.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_demont_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_digit.ml
+++ b/x86/proofs/bignum_digit.ml
@@ -7,6 +7,8 @@
 (* Constant-time digit selection from bignum.                                *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_digit.o";;
  ****)
 

--- a/x86/proofs/bignum_digitsize.ml
+++ b/x86/proofs/bignum_digitsize.ml
@@ -7,6 +7,8 @@
 (* Size in digits of a bignum.                                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_digitsize.o";;
  ****)
 

--- a/x86/proofs/bignum_divmod10.ml
+++ b/x86/proofs/bignum_divmod10.ml
@@ -7,6 +7,8 @@
 (* Division by 10 with remainder.                                            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_divmod10.o";;
  ****)
 

--- a/x86/proofs/bignum_double_p25519.ml
+++ b/x86/proofs/bignum_double_p25519.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_double_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_double_p256.ml
+++ b/x86/proofs/bignum_double_p256.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_double_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_double_p256k1.ml
+++ b/x86/proofs/bignum_double_p256k1.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_double_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_double_p384.ml
+++ b/x86/proofs/bignum_double_p384.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_double_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_double_p521.ml
+++ b/x86/proofs/bignum_double_p521.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_double_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_double_sm2.ml
+++ b/x86/proofs/bignum_double_sm2.ml
@@ -7,6 +7,8 @@
 (* Doubling modulo p_sm2, the field characteristic for the CC SM2 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_double_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_emontredc.ml
+++ b/x86/proofs/bignum_emontredc.ml
@@ -7,6 +7,8 @@
 (* Extended Montgomery reduction of arbitrary bignum.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_emontredc.o";;
  ****)
 

--- a/x86/proofs/bignum_emontredc_8n.ml
+++ b/x86/proofs/bignum_emontredc_8n.ml
@@ -7,6 +7,8 @@
 (* Extended Montgomery reduction of arbitrary bignum.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_emontredc_8n.o";;
  ****)
 

--- a/x86/proofs/bignum_eq.ml
+++ b/x86/proofs/bignum_eq.ml
@@ -7,6 +7,8 @@
 (* Equality test on bignums.                                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_eq.o";;
  ****)
 

--- a/x86/proofs/bignum_even.ml
+++ b/x86/proofs/bignum_even.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is odd or even.                                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_even.o";;
  ****)
 

--- a/x86/proofs/bignum_fromlebytes_p521.ml
+++ b/x86/proofs/bignum_fromlebytes_p521.ml
@@ -7,6 +7,8 @@
 (* Translation from little-endian byte sequence, 66 bytes -> 9 digits.       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_fromlebytes_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_ge.ml
+++ b/x86/proofs/bignum_ge.ml
@@ -7,6 +7,8 @@
 (* Comparison >= test on bignums.                                            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_ge.o";;
  ****)
 

--- a/x86/proofs/bignum_gt.ml
+++ b/x86/proofs/bignum_gt.ml
@@ -7,6 +7,8 @@
 (* Comparison > test on bignums.                                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_gt.o";;
  ****)
 

--- a/x86/proofs/bignum_half_p256.ml
+++ b/x86/proofs/bignum_half_p256.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_256, the field characteristic for the NIST P-256 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_half_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_half_p256k1.ml
+++ b/x86/proofs/bignum_half_p256k1.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_256k1, the field characteristic for secp256k1.           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_half_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_half_p384.ml
+++ b/x86/proofs/bignum_half_p384.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_384, the field characteristic for the NIST P-384 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_half_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_half_p521.ml
+++ b/x86/proofs/bignum_half_p521.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_521, the field characteristic for the NIST P-521 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_half_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_half_sm2.ml
+++ b/x86/proofs/bignum_half_sm2.ml
@@ -7,6 +7,8 @@
 (* Halving modulo p_sm2, the field characteristic for the CC SM2 curve.      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_half_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_invsqrt_p25519.ml
+++ b/x86/proofs/bignum_invsqrt_p25519.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/bignum_invsqrt_p25519_alt.ml
+++ b/x86/proofs/bignum_invsqrt_p25519_alt.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/bignum_iszero.ml
+++ b/x86/proofs/bignum_iszero.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is zero.                                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_iszero.o";;
  ****)
 

--- a/x86/proofs/bignum_kmul_16_32.ml
+++ b/x86/proofs/bignum_kmul_16_32.ml
@@ -7,6 +7,8 @@
 (* MULX-based 16x16->32 multiplication.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_kmul_16_32.o";;
  ****)
 

--- a/x86/proofs/bignum_kmul_32_64.ml
+++ b/x86/proofs/bignum_kmul_32_64.ml
@@ -7,6 +7,8 @@
 (* 32x32 -> 64 multiplication, using Karatsuba reduction.                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_kmul_32_64.o";;
  ****)
 

--- a/x86/proofs/bignum_ksqr_16_32.ml
+++ b/x86/proofs/bignum_ksqr_16_32.ml
@@ -7,6 +7,8 @@
 (* MULX-based 16x16->32 squaring.                                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_ksqr_16_32.o";;
  ****)
 

--- a/x86/proofs/bignum_ksqr_32_64.ml
+++ b/x86/proofs/bignum_ksqr_32_64.ml
@@ -7,6 +7,8 @@
 (* MULX-based Karatsuba 32x32->64 squaring.                                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_ksqr_32_64.o";;
  ****)
 

--- a/x86/proofs/bignum_le.ml
+++ b/x86/proofs/bignum_le.ml
@@ -7,6 +7,8 @@
 (* Comparison <= test on bignums.                                            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_le.o";;
  ****)
 

--- a/x86/proofs/bignum_littleendian_4.ml
+++ b/x86/proofs/bignum_littleendian_4.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (littleendian, fromlebytes and tolebytes).   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_littleendian_4.o";;
  ****)
 

--- a/x86/proofs/bignum_littleendian_6.ml
+++ b/x86/proofs/bignum_littleendian_6.ml
@@ -9,6 +9,8 @@
 (* aliases with different types (littleendian, fromlebytes and tolebytes).   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_littleendian_6.o";;
  ****)
 

--- a/x86/proofs/bignum_lt.ml
+++ b/x86/proofs/bignum_lt.ml
@@ -7,6 +7,8 @@
 (* Comparison < test on bignums.                                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_lt.o";;
  ****)
 

--- a/x86/proofs/bignum_madd.ml
+++ b/x86/proofs/bignum_madd.ml
@@ -7,6 +7,8 @@
 (* Multiplication-and-addition with (careful!) carry/remainder term.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_madd.o";;
  ****)
 

--- a/x86/proofs/bignum_madd_n25519.ml
+++ b/x86/proofs/bignum_madd_n25519.ml
@@ -7,6 +7,8 @@
 (* Multiply-add mod n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_madd_n25519.o";;
  ****)
 

--- a/x86/proofs/bignum_madd_n25519_alt.ml
+++ b/x86/proofs/bignum_madd_n25519_alt.ml
@@ -7,6 +7,8 @@
 (* Multiply-add mod n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_madd_n25519_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_m25519_4.ml
+++ b/x86/proofs/bignum_mod_m25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo m_25519, the full group order for curve25519.            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mod_m25519_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n25519.ml
+++ b/x86/proofs/bignum_mod_n25519.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_25519, basepoint order for curve25519/edwards25519.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mod_n25519.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n25519_4.ml
+++ b/x86/proofs/bignum_mod_n25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_25519, the basepoint order for curve25519.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mod_n25519_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n256.ml
+++ b/x86/proofs/bignum_mod_n256.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_n256.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n256_4.ml
+++ b/x86/proofs/bignum_mod_n256_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_n256_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n256_alt.ml
+++ b/x86/proofs/bignum_mod_n256_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256, the order of the NIST curve P-256                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_n256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n256k1_4.ml
+++ b/x86/proofs/bignum_mod_n256k1_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_256k1, the order of the secp256k1 curve.               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_mod_n256k1_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n384.ml
+++ b/x86/proofs/bignum_mod_n384.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_n384.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n384_6.ml
+++ b/x86/proofs/bignum_mod_n384_6.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_n384_6.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n384_alt.ml
+++ b/x86/proofs/bignum_mod_n384_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_384, the order of the NIST curve P-384                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_n384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n521_9.ml
+++ b/x86/proofs/bignum_mod_n521_9.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_521, the order of the NIST curve P-521                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_mod_n521_9.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_n521_9_alt.ml
+++ b/x86/proofs/bignum_mod_n521_9_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_521, the order of the NIST curve P-521                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_mod_n521_9_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_nsm2.ml
+++ b/x86/proofs/bignum_mod_nsm2.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_sm2, the order of the GM/T 0003-2012 curve SM2         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_mod_nsm2.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_nsm2_4.ml
+++ b/x86/proofs/bignum_mod_nsm2_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_sm2, the order of the GM/T 0003-2012 curve SM2                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_mod_nsm2_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_nsm2_alt.ml
+++ b/x86/proofs/bignum_mod_nsm2_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo n_sm2, the order of the GM/T 0003-2012 curve SM2         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_mod_nsm2_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p25519_4.ml
+++ b/x86/proofs/bignum_mod_p25519_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_25519, the field characteristic for curve25519.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mod_p25519_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p256.ml
+++ b/x86/proofs/bignum_mod_p256.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256, the field characteristic for NIST curve P-256.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p256_4.ml
+++ b/x86/proofs/bignum_mod_p256_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256, the field characteristic of the NIST curve P-256. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_p256_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p256_alt.ml
+++ b/x86/proofs/bignum_mod_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256, the field characteristic for NIST curve P-256.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mod_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p256k1_4.ml
+++ b/x86/proofs/bignum_mod_p256k1_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_256k1, the field characteristic for secp256k1.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_mod_p256k1_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p384.ml
+++ b/x86/proofs/bignum_mod_p384.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_384, the field characteristic for NIST curve P-384.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p384_6.ml
+++ b/x86/proofs/bignum_mod_p384_6.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_384, the field characteristic of the NIST curve P-384. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_p384_6.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p384_alt.ml
+++ b/x86/proofs/bignum_mod_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_384, the field characteristic for NIST curve P-384.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mod_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_p521_9.ml
+++ b/x86/proofs/bignum_mod_p521_9.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_521, the field characteristic of the NIST curve P-521. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_mod_p521_9.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_sm2.ml
+++ b/x86/proofs/bignum_mod_sm2.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_sm2, the field characteristic for CC curve SM2.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_mod_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_mod_sm2_4.ml
+++ b/x86/proofs/bignum_mod_sm2_4.ml
@@ -7,6 +7,8 @@
 (* Reduction modulo p_sm2, the field characteristic of the GM/T 0003-2012 curve SM2. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_mod_sm2_4.o";;
  ****)
 

--- a/x86/proofs/bignum_modadd.ml
+++ b/x86/proofs/bignum_modadd.ml
@@ -7,6 +7,8 @@
 (* Modular addition of bignums.                                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modadd.o";;
  ****)
 

--- a/x86/proofs/bignum_moddouble.ml
+++ b/x86/proofs/bignum_moddouble.ml
@@ -7,6 +7,8 @@
 (* Modular doubling of bignums.                                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_moddouble.o";;
  ****)
 

--- a/x86/proofs/bignum_modexp.ml
+++ b/x86/proofs/bignum_modexp.ml
@@ -7,6 +7,8 @@
 (* Modular exponentiation for bignums (with odd modulus).                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modexp.o";;
  ****)
 

--- a/x86/proofs/bignum_modifier.ml
+++ b/x86/proofs/bignum_modifier.ml
@@ -7,6 +7,8 @@
 (* Mod-ifier computation.                                                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modifier.o";;
  ****)
 

--- a/x86/proofs/bignum_modinv.ml
+++ b/x86/proofs/bignum_modinv.ml
@@ -7,6 +7,8 @@
 (* Modular inverse for bignums (with odd modulus).                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modinv.o";;
  ****)
 

--- a/x86/proofs/bignum_modoptneg.ml
+++ b/x86/proofs/bignum_modoptneg.ml
@@ -7,6 +7,8 @@
 (* Optional modular negation of bignum.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modoptneg.o";;
  ****)
 

--- a/x86/proofs/bignum_modsub.ml
+++ b/x86/proofs/bignum_modsub.ml
@@ -7,6 +7,8 @@
 (* Modular subtraction of bignums.                                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_modsub.o";;
  ****)
 

--- a/x86/proofs/bignum_montifier.ml
+++ b/x86/proofs/bignum_montifier.ml
@@ -7,6 +7,8 @@
 (* Montifier computation.                                                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_montifier.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul.ml
+++ b/x86/proofs/bignum_montmul.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication of arbitrary bignums.                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_montmul.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p256.ml
+++ b/x86/proofs/bignum_montmul_p256.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery multiplication modulo p_256.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_montmul_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p256_alt.ml
+++ b/x86/proofs/bignum_montmul_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_256 using using traditional x86 muls.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_montmul_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p256k1.ml
+++ b/x86/proofs/bignum_montmul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiply mod p_256k1, the field characteristic for secp256k1.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_montmul_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p256k1_alt.ml
+++ b/x86/proofs/bignum_montmul_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiply mod p_256k1, the field characteristic for secp256k1.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_montmul_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p384.ml
+++ b/x86/proofs/bignum_montmul_p384.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery multiplication modulo p_384.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_montmul_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p384_alt.ml
+++ b/x86/proofs/bignum_montmul_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_384 using traditional x86 muls.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_montmul_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p521.ml
+++ b/x86/proofs/bignum_montmul_p521.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery multiplication modulo p_521.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_montmul_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_p521_alt.ml
+++ b/x86/proofs/bignum_montmul_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_521 using traditional x86 muls.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_montmul_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_sm2.ml
+++ b/x86/proofs/bignum_montmul_sm2.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery multiplication modulo p_sm2.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_montmul_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_montmul_sm2_alt.ml
+++ b/x86/proofs/bignum_montmul_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery multiplication modulo p_sm2 using using traditional x86 muls.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_montmul_sm2_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montredc.ml
+++ b/x86/proofs/bignum_montredc.ml
@@ -7,6 +7,8 @@
 (* Montgomery reduction of arbitrary bignum.                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_montredc.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr.ml
+++ b/x86/proofs/bignum_montsqr.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring of arbitrary bignum.                                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_montsqr.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p256.ml
+++ b/x86/proofs/bignum_montsqr_p256.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery squaring modulo p_256.                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_montsqr_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p256_alt.ml
+++ b/x86/proofs/bignum_montsqr_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_256 using traditional x86 multiplications.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_montsqr_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p256k1.ml
+++ b/x86/proofs/bignum_montsqr_p256k1.ml
@@ -7,6 +7,8 @@
 (* Montgomery square mod p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_montsqr_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p256k1_alt.ml
+++ b/x86/proofs/bignum_montsqr_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery square mod p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_montsqr_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p384.ml
+++ b/x86/proofs/bignum_montsqr_p384.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery squaring modulo p_384.                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_montsqr_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p384_alt.ml
+++ b/x86/proofs/bignum_montsqr_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_384 using traditional x86 muls.              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_montsqr_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p521.ml
+++ b/x86/proofs/bignum_montsqr_p521.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_521.                                         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_montsqr_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_p521_alt.ml
+++ b/x86/proofs/bignum_montsqr_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_521.                                         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_montsqr_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_sm2.ml
+++ b/x86/proofs/bignum_montsqr_sm2.ml
@@ -7,6 +7,8 @@
 (* MULX-based Montgomery squaring modulo p_sm2.                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_montsqr_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_montsqr_sm2_alt.ml
+++ b/x86/proofs/bignum_montsqr_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Montgomery squaring modulo p_sm2 using traditional x86 multiplications.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_montsqr_sm2_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul.ml
+++ b/x86/proofs/bignum_mul.ml
@@ -7,6 +7,8 @@
 (* Multiplication.                                                           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_mul.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_4_8.ml
+++ b/x86/proofs/bignum_mul_4_8.ml
@@ -7,6 +7,8 @@
 (* MULX-based 4x4->8 multiplication.                                         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_4_8.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_4_8_alt.ml
+++ b/x86/proofs/bignum_mul_4_8_alt.ml
@@ -7,6 +7,8 @@
 (* 4x4->8 multiplication using traditional x86 mul instructions.             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_4_8_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_6_12.ml
+++ b/x86/proofs/bignum_mul_6_12.ml
@@ -7,6 +7,8 @@
 (* MULX-based 6x6->12 multiplication.                                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_6_12.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_6_12_alt.ml
+++ b/x86/proofs/bignum_mul_6_12_alt.ml
@@ -7,6 +7,8 @@
 (* 6x6->12 multiplication using traditional x86 mul instructions.            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_6_12_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_8_16.ml
+++ b/x86/proofs/bignum_mul_8_16.ml
@@ -7,6 +7,8 @@
 (* MULX-based 8x8->16 multiplication.                                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_8_16.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_8_16_alt.ml
+++ b/x86/proofs/bignum_mul_8_16_alt.ml
@@ -7,6 +7,8 @@
 (* 8x8->16 multiplication using traditional x86 muls.                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_mul_8_16_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p25519.ml
+++ b/x86/proofs/bignum_mul_p25519.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519, the field characteristic for curve25519.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mul_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p25519_alt.ml
+++ b/x86/proofs/bignum_mul_p25519_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_25519, the field characteristic for curve25519.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_mul_p25519_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p256k1.ml
+++ b/x86/proofs/bignum_mul_p256k1.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_mul_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p256k1_alt.ml
+++ b/x86/proofs/bignum_mul_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_256k1, the field characteristic for secp256k1.    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_mul_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p521.ml
+++ b/x86/proofs/bignum_mul_p521.ml
@@ -7,6 +7,8 @@
 (* MULX-based multiplication modulo p_521.                                   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_mul_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_mul_p521_alt.ml
+++ b/x86/proofs/bignum_mul_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Multiplication modulo p_521 using conventional x86 muls.                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_mul_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_muladd10.ml
+++ b/x86/proofs/bignum_muladd10.ml
@@ -7,6 +7,8 @@
 (* Multiply by 10 and add another word.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_muladd10.o";;
  ****)
 

--- a/x86/proofs/bignum_mux.ml
+++ b/x86/proofs/bignum_mux.ml
@@ -7,6 +7,8 @@
 (* Multiplexing for raw bignums with same length.                            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_mux.o";;
  ****)
 

--- a/x86/proofs/bignum_mux16.ml
+++ b/x86/proofs/bignum_mux16.ml
@@ -7,6 +7,8 @@
 (* 16-way multiplexing for k-length bignums.                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_mux16.o";;
  ****)
 

--- a/x86/proofs/bignum_mux_4.ml
+++ b/x86/proofs/bignum_mux_4.ml
@@ -7,6 +7,8 @@
 (* Multiplexing (selection, if-then-else) for 4-digit (256-bit) bignums.     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_mux_4.o";;
  ****)
 

--- a/x86/proofs/bignum_mux_6.ml
+++ b/x86/proofs/bignum_mux_6.ml
@@ -7,6 +7,8 @@
 (* Multiplexing (selection, if-then-else) for 6-digit (384-bit) bignums.     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_mux_6.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_p25519.ml
+++ b/x86/proofs/bignum_neg_p25519.ml
@@ -7,6 +7,8 @@
 (* Negation modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_neg_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_p256.ml
+++ b/x86/proofs/bignum_neg_p256.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_256, field characteristic for NIST P-256 curve.            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_neg_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_p256k1.ml
+++ b/x86/proofs/bignum_neg_p256k1.ml
@@ -7,6 +7,8 @@
 (* Negation modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_neg_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_p384.ml
+++ b/x86/proofs/bignum_neg_p384.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_384, field characteristic for NIST P-384 curve.            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_neg_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_p521.ml
+++ b/x86/proofs/bignum_neg_p521.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_521, field characteristic for NIST P-521 curve.            *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_neg_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_neg_sm2.ml
+++ b/x86/proofs/bignum_neg_sm2.ml
@@ -7,6 +7,8 @@
 (* Negation mod p_sm2, field characteristic for CC SM2 curve.                *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_neg_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_negmodinv.ml
+++ b/x86/proofs/bignum_negmodinv.ml
@@ -7,6 +7,8 @@
 (* Bignum negated modular inversion.                                         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_negmodinv.o";;
  ****)
 

--- a/x86/proofs/bignum_nonzero.ml
+++ b/x86/proofs/bignum_nonzero.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is zero.                                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_nonzero.o";;
  ****)
 

--- a/x86/proofs/bignum_nonzero_4.ml
+++ b/x86/proofs/bignum_nonzero_4.ml
@@ -7,6 +7,8 @@
 (* Deduce if a 256-bit bignum is nonzero.                                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_nonzero_4.o";;
  ****)
 

--- a/x86/proofs/bignum_nonzero_6.ml
+++ b/x86/proofs/bignum_nonzero_6.ml
@@ -7,6 +7,8 @@
 (* Deduce if a 384-bit bignum is nonzero.                                    *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_nonzero_6.o";;
  ****)
 

--- a/x86/proofs/bignum_normalize.ml
+++ b/x86/proofs/bignum_normalize.ml
@@ -7,6 +7,8 @@
 (* Normalization of a bignum in-place in constant time.                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_normalize.o";;
  ****)
 

--- a/x86/proofs/bignum_odd.ml
+++ b/x86/proofs/bignum_odd.ml
@@ -7,6 +7,8 @@
 (* Deduce if a bignum is odd or even.                                        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_odd.o";;
  ****)
 

--- a/x86/proofs/bignum_of_word.ml
+++ b/x86/proofs/bignum_of_word.ml
@@ -7,6 +7,8 @@
 (* Conversion of a single word (digit) to a bignum.                          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_of_word.o";;
  ****)
 

--- a/x86/proofs/bignum_optadd.ml
+++ b/x86/proofs/bignum_optadd.ml
@@ -7,6 +7,8 @@
 (* Optional addition of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_optadd.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg.ml
+++ b/x86/proofs/bignum_optneg.ml
@@ -7,6 +7,8 @@
 (* Optional negation of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_optneg.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_p25519.ml
+++ b/x86/proofs/bignum_optneg_p25519.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_25519, field characteristic for curve25519.       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_optneg_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_p256.ml
+++ b/x86/proofs/bignum_optneg_p256.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_256, field characteristic for NIST P-256 curve.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_optneg_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_p256k1.ml
+++ b/x86/proofs/bignum_optneg_p256k1.ml
@@ -7,6 +7,8 @@
 (* Optional negation modulo p_256k1, the field characteristic for secp256k1. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_optneg_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_p384.ml
+++ b/x86/proofs/bignum_optneg_p384.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_384, field characteristic for NIST P-384 curve.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_optneg_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_p521.ml
+++ b/x86/proofs/bignum_optneg_p521.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_521, field characteristic for NIST P-521 curve.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_optneg_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_optneg_sm2.ml
+++ b/x86/proofs/bignum_optneg_sm2.ml
@@ -7,6 +7,8 @@
 (* Optional negation mod p_sm2, field characteristic for CC SM2 curve.       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_optneg_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_optsub.ml
+++ b/x86/proofs/bignum_optsub.ml
@@ -7,6 +7,8 @@
 (* "Optional subtraction" function, subtracting iff a flag is nonzero.       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_optsub.o";;
  ****)
 

--- a/x86/proofs/bignum_optsubadd.ml
+++ b/x86/proofs/bignum_optsubadd.ml
@@ -7,6 +7,8 @@
 (* Optional addition of bignums.                                             *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_optsubadd.o";;
  ****)
 

--- a/x86/proofs/bignum_pow2.ml
+++ b/x86/proofs/bignum_pow2.ml
@@ -7,6 +7,8 @@
 (* Creation of a power-of-2 bignum using the input word as the index.        *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_pow2.o";;
  ****)
 

--- a/x86/proofs/bignum_shl_small.ml
+++ b/x86/proofs/bignum_shl_small.ml
@@ -7,6 +7,8 @@
 (* Shifting of a bignum left < 64 bits.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_shl_small.o";;
  ****)
 

--- a/x86/proofs/bignum_shr_small.ml
+++ b/x86/proofs/bignum_shr_small.ml
@@ -7,6 +7,8 @@
 (* Shifting of a bignum right < 64 bits.                                     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_shr_small.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr.ml
+++ b/x86/proofs/bignum_sqr.ml
@@ -7,6 +7,8 @@
 (* Squaring.                                                                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_sqr.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_4_8.ml
+++ b/x86/proofs/bignum_sqr_4_8.ml
@@ -7,6 +7,8 @@
 (* MULX-based 4x4->8 squaring.                                               *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_4_8.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_4_8_alt.ml
+++ b/x86/proofs/bignum_sqr_4_8_alt.ml
@@ -7,6 +7,8 @@
 (* 4x4->8 squaring using traditional x86 mul instructions.                   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_4_8_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_6_12.ml
+++ b/x86/proofs/bignum_sqr_6_12.ml
@@ -7,6 +7,8 @@
 (* MULX-based 6x6->12 squaring.                                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_6_12.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_6_12_alt.ml
+++ b/x86/proofs/bignum_sqr_6_12_alt.ml
@@ -7,6 +7,8 @@
 (* 6x6->12 squaring using traditional x86 mul instructions.                  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_6_12_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_8_16.ml
+++ b/x86/proofs/bignum_sqr_8_16.ml
@@ -7,6 +7,8 @@
 (* MULX-based 8x8->16 squaring.                                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_8_16.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_8_16_alt.ml
+++ b/x86/proofs/bignum_sqr_8_16_alt.ml
@@ -7,6 +7,8 @@
 (* 8x8->16 squaring using traditional x86 muls.                              *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/fastmul/bignum_sqr_8_16_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p25519.ml
+++ b/x86/proofs/bignum_sqr_p25519.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_25519, the field characteristic for curve25519.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_sqr_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p25519_alt.ml
+++ b/x86/proofs/bignum_sqr_p25519_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_25519, the field characteristic for curve25519.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_sqr_p25519_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p256k1.ml
+++ b/x86/proofs/bignum_sqr_p256k1.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_sqr_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p256k1_alt.ml
+++ b/x86/proofs/bignum_sqr_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_sqr_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p521.ml
+++ b/x86/proofs/bignum_sqr_p521.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_sqr_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_sqr_p521_alt.ml
+++ b/x86/proofs/bignum_sqr_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Squaring modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_sqr_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_sqrt_p25519.ml
+++ b/x86/proofs/bignum_sqrt_p25519.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/bignum_sqrt_p25519_alt.ml
+++ b/x86/proofs/bignum_sqrt_p25519_alt.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/bignum_sub.ml
+++ b/x86/proofs/bignum_sub.ml
@@ -7,6 +7,8 @@
 (* Subtraction of bignums.                                                   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/bignum_sub.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_p25519.ml
+++ b/x86/proofs/bignum_sub_p25519.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_25519, the field characteristic for curve25519.      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/curve25519/bignum_sub_p25519.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_p256.ml
+++ b/x86/proofs/bignum_sub_p256.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_256, the field characteristic for NIST P-256 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_sub_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_p256k1.ml
+++ b/x86/proofs/bignum_sub_p256k1.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_256k1, the field characteristic for secp256k1.       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_sub_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_p384.ml
+++ b/x86/proofs/bignum_sub_p384.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_384, the field characteristic for NIST P-384 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_sub_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_p521.ml
+++ b/x86/proofs/bignum_sub_p521.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_521, the field characteristic for NIST P-521 curve.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_sub_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_sub_sm2.ml
+++ b/x86/proofs/bignum_sub_sm2.ml
@@ -7,6 +7,8 @@
 (* Subtraction modulo p_sm2, the field characteristic for CC SM2 curve.      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_sub_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_tolebytes_p521.ml
+++ b/x86/proofs/bignum_tolebytes_p521.ml
@@ -7,6 +7,8 @@
 (* Translation to little-endian byte sequence, 9 digits -> 66 bytes.         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_tolebytes_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p256.ml
+++ b/x86/proofs/bignum_tomont_p256.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form modulo p_256.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_tomont_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p256_alt.ml
+++ b/x86/proofs/bignum_tomont_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form modulo p_256.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_tomont_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p256k1.ml
+++ b/x86/proofs/bignum_tomont_p256k1.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form mod p_256k1.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_tomont_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p256k1_alt.ml
+++ b/x86/proofs/bignum_tomont_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form mod p_256k1.   *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_tomont_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p384.ml
+++ b/x86/proofs/bignum_tomont_p384.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 6-word (384-bit) bignum to Montgomery form modulo p_384.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_tomont_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p384_alt.ml
+++ b/x86/proofs/bignum_tomont_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 6-word (384-bit) bignum to Montgomery form modulo p_384.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_tomont_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_p521.ml
+++ b/x86/proofs/bignum_tomont_p521.ml
@@ -7,6 +7,8 @@
 (* Mapping into Montgomery representation for p_521.                         *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_tomont_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_tomont_sm2.ml
+++ b/x86/proofs/bignum_tomont_sm2.ml
@@ -7,6 +7,8 @@
 (* Conversion of a 4-word (256-bit) bignum to Montgomery form modulo p_sm2.  *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_tomont_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p256.ml
+++ b/x86/proofs/bignum_triple_p256.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_triple_p256.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p256_alt.ml
+++ b/x86/proofs/bignum_triple_p256_alt.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256, the field characteristic for the NIST P-256 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p256/bignum_triple_p256_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p256k1.ml
+++ b/x86/proofs/bignum_triple_p256k1.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_triple_p256k1.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p256k1_alt.ml
+++ b/x86/proofs/bignum_triple_p256k1_alt.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_256k1, the field characteristic for secp256k1.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/secp256k1/bignum_triple_p256k1_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p384.ml
+++ b/x86/proofs/bignum_triple_p384.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_triple_p384.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p384_alt.ml
+++ b/x86/proofs/bignum_triple_p384_alt.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_384, the field characteristic for the NIST P-384 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p384/bignum_triple_p384_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p521.ml
+++ b/x86/proofs/bignum_triple_p521.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_triple_p521.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_p521_alt.ml
+++ b/x86/proofs/bignum_triple_p521_alt.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_521, the field characteristic for the NIST P-521 curve. *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/p521/bignum_triple_p521_alt.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_sm2.ml
+++ b/x86/proofs/bignum_triple_sm2.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_triple_sm2.o";;
  ****)
 

--- a/x86/proofs/bignum_triple_sm2_alt.ml
+++ b/x86/proofs/bignum_triple_sm2_alt.ml
@@ -7,6 +7,8 @@
 (* Tripling modulo p_sm2, the field characteristic for the CC SM2 curve.     *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/sm2/bignum_triple_sm2_alt.o";;
  ****)
 

--- a/x86/proofs/edwards25519_decode.ml
+++ b/x86/proofs/edwards25519_decode.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/edwards25519_decode_alt.ml
+++ b/x86/proofs/edwards25519_decode_alt.ml
@@ -1,4 +1,4 @@
- (*
+(*
  * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)

--- a/x86/proofs/word_bytereverse.ml
+++ b/x86/proofs/word_bytereverse.ml
@@ -7,6 +7,8 @@
 (* Reversing the order of the bytes in a single 64-bit word.                 *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_bytereverse.o";;
  ****)
 

--- a/x86/proofs/word_clz.ml
+++ b/x86/proofs/word_clz.ml
@@ -7,6 +7,8 @@
 (* Counting leading zeros in a well-defined way for a single word.           *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_clz.o";;
  ****)
 

--- a/x86/proofs/word_ctz.ml
+++ b/x86/proofs/word_ctz.ml
@@ -7,6 +7,8 @@
 (* Counting trailing zeros in a well-defined way for a single word.          *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_ctz.o";;
  ****)
 

--- a/x86/proofs/word_max.ml
+++ b/x86/proofs/word_max.ml
@@ -7,6 +7,8 @@
 (* Finding maximum of two 64-bit words.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_max.o";;
  ****)
 

--- a/x86/proofs/word_min.ml
+++ b/x86/proofs/word_min.ml
@@ -7,6 +7,8 @@
 (* Finding minimum of two 64-bit words.                                      *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_min.o";;
  ****)
 

--- a/x86/proofs/word_negmodinv.ml
+++ b/x86/proofs/word_negmodinv.ml
@@ -7,6 +7,8 @@
 (* Word-level negated modular inverse.                                       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_negmodinv.o";;
  ****)
 

--- a/x86/proofs/word_recip.ml
+++ b/x86/proofs/word_recip.ml
@@ -7,6 +7,8 @@
 (* Word-level negated modular inverse.                                       *)
 (* ========================================================================= *)
 
+needs "x86/proofs/base.ml";;
+
 (**** print_literal_from_elf "x86/generic/word_recip.o";;
  ****)
 


### PR DESCRIPTION
This patch adds `needs "{arm,x86}/proofs/base.ml";;` to the beginning of every proof file, instead of externally running this from `run-proof.sh`.

This has several benefits:

1. This makes it clear that proofs require loading `"{arm,x86}/proofs/base.ml"` in advance, which was not explicitly described in README.

2. When using OCaml REPL, this removes waiting finishing `loadt "{arm,x86}/proofs/base.ml";;`
For example, to run `arm/proofs/bignum_add.ml` on OCaml REPL, `loadt "arm/proofs/base.ml";;` must be run first, which will take a few minutes. This patch removes the necessity of intervention.

3. vscode-hol-light's release candidate 2.0 now supports 'Go to definition'. This requires the dependency between source files to be explicitly written as `needs`,`loadt`,`loads`.
This patch makes the functionality work well for s2n-bignum proofs.

### How to review this patch

This patch can be reviewed as follows:
- `{arm/x86}/proofs/specifications.txt` are not modified by this patch. CI checks guarantee that the theorems are not deleted.
- Diff of this patch only contains `needs "{arm,x86}/proofs/base.ml";;\n` (not other texts) in every .ml file (https://dellsystem.me/posts/additions-deletions-git). This guarantees that the specification theorems are not modified.
- `tools/run-proof.sh` does not load the `base.ml` file anymore.

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
