### PR TITLE
Fix HOL Light commit hash to explicitly state which version was used

### DIFF
--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -13,6 +13,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
+      - git checkout 9eccc5e457c56b94a3223821e98f5ec559023c67
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)
@@ -20,7 +21,7 @@ phases:
       - make
   build:
     commands:
-      - CORE_COUNT=50
+      - CORE_COUNT=45
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
       - make -j ${CORE_COUNT} proofs

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -14,6 +14,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
+      - git checkout 9eccc5e457c56b94a3223821e98f5ec559023c67
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)


### PR DESCRIPTION
This patch updates the CI script to explicitly check out a specified HOL Light version.
This helps users understand which version of HOL Light is being used for CI. Previously it was simply picking the latest version of HOL Light at the CI running time.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
