### PR TITLE
Check usage of the x18 register in Arm

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -50,14 +50,18 @@ SPLIT=tr ';' '\n'
 
 ifeq ($(ARCHTYPE_RESULT),aarch64)
 ASSEMBLE=as
+OBJDUMP=objdump -d
 else
 ifeq ($(ARCHTYPE_RESULT),arm64)
 ASSEMBLE=as
+OBJDUMP=objdump -d
 else
 ifeq ($(OSTYPE_RESULT),Darwin)
 ASSEMBLE=as -arch arm64
+OBJDUMP=otool -tvV
 else
 ASSEMBLE=aarch64-linux-gnu-as
+OBJDUMP=aarch64-linux-gnu-objdump -d
 endif
 endif
 endif
@@ -385,7 +389,14 @@ UNOPT_OBJ = p256/unopt/p256_montjadd.o \
 
 OBJ = $(POINT_OBJ) $(BIGNUM_OBJ)
 
-%.o : %.S ; cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
+# According to
+# https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms,
+# x18 should not be used for Apple platforms. Check this using grep.
+
+%.o : %.S
+	cat $< | $(PREPROCESS) | $(SPLIT) | grep -v -E '^\s+.quad\s+0x[0-9a-f]+$$' | $(ASSEMBLE) -o $@
+	$(OBJDUMP) $@ | ( ! grep --ignore-case -E 'w18|[^0]x18' )
+	cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
 
 libs2nbignum.a: $(OBJ) ; ar -rc libs2nbignum.a $(OBJ)
 
@@ -398,15 +409,6 @@ clean:; rm -f libs2nbignum.a */*.o */*/*.o */*.correct
 # run the proofs in parallel for more speed, e.g.
 #
 #    nohup make -j 16 proofs &
-#
-# On debian, the underlying prover HOL Light can be installed as a package
-# by something like
-#
-#    sudo apt-get install hol-light
-#
-# for which you would set this below:
-#
-#    HOLDIR=/usr/share/hol-light
 #
 # If you build hol-light yourself (see https://github.com/jrh13/hol-light)
 # in your home directory, and do "make" inside the subdirectory hol-light,

--- a/arm/Makefile
+++ b/arm/Makefile
@@ -394,8 +394,8 @@ OBJ = $(POINT_OBJ) $(BIGNUM_OBJ)
 # x18 should not be used for Apple platforms. Check this using grep.
 
 %.o : %.S
-	cat $< | $(PREPROCESS) | $(SPLIT) | grep -v -E '^\s+.quad\s+0x[0-9a-f]+$$' | $(ASSEMBLE) -o $@
-	$(OBJDUMP) $@ | ( ! grep --ignore-case -E 'w18|[^0]x18' )
+	cat $< | $(PREPROCESS) | $(SPLIT) | grep -v -E '^\s+.quad\s+0x[0-9a-f]+$$' | $(ASSEMBLE) -o $@ -
+	$(OBJDUMP) $@ | ( ( ! grep --ignore-case -E 'w18|[^0]x18' ) || ( rm $@ ; exit 1 ) )
 	cat $< | $(PREPROCESS) | $(SPLIT) | $(ASSEMBLE) -o $@ -
 
 libs2nbignum.a: $(OBJ) ; ar -rc libs2nbignum.a $(OBJ)

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -428,15 +428,6 @@ clobber: clean ; rm -f yesbmi_functions nonbmi_functions
 #
 #    nohup make -j 16 proofs &
 #
-# On debian, the underlying prover HOL Light can be installed as a package
-# by something like
-#
-#    sudo apt-get install hol-light
-#
-# for which you would set this below:
-#
-#    HOLDIR=/usr/share/hol-light
-#
 # If you build hol-light yourself (see https://github.com/jrh13/hol-light)
 # in your home directory, and do "make" inside the subdirectory hol-light,
 # then the following HOLDIR setting should be right:


### PR DESCRIPTION
This patch adds checking the usage of x18 register in Arm. According to
https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms , x18 should not be used for Apple platforms.
Resolves: https://github.com/awslabs/s2n-bignum/issues/143

This also removes old comments about installing hol-light using apt.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
