### PR TITLE
Minor typographical fixes

### DIFF
--- a/arm/fastmul/bignum_emontredc_8n_neon.S
+++ b/arm/fastmul/bignum_emontredc_8n_neon.S
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
 
 // ----------------------------------------------------------------------------
-// Extend Montgomery reduce in 8-digit blocks, results in input-output buffer
+// Extended Montgomery reduce in 8-digit blocks, results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
 //    extern uint64_t bignum_emontredc_8n_neon

--- a/arm/generic/bignum_copy_row_from_table_16_neon.S
+++ b/arm/generic/bignum_copy_row_from_table_16_neon.S
@@ -12,7 +12,7 @@
 //     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t idx);
 //
 // Initial version written by Hanno Becker
-// Standard ARM ABI: X0 = z, X1 = table, X2 = height, X4 = idx
+// Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = idx
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 

--- a/arm/generic/bignum_copy_row_from_table_32_neon.S
+++ b/arm/generic/bignum_copy_row_from_table_32_neon.S
@@ -12,7 +12,7 @@
 //     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t idx);
 //
 // Initial version written by Hanno Becker
-// Standard ARM ABI: X0 = z, X1 = table, X2 = height, X4 = idx
+// Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = idx
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 

--- a/arm/p256/bignum_montmul_p256_alt.S
+++ b/arm/p256/bignum_montmul_p256_alt.S
@@ -30,7 +30,7 @@
 // It is fine for d4 to be the same register as d0, and it often is.
 // ---------------------------------------------------------------------------
 
-#define montreds(d4,d3,d2,d1,d0, tmp)                               \
+#define montreds(d4,d3,d2,d1,d0, tmp,mc)                            \
         adds    d1, d1, d0, lsl #32;                                \
         lsr     tmp, d0, #32;                                       \
         adcs    d2, d2, tmp;                                        \
@@ -151,7 +151,7 @@ S2N_BN_SYMBOL(bignum_montmul_p256_alt):
         adc     u7, u7, xzr
 
         mov mc, 0xFFFFFFFF00000001
-        montreds(u0,u3,u2,u1,u0, l)
+        montreds(u0,u3,u2,u1,u0, l,mc)
 
         umulh   l, a3, b0
         adds    u4, u4, l
@@ -163,9 +163,9 @@ S2N_BN_SYMBOL(bignum_montmul_p256_alt):
 
 // Perform 3 further Montgomery steps to rotate the lower half
 
-        montreds(u1,u0,u3,u2,u1, l)
-        montreds(u2,u1,u0,u3,u2, l)
-        montreds(u3,u2,u1,u0,u3, l)
+        montreds(u1,u0,u3,u2,u1, l,mc)
+        montreds(u2,u1,u0,u3,u2, l,mc)
+        montreds(u3,u2,u1,u0,u3, l,mc)
 
 // Add high and low parts, catching carry in b1
 

--- a/arm/p256/bignum_montsqr_p256_alt.S
+++ b/arm/p256/bignum_montsqr_p256_alt.S
@@ -29,7 +29,7 @@
 // It is fine for d4 to be the same register as d0, and it often is.
 // ---------------------------------------------------------------------------
 
-#define montreds(d4,d3,d2,d1,d0, tmp)                               \
+#define montreds(d4,d3,d2,d1,d0, tmp,mc)                            \
         adds    d1, d1, d0, lsl #32;                                \
         lsr     tmp, d0, #32;                                       \
         adcs    d2, d2, tmp;                                        \
@@ -139,10 +139,10 @@ S2N_BN_SYMBOL(bignum_montsqr_p256_alt):
 // Squaring complete. Perform 4 Montgomery steps to rotate the lower half
 
         mov     mc, #0xFFFFFFFF00000001
-        montreds(u0,u3,u2,u1,u0, a0)
-        montreds(u1,u0,u3,u2,u1, a0)
-        montreds(u2,u1,u0,u3,u2, a0)
-        montreds(u3,u2,u1,u0,u3, a0)
+        montreds(u0,u3,u2,u1,u0, a0,mc)
+        montreds(u1,u0,u3,u2,u1, a0,mc)
+        montreds(u2,u1,u0,u3,u2, a0,mc)
+        montreds(u3,u2,u1,u0,u3, a0,mc)
 
 // Add high and low parts, catching carry in a0
 


### PR DESCRIPTION
*Description of changes:*

A few nits I came across:

- Some comment typos in `bignum_copy_row_from_table` neon specialisations, from when they lost their explicit width parameter.
- Typo in `bignum_emontredc_8n_neon`, to match the "parent" `bignum_emontredc_8n`
- `bignum_mont{mul,sqr}_p256_alt`, a macro parameter mentioned in a comment which didn't exist; this code worked instead via global macro expansion.

None of these should have any effect on the generated code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
