### PR TITLE
Avoid using term_match for performance, do small refactoring to equiv tactics

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -380,11 +380,8 @@ let ARM_THM =
       let pc_expr = fst (List.hd inst) in
       if is_var pc_expr then 0
       else try
-        let _,inst2,_ = term_match [] `pc_base + ofs` pc_expr in
-        let ofs,ofs_var = List.hd inst2 in
-        if ofs_var <> `ofs:num` || not (is_numeral ofs)
-        then failwith ""
-        else dest_small_numeral ofs
+        let pc_base,ofs = dest_binary "+" pc_expr in
+        dest_small_numeral ofs
       with Failure _ ->
         failwith ("ARM_THM: Cannot decompose PC expression: " ^ (string_of_term (concl pc_th))) in
     MATCH_MP th (MATCH_MP (Option.get execth2.(pc_ofs)) loaded_mc_th);;
@@ -396,6 +393,12 @@ let ARM_ENSURES_SUBSUBLEMMA_TAC =
   ENSURES_SUBSUBLEMMA_TAC o
   map (MATCH_MP aligned_bytes_loaded_update o CONJUNCT1);;
 
+(* returns true if t is `read PC <state>`. *)
+let is_read_pc t =
+  match t with
+  | Comb (Comb (Const ("read", _), Const ("PC", _)), _) -> true
+  | _ -> false;;
+
 (*** decode_ths is an array from int offset i to
  ***   Some `|- !s pc. aligned_bytes_loaded s pc *_mc
  ***            ==> arm_decode s (word (pc+i)) (..inst..)`
@@ -404,7 +407,9 @@ let ARM_ENSURES_SUBSUBLEMMA_TAC =
 
 let ARM_CONV (decode_ths:thm option array) (ths:thm list) tm =
   let pc_th = find
-    (fun th -> can (term_match [] `read PC s = (e:int64)`) (concl th))
+    (fun th -> (* do not use term_match because it is slow. *)
+      let c = concl th in
+      is_eq c && is_read_pc (fst (dest_eq c)))
     ths in
   let eth = tryfind (fun loaded_mc_th ->
       GEN_REWRITE_CONV I [ARM_THM decode_ths loaded_mc_th pc_th] tm) ths in

--- a/arm/proofs/bignum_montmul_p256_neon.ml
+++ b/arm/proofs/bignum_montmul_p256_neon.ml
@@ -279,18 +279,18 @@ let actions = [
   ("equal", 51, 175, 80, 204)
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montmul_p256_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p256_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p256_core_mc 0
+    bignum_montmul_p256_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montmul_p256_interm1_core_mc 0
+    bignum_montmul_p256_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 
@@ -363,16 +363,16 @@ let bignum_montmul_p256_neon_core_mc_def,
     (fst BIGNUM_MONTMUL_P256_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montmul_p256_interm1_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p256_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p256_interm1_core_mc 0
+    bignum_montmul_p256_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`
-    bignum_montmul_p256_neon_core_mc 0
+    bignum_montmul_p256_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 
@@ -436,18 +436,18 @@ let BIGNUM_MONTMUL_P256_CORE_EQUIV2 = prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montmul_p256_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p256_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p256_core_mc 0
+    bignum_montmul_p256_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montmul_p256_neon_core_mc 0
+    bignum_montmul_p256_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 

--- a/arm/proofs/bignum_montmul_p384_neon.ml
+++ b/arm/proofs/bignum_montmul_p384_neon.ml
@@ -487,19 +487,19 @@ let actions = [
   ("equal", 122, 377, 151, 406);
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montmul_p384_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p384_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p384_core_mc 0
+    bignum_montmul_p384_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montmul_p384_interm1_core_mc 0
+    bignum_montmul_p384_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;
@@ -572,17 +572,17 @@ let bignum_montmul_p384_neon_core_mc_def,
     (fst BIGNUM_MONTMUL_P384_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montmul_p384_interm1_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p384_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p384_interm1_core_mc 0
+    bignum_montmul_p384_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`
-    bignum_montmul_p384_neon_core_mc 0
+    bignum_montmul_p384_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;
@@ -648,19 +648,19 @@ let BIGNUM_MONTMUL_P384_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montmul_p384_core_mc);
        (word pc2:int64,LENGTH bignum_montmul_p384_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p384_core_mc 0
+    bignum_montmul_p384_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montmul_p384_neon_core_mc 0
+    bignum_montmul_p384_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;

--- a/arm/proofs/bignum_montmul_p521_neon.ml
+++ b/arm/proofs/bignum_montmul_p521_neon.ml
@@ -746,7 +746,7 @@ let actions = [
   ("equal", 148, 619, 197, 668);
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montmul_p521_core_mc);
@@ -757,14 +757,14 @@ let equiv_goal1 = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p521_core_mc 0
+    bignum_montmul_p521_core_mc
     `MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_montmul_p521_interm1_core_mc 0
+    bignum_montmul_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
@@ -839,7 +839,7 @@ let bignum_montmul_p521_neon_core_mc_def,
     (fst BIGNUM_MONTMUL_P521_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montmul_p521_interm1_core_mc);
@@ -850,12 +850,12 @@ let equiv_goal2 = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p521_interm1_core_mc 0
+    bignum_montmul_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_montmul_p521_neon_core_mc 0
+    bignum_montmul_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
@@ -918,7 +918,7 @@ let BIGNUM_MONTMUL_P521_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montmul_p521_core_mc);
@@ -929,14 +929,14 @@ let equiv_goal = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_montmul_p521_core_mc 0
+    bignum_montmul_p521_core_mc
     `MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_montmul_p521_neon_core_mc 0
+    bignum_montmul_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);

--- a/arm/proofs/bignum_montsqr_p256_neon.ml
+++ b/arm/proofs/bignum_montsqr_p256_neon.ml
@@ -210,18 +210,18 @@ let actions2 = [
   ("equal", 42, 124, 54, 136);
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montsqr_p256_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p256_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p256_core_mc 0
+    bignum_montsqr_p256_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montsqr_p256_interm1_core_mc 0
+    bignum_montsqr_p256_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 
@@ -416,16 +416,16 @@ let bignum_montsqr_p256_neon_core_mc_def,
     (fst BIGNUM_MONTSQR_P256_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montsqr_p256_interm1_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p256_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p256_interm1_core_mc 0
+    bignum_montsqr_p256_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`
-    bignum_montsqr_p256_neon_core_mc 0
+    bignum_montsqr_p256_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 
@@ -487,18 +487,18 @@ let BIGNUM_MONTSQR_P256_CORE_EQUIV2 = prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 4))
       [(word pc:int64,LENGTH bignum_montsqr_p256_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p256_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p256_core_mc 0
+    bignum_montsqr_p256_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montsqr_p256_neon_core_mc 0
+    bignum_montsqr_p256_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 4)]`;;
 

--- a/arm/proofs/bignum_montsqr_p384_neon.ml
+++ b/arm/proofs/bignum_montsqr_p384_neon.ml
@@ -385,18 +385,18 @@ let actions = [
   ("equal", 223, 260, 269, 306);
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montsqr_p384_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p384_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p384_core_mc 0
+    bignum_montsqr_p384_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montsqr_p384_interm1_core_mc 0
+    bignum_montsqr_p384_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;
 
@@ -469,16 +469,16 @@ let bignum_montsqr_p384_neon_core_mc_def,
     (fst BIGNUM_MONTSQR_P384_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montsqr_p384_interm1_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p384_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p384_interm1_core_mc 0
+    bignum_montsqr_p384_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`
-    bignum_montsqr_p384_neon_core_mc 0
+    bignum_montsqr_p384_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;
 
@@ -542,18 +542,18 @@ let BIGNUM_MONTSQR_P384_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 6))
       [(word pc:int64,LENGTH bignum_montsqr_p384_core_mc);
        (word pc2:int64,LENGTH bignum_montsqr_p384_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p384_core_mc 0
+    bignum_montsqr_p384_core_mc
     `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
                 X13; X14; X15; X16; X17] ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)] ,,
      MAYCHANGE SOME_FLAGS`
-    bignum_montsqr_p384_neon_core_mc 0
+    bignum_montsqr_p384_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [memory :> bytes(z,8 * 6)]`;;
 

--- a/arm/proofs/bignum_montsqr_p521_neon.ml
+++ b/arm/proofs/bignum_montsqr_p521_neon.ml
@@ -600,18 +600,18 @@ let actions2 = [
   ("equal", 249, 423, 351, 525)
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montsqr_p521_core_mc);
         (word pc2,LENGTH bignum_montsqr_p521_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p521_core_mc 0
+    bignum_montsqr_p521_core_mc
     `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12; X13;
                 X14; X15; X16; X17; X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_montsqr_p521_interm1_core_mc 0
+    bignum_montsqr_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;
@@ -691,17 +691,17 @@ let bignum_montsqr_p521_neon_core_mc_def,
     (`12`,`LENGTH bignum_montsqr_p521_neon_mc - 28`)
     (fst BIGNUM_MONTSQR_P521_NEON_EXEC);;
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montsqr_p521_interm1_core_mc);
         (word pc2,LENGTH bignum_montsqr_p521_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p521_interm1_core_mc 0
+    bignum_montsqr_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_montsqr_p521_neon_core_mc 0
+    bignum_montsqr_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;
@@ -764,18 +764,18 @@ let BIGNUM_MONTSQR_P521_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_montsqr_p521_core_mc);
         (word pc2,LENGTH bignum_montsqr_p521_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_montsqr_p521_core_mc 0
+    bignum_montsqr_p521_core_mc
     `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12; X13;
                 X14; X15; X16; X17; X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_montsqr_p521_neon_core_mc 0
+    bignum_montsqr_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;

--- a/arm/proofs/bignum_mul_8_16_neon.ml
+++ b/arm/proofs/bignum_mul_8_16_neon.ml
@@ -560,20 +560,20 @@ let bignum_mul_8_16_equiv_output_states = new_definition
       bignum_from_memory (z,16) s1 = c /\
       bignum_from_memory (z,16) s1' = c)`;;
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
   `ALL (nonoverlapping (z,8 * 16)) [
       (word pc:int64,LENGTH bignum_mul_8_16_core_mc);
       (word pc2:int64,LENGTH bignum_mul_8_16_neon_core_mc);
       (x,8 * 8); (y,8 * 8)]`
   bignum_mul_8_16_equiv_input_states
   bignum_mul_8_16_equiv_output_states
-  bignum_mul_8_16_core_mc 0
+  bignum_mul_8_16_core_mc
   `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8;
               X9; X10; X11; X12; X13; X14; X15; X16;
               X17; X19; X20; X21; X22; X23; X24] ,,
    MAYCHANGE [memory :> bytes(z,8 * 16)] ,,
    MAYCHANGE SOME_FLAGS`
-  bignum_mul_8_16_neon_core_mc 0
+  bignum_mul_8_16_neon_core_mc
   `MAYCHANGE [PC; X1; X2; X3; X4; X5; X6; X7; X8;
               X9; X10; X11; X12; X13; X14; X15; X16;
               X17; X19; X20; X21; X22; X23; X24] ,,
@@ -665,8 +665,8 @@ let event_n_at_pc_goal = mk_eventually_n_at_pc_statement
       (word pc:int64,
        LENGTH (APPEND bignum_mul_8_16_core_mc barrier_inst_bytes));
       (x:int64,8 * 8); (y:int64,8 * 8)]`
-  [`z:int64`;`x:int64`;`y:int64`] 0
-  bignum_mul_8_16_core_mc 0
+  [`z:int64`;`x:int64`;`y:int64`] (*pc_ofs*)0
+  bignum_mul_8_16_core_mc (*pc_ofs*)0
   `(\s0. C_ARGUMENTS [z;x;y] s0)`;;
 
 let BIGNUM_MUL_8_16_EVENTUALLY_N_AT_PC = prove(event_n_at_pc_goal,

--- a/arm/proofs/bignum_mul_p521_neon.ml
+++ b/arm/proofs/bignum_mul_p521_neon.ml
@@ -739,7 +739,7 @@ let actions = [
   ("equal", 144, 624, 184, 664);
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_mul_p521_core_mc);
@@ -750,14 +750,14 @@ let equiv_goal1 = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_mul_p521_core_mc 0
+    bignum_mul_p521_core_mc
     `MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_mul_p521_interm1_core_mc 0
+    bignum_mul_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
@@ -832,7 +832,7 @@ let bignum_mul_p521_neon_core_mc_def,
     (fst BIGNUM_MUL_P521_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_mul_p521_interm1_core_mc);
@@ -843,12 +843,12 @@ let equiv_goal2 = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_mul_p521_interm1_core_mc 0
+    bignum_mul_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_mul_p521_neon_core_mc 0
+    bignum_mul_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);
@@ -911,7 +911,7 @@ let BIGNUM_MUL_P521_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `aligned 16 stackpointer /\
      ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_mul_p521_core_mc);
@@ -922,14 +922,14 @@ let equiv_goal = mk_equiv_statement
         (z,8 * 9); (x:int64,8 * 9); (y:int64,8 * 9)]`
     equiv_input_states
     equiv_output_states
-    bignum_mul_p521_core_mc 0
+    bignum_mul_p521_core_mc
     `MAYCHANGE [PC; X3; X4; X5; X6; X7; X8; X9;
                 X10; X11; X12; X13; X14; X15; X16; X17; X19;
                 X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9);
                 memory :> bytes(stackpointer,80)]`
-    bignum_mul_p521_neon_core_mc 0
+    bignum_mul_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24; X25; X26] ,,
      MAYCHANGE [memory :> bignum(z,9);

--- a/arm/proofs/bignum_sqr_8_16_neon.ml
+++ b/arm/proofs/bignum_sqr_8_16_neon.ml
@@ -580,19 +580,19 @@ let actions2 = [
 
 
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
   `ALL (nonoverlapping (z,8 * 16)) [
     (word pc:int64,LENGTH bignum_sqr_8_16_core_mc);
     (word pc2:int64,LENGTH bignum_sqr_8_16_neon_core_mc);
     (x,8 * 8)]`
   bignum_sqr_8_16_equiv_input_states
   bignum_sqr_8_16_equiv_output_states
-  bignum_sqr_8_16_core_mc 0
+  bignum_sqr_8_16_core_mc
   `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
               X13; X14; X15; X16; X17; X19; X20; X21; X22] ,,
    MAYCHANGE [memory :> bytes(z,8 * 16)] ,,
    MAYCHANGE SOME_FLAGS`
-  bignum_sqr_8_16_neon_core_mc 0
+  bignum_sqr_8_16_neon_core_mc
   `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12;
               X13; X14; X15; X16; X17; X19; X20; X21; X22] ,,
    MAYCHANGE [Q0; Q1; Q2; Q3; Q4; Q5; Q6; Q7; Q16; Q17; Q18; Q19; Q20;
@@ -655,7 +655,7 @@ extra_word_CONV := _org_extra_word_CONV;;
 let event_n_at_pc_goal = mk_eventually_n_at_pc_statement
   `nonoverlapping (word pc:int64,
     LENGTH (APPEND bignum_sqr_8_16_core_mc barrier_inst_bytes)) (z:int64,8 * 16)`
-  [`z:int64`;`x:int64`] 0 bignum_sqr_8_16_core_mc 0
+  [`z:int64`;`x:int64`] 0 bignum_sqr_8_16_core_mc (*pc_ofs*)0
   `(\s0. C_ARGUMENTS [z;x] s0)`;;
 
 let BIGNUM_SQR_8_16_EVENTUALLY_N_AT_PC = prove(event_n_at_pc_goal,

--- a/arm/proofs/bignum_sqr_p521_neon.ml
+++ b/arm/proofs/bignum_sqr_p521_neon.ml
@@ -599,18 +599,18 @@ let actions = [
   ("insert", 253, 253, 367, 368); ("equal", 253, 412, 368, 527)
 ];;
 
-let equiv_goal1 = mk_equiv_statement
+let equiv_goal1 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_sqr_p521_core_mc);
         (word pc2,LENGTH bignum_sqr_p521_interm1_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_sqr_p521_core_mc 0
+    bignum_sqr_p521_core_mc
     `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12; X13;
                 X14; X15; X16; X17; X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_sqr_p521_interm1_core_mc 0
+    bignum_sqr_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;
@@ -684,17 +684,17 @@ let bignum_sqr_p521_neon_core_mc_def,
     (fst BIGNUM_SQR_P521_NEON_EXEC);;
 
 
-let equiv_goal2 = mk_equiv_statement
+let equiv_goal2 = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_sqr_p521_interm1_core_mc);
         (word pc2,LENGTH bignum_sqr_p521_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_sqr_p521_interm1_core_mc 0
+    bignum_sqr_p521_interm1_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_sqr_p521_neon_core_mc 0
+    bignum_sqr_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;
@@ -756,18 +756,18 @@ let BIGNUM_SQR_P521_CORE_EQUIV2 = time prove(
   correctness
 ******************************************************************************)
 
-let equiv_goal = mk_equiv_statement
+let equiv_goal = mk_equiv_statement_simple
     `ALL (nonoverlapping (z:int64,8 * 9))
        [(word pc,LENGTH bignum_sqr_p521_core_mc);
         (word pc2,LENGTH bignum_sqr_p521_neon_core_mc)]`
     equiv_input_states
     equiv_output_states
-    bignum_sqr_p521_core_mc 0
+    bignum_sqr_p521_core_mc
     `MAYCHANGE [PC; X2; X3; X4; X5; X6; X7; X8; X9; X10; X11; X12; X13;
                 X14; X15; X16; X17; X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE SOME_FLAGS ,,
      MAYCHANGE [memory :> bignum(z,9)]`
-    bignum_sqr_p521_neon_core_mc 0
+    bignum_sqr_p521_neon_core_mc
     `MAYCHANGE_REGS_AND_FLAGS_PERMITTED_BY_ABI ,,
      MAYCHANGE [X19; X20; X21; X22; X23; X24] ,,
      MAYCHANGE [memory :> bignum(z,9)]`;;

--- a/common/components.ml
+++ b/common/components.ml
@@ -3220,9 +3220,10 @@ let STATE_UPDATE_NEW_RULE th =
 
 let ASSUMPTION_STATE_UPDATE_TAC =
   DISCH_THEN(fun uth ->
+    let update_tac = STATE_UPDATE_TAC uth in
     MP_TAC uth THEN
     ASSUM_LIST(MAP_EVERY (fun th g ->
-      try STATE_UPDATE_TAC uth th g
+      try update_tac th g
       with Failure s ->
         if !components_print_log then
           if s = "NONOVERLAPPING_TAC: orthogonal_components with identical operands"

--- a/common/relational2.ml
+++ b/common/relational2.ml
@@ -973,9 +973,13 @@ let ENSURES2_WHILE_PAUP_TAC =
       REWRITE_TAC[SEQ_PAIR_SPLIT] THEN
       REWRITE_TAC[ETA_AX] THEN
       REPEAT STRIP_TAC THEN
-      MATCH_MP_TAC (MESON[] `!(p:A->A->bool) (q:A->A->bool) r s.
+      ((MATCH_MP_TAC (MESON[] `!(p:A->A->bool) (q:A->A->bool) r s.
         ((p = r) /\ (q = s)) ==> (p x1 x2 /\ q y1 y2 <=> r x1 x2 /\ s y1 y2)`) THEN
-      REWRITE_TAC[ETA_AX] THEN MAYCHANGE_IDEMPOT_TAC;
+        REWRITE_TAC[ETA_AX] THEN
+        MAYCHANGE_IDEMPOT_TAC)
+        ORELSE
+        (* a simpler case *)
+        (REWRITE_TAC[seq;EXISTS_PAIR_THM] THEN NO_TAC));
 
       (* The remaining condition. *)
       ALL_TAC


### PR DESCRIPTION
This patch makes small updates to avoid term_match which seems to be slower than directly using the match statement. A particular case that had to be fixed was when term_match was being invoked for every assumption because the number of assumptions can grow linearly to the number of simulated instructions unless it is cleaned up in the middle. This fix specifically brought ~14% speedups to proofs using equivalence checking tactic because when the lockstep simulation simulates one program it had to filter assumptions to hide that correspond to another program and it was using term_match.
There was also some speedups in large proofs not using equivalence tactic. I will attach the full result in the PR.

Another update that was orthogonally make was to the code related to equivalence checks :

- Rename `mk_equiv_statement` to `mk_equiv_statement_simple` that only considers a pair of straight-line codes from begin to end, and add `mk_equiv_statement` for more generic case.
- Some fix in `common/relational2.ml` in order to support constant-time proof in the future.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
