### PR TITLE
Feature request: p256 avx2 affine point table selection

### DIFF
--- a/x86/p256/bignum_aff_point_select_p256_avx2.S
+++ b/x86/p256/bignum_aff_point_select_p256_avx2.S
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+
+// ----------------------------------------------------------------------------
+// Viewing table as `height` rows with 8 words width, copy the 8 words at
+// table[idx - 1] into z.  If `idx` is zero or larger than `height`,
+// `z` is set to zero (ie, the affine point at infinity).
+//
+// This is useful to select an affine p256 point from a table of
+// precomputed points.
+//
+//    extern void bignum_aff_point_select_p256_avx2
+//     (uint64_t z[static 8], const uint64_t *table, uint64_t height,
+//      uint64_t idx);
+//
+// This uses avx2 instructions, it is the callers responsibility to ensure
+// the CPU supports these.  If not, the caller should instead call
+// `bignum_copy_row_from_table(z, table, height, 8, idx - 1)`
+// and then use `bignum_mux_4` to select between that and the point at infinity
+// for zero `idx`.
+//
+// Standard x86-64 ABI: RDI = z, RSI = table, RDX = height, RCX = idx
+// Microsoft x64 ABI:   RCX = z, RDX = table, R8 = height, R9 = idx
+// ----------------------------------------------------------------------------
+
+#include "_internal_s2n_bignum.h"
+
+        .intel_syntax noprefix
+        S2N_BN_SYM_VISIBILITY_DIRECTIVE(bignum_aff_point_select_p256_avx2)
+        S2N_BN_SYM_PRIVACY_DIRECTIVE(bignum_aff_point_select_p256_avx2)
+        .text
+
+#define z rdi
+#define table rsi
+#define height rdx
+#define idx rcx
+
+// loop counter
+#define i r9
+
+#define acc0  ymm0
+#define acc1  ymm1
+#define row0  ymm2
+#define row1  ymm3
+#define xi    xmm4
+#define yi    ymm4
+#define xidx  xmm5
+#define yidx  ymm5
+#define ymask ymm6
+#define yones ymm7
+
+S2N_BN_SYMBOL(bignum_aff_point_select_p256_avx2):
+
+#if WINDOWS_ABI
+        push    rdi
+        push    rsi
+        mov     rdi, rcx
+        mov     rsi, rdx
+        mov     rdx, r8
+        mov     rcx, r9
+#endif
+        prefetcht0 [table]
+        prefetcht0 [table+128]
+
+        // zero accumulators
+        vpxor   acc0, acc0, acc0
+        vpxor   acc1, acc1, acc1
+
+        // skip if height == 0
+        test    height, height
+        jz      bignum_aff_point_select_p256_avx2_end
+
+        // nb, i and idx are 1-indexed
+        mov     i, 1
+        mov     rax, table
+
+        // set up selection blocks (acc0 as a stand-in for zeros):
+        vmovq   xidx, idx
+        vpermd  yidx, acc0, yidx
+        vmovq   xi, i
+        vpermd  yi, acc0, yi
+        vmovdqa yones, yi
+
+bignum_aff_point_select_p256_avx2_rowloop:
+        // read in candidate row
+        vmovdqu row0, [rax]
+        vmovdqu row1, [rax+32]
+
+        // construct 256-bit mask selecting correct row
+        vpcmpeqd ymask, yi, yidx
+        vpaddq   yi, yi, yones
+
+        // mix into accumulators based on mask
+        vblendvpd    acc0, acc0, row0, ymask
+        vblendvpd    acc1, acc1, row1, ymask
+
+        // next row
+        add     rax, 64
+        inc     i
+        cmp     i, height
+        jle     bignum_aff_point_select_p256_avx2_rowloop
+
+bignum_aff_point_select_p256_avx2_end:
+        vmovdqu [z], acc0
+        vmovdqu [z+32], acc1
+
+#if WINDOWS_ABI
+        pop    rsi
+        pop    rdi
+#endif
+        ret
+
+
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif


### PR DESCRIPTION
Hello,

I was hoping you might consider offering a function like this. This is mainly for discussion rather than a real contribution; notably, I have not written any proof for this or even added it to any makefiles (but I'm happy to do both those things, though would certainly need help with the proof!).  It is effectively a specialisation of `bignum_copy_row_from_table` using AVX2 to improve throughput.

*Background:* I've been building upon s2n-bignum to make a new crypto library in Rust. For p256 base point multiplication I'm using the same approach as BoringSSL/AWS-LC which work through the exponent in 7-bit chunks, in wNAF form, and have a table of 37x64 multiples of the curve generator, at a cost of ~148KB of data. (Most of this predates the new `scalarmul` functions; I haven't measured these to see how they compare yet.)

I was using `bignum_copy_row_from_table` for this, but identified that it was relatively slow for such a large amount of data.

Compared to using `bignum_copy_row_from_table` the performance improvement looks like:

```
p256-keygen/graviola    time:   [8.2675 µs 8.2902 µs 8.3212 µs]
                        thrpt:  [120.18 Kelem/s 120.62 Kelem/s 120.96 Kelem/s]
                 change:
                        time:   [-39.295% -38.577% -37.704%] (p = 0.00 < 0.05)
                        thrpt:  [+60.524% +62.805% +64.730%]
                        Performance has improved.
```

For comparison:

```
p256-keygen/aws-lc-rs   time:   [8.3274 µs 8.3402 µs 8.3556 µs]
                        thrpt:  [119.68 Kelem/s 119.90 Kelem/s 120.09 Kelem/s]
```

(BoringSSL/AWS-LC has a similar, but more aggressive version; see `ecp_nistz256_select_w7`, this implementation is not derived from that one.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
