### PR TITLE
Tactic optimization: hoist term/type parsings, remove unnecessary term_matchs, etc

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -372,12 +372,11 @@ let ARM_THM =
     REPEAT STRIP_TAC THEN REWRITE_TAC [arm] THEN
     ASM_REWRITE_TAC[GSYM WORD_ADD; arm_execute] THEN
     ASM_MESON_TAC[arm_decode_unique]) in
+  (* pc_th: `|- ... = word <pc_expr>` *)
   fun (execth2:thm option array) loaded_mc_th pc_th ->
     let th = MATCH_MP pth pc_th in
     let pc_ofs:int =
-      let _,inst,_ = term_match [] `word pc:int64` (snd (dest_eq (concl pc_th))) in
-      if inst = [] then 0 else
-      let pc_expr = fst (List.hd inst) in
+      let pc_expr = snd (dest_comb (snd (dest_eq (concl pc_th)))) in
       if is_var pc_expr then 0
       else try
         let pc_base,ofs = dest_binary "+" pc_expr in

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -2345,9 +2345,7 @@ let X86_THM =
   fun (execth2:thm option array) loaded_mc_th pc_th ->
     let th = MATCH_MP pth pc_th in
     let pc_ofs:int =
-      let _,inst,_ = term_match [] `word pc:int64` (snd (dest_eq (concl pc_th))) in
-      if inst = [] then 0 else
-      let pc_expr = fst (List.hd inst) in
+      let pc_expr = snd (dest_comb (snd (dest_eq (concl pc_th)))) in
       if is_var pc_expr then 0
       else try
         let pc_base,ofs = dest_binary "+" pc_expr in


### PR DESCRIPTION
*Description of changes:*

This patch hoists term/type parsings and remove unnecessary term_matchs and unused definitions.
Also, this makes equivalence checker print infos only when `arm_print_log` is set.
With these simple updates combined, some proofs have slightly less than a 10% speedup.

[speedup.xlsx](https://github.com/user-attachments/files/17272280/speedup.xlsx)

By submitting 
this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
