### PR TITLE
Use native OCaml compiler to build & run proofs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.correct
+*.native
 *.o
 *.obj
 .vscode

--- a/arm/Makefile
+++ b/arm/Makefile
@@ -389,7 +389,7 @@ OBJ = $(POINT_OBJ) $(BIGNUM_OBJ)
 
 libs2nbignum.a: $(OBJ) ; ar -rc libs2nbignum.a $(OBJ)
 
-clean:; rm -f libs2nbignum.a */*.o */*/*.o */*.correct
+clean:; rm -f libs2nbignum.a */*.o */*/*.o */*.correct */*.native
 
 # Proof-related parts
 #
@@ -415,103 +415,69 @@ clean:; rm -f libs2nbignum.a */*.o */*/*.o */*.correct
 HOLDIR?=$(HOME)/hol-light
 HOLLIGHT:=$(HOLDIR)/hol.sh
 
-PROOFS = $(OBJ:.o=.correct)
+PROOF_BINS = $(OBJ:.o=.native)
+PROOF_LOGS = $(OBJ:.o=.correct)
+
+# Build precompiled native binaries of HOL Light proofs
+
+.SECONDEXPANSION:
+%.native: proofs/$$(*F).ml %.o ; ../tools/build-proof.sh "$<" "$(HOLLIGHT)" "$@"
+
+# Run them and print the standard output+error at *.correct
+
+%.correct: %.native ; ../tools/run-proof.sh "$<" "$@"
 
 # Cases where a proof uses other proofs for lemmas and/or subroutines
 
-p256/bignum_montmul_p256_neon.correct: proofs/bignum_montmul_p256_neon.ml p256/bignum_montmul_p256_neon.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o ; ../tools/run-proof.sh arm bignum_montmul_p256_neon "$(HOLLIGHT)" $@
-p384/bignum_montmul_p384_neon.correct: proofs/bignum_montmul_p384_neon.ml p384/bignum_montmul_p384_neon.o proofs/bignum_montmul_p384.ml p384/bignum_montmul_p384.o ; ../tools/run-proof.sh arm bignum_montmul_p384_neon "$(HOLLIGHT)" $@
-p521/bignum_montmul_p521_neon.correct: proofs/bignum_montmul_p521_neon.ml p521/bignum_montmul_p521_neon.o proofs/bignum_montmul_p521.ml p521/bignum_montmul_p521.o ; ../tools/run-proof.sh arm bignum_montmul_p521_neon "$(HOLLIGHT)" $@
-p256/bignum_montsqr_p256_neon.correct: proofs/bignum_montsqr_p256_neon.ml p256/bignum_montsqr_p256_neon.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o ; ../tools/run-proof.sh arm bignum_montsqr_p256_neon "$(HOLLIGHT)" $@
-p384/bignum_montsqr_p384_neon.correct: proofs/bignum_montsqr_p384_neon.ml p384/bignum_montsqr_p384_neon.o proofs/bignum_montsqr_p384.ml p384/bignum_montsqr_p384.o ; ../tools/run-proof.sh arm bignum_montsqr_p384_neon "$(HOLLIGHT)" $@
-p521/bignum_montsqr_p521_neon.correct: proofs/bignum_montsqr_p521_neon.ml p521/bignum_montsqr_p521_neon.o proofs/bignum_montsqr_p521.ml p521/bignum_montsqr_p521.o ; ../tools/run-proof.sh arm bignum_montsqr_p521_neon "$(HOLLIGHT)" $@
-fastmul/bignum_mul_8_16_neon.correct: proofs/bignum_mul_8_16_neon.ml fastmul/bignum_mul_8_16_neon.o proofs/bignum_mul_8_16.ml fastmul/bignum_mul_8_16.o ; ../tools/run-proof.sh arm bignum_mul_8_16_neon "$(HOLLIGHT)" $@
-p521/bignum_mul_p521_neon.correct: proofs/bignum_mul_p521_neon.ml p521/bignum_mul_p521_neon.o proofs/bignum_mul_p521.ml p521/bignum_mul_p521.o ; ../tools/run-proof.sh arm bignum_mul_p521_neon "$(HOLLIGHT)" $@
-fastmul/bignum_sqr_8_16_neon.correct: proofs/bignum_sqr_8_16_neon.ml fastmul/bignum_sqr_8_16_neon.o proofs/bignum_sqr_8_16.ml fastmul/bignum_sqr_8_16.o ; ../tools/run-proof.sh arm bignum_sqr_8_16_neon "$(HOLLIGHT)" $@
-p521/bignum_sqr_p521_neon.correct: proofs/bignum_sqr_p521_neon.ml p521/bignum_sqr_p521_neon.o proofs/bignum_sqr_p521.ml p521/bignum_sqr_p521.o ; ../tools/run-proof.sh arm bignum_sqr_p521_neon "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519.ml curve25519/curve25519_x25519.o ; ../tools/run-proof.sh arm curve25519_x25519 "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_alt.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519_alt.ml curve25519/curve25519_x25519_alt.o ; ../tools/run-proof.sh arm curve25519_x25519_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_byte.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519_byte.ml curve25519/curve25519_x25519_byte.o ; ../tools/run-proof.sh arm curve25519_x25519_byte "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_byte_alt.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519_byte_alt.ml curve25519/curve25519_x25519_byte_alt.o ; ../tools/run-proof.sh arm curve25519_x25519_byte_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519base.ml curve25519/curve25519_x25519base.o ; ../tools/run-proof.sh arm curve25519_x25519base "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_alt.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519base_alt.ml curve25519/curve25519_x25519base_alt.o ; ../tools/run-proof.sh arm curve25519_x25519base_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_byte.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519base_byte.ml curve25519/curve25519_x25519base_byte.o ; ../tools/run-proof.sh arm curve25519_x25519base_byte "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_byte_alt.correct: curve25519/bignum_inv_p25519.o proofs/curve25519_x25519base_byte_alt.ml curve25519/curve25519_x25519base_byte_alt.o ; ../tools/run-proof.sh arm curve25519_x25519base_byte_alt "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmulbase.correct: curve25519/bignum_inv_p25519.o proofs/edwards25519_scalarmulbase.ml curve25519/edwards25519_scalarmulbase.o ; ../tools/run-proof.sh arm edwards25519_scalarmulbase "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmulbase_alt.correct: curve25519/bignum_inv_p25519.o proofs/edwards25519_scalarmulbase_alt.ml curve25519/edwards25519_scalarmulbase_alt.o ; ../tools/run-proof.sh arm edwards25519_scalarmulbase_alt "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmuldouble.correct: curve25519/bignum_inv_p25519.o proofs/edwards25519_scalarmuldouble.ml curve25519/edwards25519_scalarmuldouble.o ; ../tools/run-proof.sh arm edwards25519_scalarmuldouble "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmuldouble_alt.correct: curve25519/bignum_inv_p25519.o proofs/edwards25519_scalarmuldouble_alt.ml curve25519/edwards25519_scalarmuldouble_alt.o ; ../tools/run-proof.sh arm edwards25519_scalarmuldouble_alt "$(HOLLIGHT)" $@
-generic/bignum_modexp.correct: generic/bignum_amontifier.correct generic/bignum_amontmul.correct generic/bignum_demont.correct generic/bignum_mux.correct proofs/bignum_modexp.ml generic/bignum_modexp.o ; ../tools/run-proof.sh arm bignum_modexp "$(HOLLIGHT)" $@
-p256/p256_montjadd.correct: proofs/p256_montjadd.ml p256/p256_montjadd.o p256/unopt/p256_montjadd.o proofs/bignum_montsqr_p256_neon.ml p256/bignum_montsqr_p256_neon.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/bignum_montmul_p256_neon.ml p256/bignum_montmul_p256_neon.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_sub_p256.ml p256/bignum_sub_p256.o ; ../tools/run-proof.sh arm p256_montjadd "$(HOLLIGHT)" $@
-p256/p256_montjdouble.correct: proofs/p256_montjdouble.ml p256/p256_montjdouble.o p256/unopt/p256_montjdouble.o proofs/bignum_montsqr_p256_neon.ml p256/bignum_montsqr_p256_neon.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/bignum_montmul_p256_neon.ml p256/bignum_montmul_p256_neon.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_sub_p256.ml p256/bignum_sub_p256.o proofs/bignum_add_p256.ml p256/bignum_add_p256.o ; ../tools/run-proof.sh arm p256_montjdouble "$(HOLLIGHT)" $@
-p256/p256_montjscalarmul.correct: proofs/p256_montjadd.ml p256/p256_montjadd.o p256/unopt/p256_montjadd.o proofs/p256_montjdouble.ml p256/p256_montjdouble.o p256/unopt/p256_montjdouble.o proofs/bignum_montsqr_p256_neon.ml p256/bignum_montsqr_p256_neon.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/bignum_montmul_p256_neon.ml p256/bignum_montmul_p256_neon.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_sub_p256.ml p256/bignum_sub_p256.o proofs/bignum_add_p256.ml p256/bignum_add_p256.o proofs/p256_montjscalarmul.ml p256/p256_montjscalarmul.o ; ../tools/run-proof.sh arm p256_montjscalarmul "$(HOLLIGHT)" $@
-p256/p256_montjscalarmul_alt.correct: proofs/p256_montjadd_alt.ml p256/p256_montjadd_alt.o proofs/p256_montjdouble_alt.ml p256/p256_montjdouble_alt.o proofs/p256_montjscalarmul_alt.ml p256/p256_montjscalarmul_alt.o ; ../tools/run-proof.sh arm p256_montjscalarmul_alt "$(HOLLIGHT)" $@
-p256/p256_scalarmul.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/bignum_tomont_p256.ml p256/bignum_tomont_p256.o proofs/p256_montjadd.ml p256/p256_montjadd.o p256/unopt/p256_montjadd.o proofs/p256_montjdouble.ml p256/p256_montjdouble.o p256/unopt/p256_montjdouble.o proofs/bignum_montsqr_p256_neon.ml p256/bignum_montsqr_p256_neon.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/bignum_montmul_p256_neon.ml p256/bignum_montmul_p256_neon.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_sub_p256.ml p256/bignum_sub_p256.o proofs/bignum_add_p256.ml p256/bignum_add_p256.o proofs/p256_montjmixadd.ml p256/p256_montjmixadd.o proofs/p256_scalarmul.ml p256/p256_scalarmul.o ; ../tools/run-proof.sh arm p256_scalarmul "$(HOLLIGHT)" $@
-p256/p256_scalarmul_alt.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o proofs/bignum_montmul_p256_alt.ml p256/bignum_montmul_p256_alt.o proofs/bignum_montsqr_p256_alt.ml p256/bignum_montsqr_p256_alt.o proofs/bignum_tomont_p256.ml p256/bignum_tomont_p256.o proofs/p256_montjadd_alt.ml p256/p256_montjadd_alt.o proofs/p256_montjdouble_alt.ml p256/p256_montjdouble_alt.o proofs/p256_montjmixadd_alt.ml p256/p256_montjmixadd_alt.o proofs/p256_scalarmul_alt.ml p256/p256_scalarmul_alt.o ; ../tools/run-proof.sh arm p256_scalarmul_alt "$(HOLLIGHT)" $@
-p256/p256_scalarmulbase.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o proofs/p256_montjmixadd.ml p256/p256_montjmixadd.o proofs/p256_scalarmulbase.ml p256/p256_scalarmulbase.o ; ../tools/run-proof.sh arm p256_scalarmulbase "$(HOLLIGHT)" $@
-p256/p256_scalarmulbase_alt.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o proofs/bignum_montmul_p256_alt.ml p256/bignum_montmul_p256_alt.o proofs/bignum_montsqr_p256_alt.ml p256/bignum_montsqr_p256_alt.o proofs/p256_montjmixadd_alt.ml p256/p256_montjmixadd_alt.o proofs/p256_scalarmulbase_alt.ml p256/p256_scalarmulbase_alt.o ; ../tools/run-proof.sh arm p256_scalarmulbase_alt "$(HOLLIGHT)" $@
-p384/p384_montjadd.correct: proofs/p384_montjadd.ml p384/p384_montjadd.o p384/unopt/p384_montjadd.o proofs/bignum_montsqr_p384_neon.ml p384/bignum_montsqr_p384_neon.o proofs/bignum_montsqr_p384.ml p384/bignum_montsqr_p384.o proofs/bignum_montmul_p384_neon.ml p384/bignum_montmul_p384_neon.o proofs/bignum_montmul_p384.ml p384/bignum_montmul_p384.o proofs/bignum_sub_p384.ml p384/bignum_sub_p384.o ; ../tools/run-proof.sh arm p384_montjadd "$(HOLLIGHT)" $@
-p384/p384_montjdouble.correct: proofs/p384_montjdouble.ml p384/p384_montjdouble.o p384/unopt/p384_montjdouble.o proofs/bignum_montsqr_p384_neon.ml p384/bignum_montsqr_p384_neon.o proofs/bignum_montsqr_p384.ml p384/bignum_montsqr_p384.o proofs/bignum_montmul_p384_neon.ml p384/bignum_montmul_p384_neon.o proofs/bignum_montmul_p384.ml p384/bignum_montmul_p384.o proofs/bignum_sub_p384.ml p384/bignum_sub_p384.o proofs/bignum_add_p384.ml p384/bignum_add_p384.o ; ../tools/run-proof.sh arm p384_montjdouble "$(HOLLIGHT)" $@
-p384/p384_montjscalarmul.correct: \
-    proofs/p384_montjadd.ml p384/p384_montjadd.o p384/unopt/p384_montjadd.o \
-    proofs/p384_montjdouble.ml p384/p384_montjdouble.o p384/unopt/p384_montjdouble.o \
-    proofs/bignum_montsqr_p384_neon.ml p384/bignum_montsqr_p384_neon.o \
-    proofs/bignum_montsqr_p384.ml p384/bignum_montsqr_p384.o \
-    proofs/bignum_montmul_p384_neon.ml p384/bignum_montmul_p384_neon.o \
-    proofs/bignum_montmul_p384.ml p384/bignum_montmul_p384.o \
-    proofs/bignum_sub_p384.ml p384/bignum_sub_p384.o \
-    proofs/bignum_add_p384.ml p384/bignum_add_p384.o \
-    proofs/p384_montjscalarmul.ml p384/p384_montjscalarmul.o ; \
-    ../tools/run-proof.sh arm p384_montjscalarmul "$(HOLLIGHT)" $@
-p384/p384_montjscalarmul_alt.correct: \
-    proofs/p384_montjadd_alt.ml p384/p384_montjadd_alt.o \
-    proofs/p384_montjdouble_alt.ml p384/p384_montjdouble_alt.o \
-    proofs/p384_montjscalarmul_alt.ml p384/p384_montjscalarmul_alt.o ; \
-    ../tools/run-proof.sh arm p384_montjscalarmul_alt "$(HOLLIGHT)" $@
-p521/p521_jadd.correct: \
-    proofs/p521_jadd.ml p521/p521_jadd.o \
-    proofs/bignum_mul_p521_neon.ml p521/bignum_mul_p521_neon.o \
-    proofs/bignum_mul_p521.ml p521/bignum_mul_p521.o \
-    proofs/bignum_sqr_p521_neon.ml p521/bignum_sqr_p521_neon.o \
-    proofs/bignum_sqr_p521.ml p521/bignum_sqr_p521.o ; \
-    ../tools/run-proof.sh arm p521_jadd "$(HOLLIGHT)" $@
-p521/p521_jdouble.correct: \
-    proofs/p521_jdouble.ml p521/p521_jdouble.o \
-    proofs/bignum_mul_p521_neon.ml p521/bignum_mul_p521_neon.o \
-    proofs/bignum_mul_p521.ml p521/bignum_mul_p521.o \
-    proofs/bignum_sqr_p521_neon.ml p521/bignum_sqr_p521_neon.o \
-    proofs/bignum_sqr_p521.ml p521/bignum_sqr_p521.o ; \
-    ../tools/run-proof.sh arm p521_jdouble "$(HOLLIGHT)" $@
-p521/p521_jscalarmul.correct: \
-    proofs/bignum_mod_n521_9.ml p521/bignum_mod_n521_9.o \
-    proofs/p521_jscalarmul.ml p521/p521_jscalarmul.o \
-    proofs/p521_jadd.ml p521/p521_jadd.o \
-    proofs/p521_jdouble.ml p521/p521_jdouble.o \
-    proofs/bignum_mul_p521_neon.ml p521/bignum_mul_p521_neon.o \
-    proofs/bignum_mul_p521.ml p521/bignum_mul_p521.o \
-    proofs/bignum_sqr_p521_neon.ml p521/bignum_sqr_p521_neon.o \
-    proofs/bignum_sqr_p521.ml p521/bignum_sqr_p521.o ; \
-    ../tools/run-proof.sh arm p521_jscalarmul "$(HOLLIGHT)" $@
-p521/p521_jscalarmul_alt.correct: \
-    proofs/bignum_mod_n521_9.ml p521/bignum_mod_n521_9.o \
-    proofs/p521_jscalarmul_alt.ml p521/p521_jscalarmul_alt.o ; \
-    ../tools/run-proof.sh arm p521_jscalarmul_alt "$(HOLLIGHT)" $@
-sm2/sm2_montjscalarmul.correct: proofs/sm2_montjadd.ml sm2/sm2_montjadd.o proofs/sm2_montjdouble.ml sm2/sm2_montjdouble.o proofs/sm2_montjscalarmul.ml sm2/sm2_montjscalarmul.o ; ../tools/run-proof.sh arm sm2_montjscalarmul "$(HOLLIGHT)" $@
-sm2/sm2_montjscalarmul_alt.correct: proofs/sm2_montjadd_alt.ml sm2/sm2_montjadd_alt.o proofs/sm2_montjdouble_alt.ml sm2/sm2_montjdouble_alt.o proofs/sm2_montjscalarmul_alt.ml sm2/sm2_montjscalarmul_alt.o ; ../tools/run-proof.sh arm sm2_montjscalarmul_alt "$(HOLLIGHT)" $@
+p256/bignum_montmul_p256_neon.native: p256/bignum_montmul_p256.native
+p384/bignum_montmul_p384_neon.native: p384/bignum_montmul_p384.native
+p521/bignum_montmul_p521_neon.native: p521/bignum_montmul_p521.native
+p256/bignum_montsqr_p256_neon.native: p256/bignum_montsqr_p256.native
+p384/bignum_montsqr_p384_neon.native: p384/bignum_montsqr_p384.native
+p521/bignum_montsqr_p521_neon.native: p521/bignum_montsqr_p521.native
+p521/bignum_mul_p521_neon.native: p521/bignum_mul_p521.native
+p521/bignum_sqr_p521_neon.native: p521/bignum_sqr_p521.native
+fastmul/bignum_mul_8_16_neon.native: fastmul/bignum_mul_8_16.native
+fastmul/bignum_sqr_8_16_neon.native: fastmul/bignum_sqr_8_16.native
+curve25519/curve25519_x25519.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_byte.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_byte_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_byte.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_byte_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmulbase.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmulbase_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmuldouble.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmuldouble_alt.native: curve25519/bignum_inv_p25519.native
+generic/bignum_modexp.native: generic/bignum_amontifier.native generic/bignum_amontmul.native generic/bignum_demont.native generic/bignum_mux.native
+p256/p256_montjadd.native: p256/unopt/p256_montjadd.o p256/bignum_montsqr_p256_neon.native p256/bignum_montmul_p256_neon.native p256/bignum_sub_p256.native
+p256/p256_montjdouble.native: p256/unopt/p256_montjdouble.o p256/bignum_montsqr_p256_neon.native p256/bignum_montmul_p256_neon.native p256/bignum_sub_p256.native p256/bignum_add_p256.native
+p256/p256_montjscalarmul.native: p256/p256_montjadd.native p256/p256_montjdouble.native
+p256/p256_montjscalarmul_alt.native: p256/p256_montjadd_alt.native p256/p256_montjdouble_alt.native
+p256/p256_scalarmul.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/bignum_tomont_p256.native p256/p256_montjadd.native p256/p256_montjdouble.native p256/p256_montjmixadd.native
+p256/p256_scalarmul_alt.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjadd_alt.native p256/p256_montjdouble_alt.native p256/p256_montjmixadd_alt.native
+p256/p256_scalarmulbase.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjmixadd.native
+p256/p256_scalarmulbase_alt.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjmixadd_alt.native
+p384/p384_montjadd.native: p384/unopt/p384_montjadd.o p384/bignum_montsqr_p384_neon.native p384/bignum_montmul_p384_neon.native p384/bignum_sub_p384.native
+p384/p384_montjdouble.native: p384/unopt/p384_montjdouble.o p384/bignum_montsqr_p384_neon.native p384/bignum_montmul_p384_neon.native p384/bignum_sub_p384.native p384/bignum_add_p384.native
+p384/p384_montjscalarmul.native: \
+    p384/p384_montjadd.native p384/p384_montjdouble.native \
+    p384/bignum_sub_p384.native p384/bignum_add_p384.native
+p384/p384_montjscalarmul_alt.native: p384/p384_montjadd_alt.native p384/p384_montjdouble_alt.native
+p521/p521_jadd.native: p521/bignum_mul_p521_neon.native p521/bignum_sqr_p521_neon.native
+p521/p521_jdouble.native: p521/bignum_mul_p521_neon.native p521/bignum_sqr_p521_neon.native
+p521/p521_jscalarmul.native: p521/bignum_mod_n521_9.native p521/p521_jadd.native p521/p521_jdouble.native
+p521/p521_jscalarmul_alt.native: p521/bignum_mod_n521_9.native
+sm2/sm2_montjscalarmul.native: sm2/sm2_montjadd.native sm2/sm2_montjdouble.native
+sm2/sm2_montjscalarmul_alt.native: sm2/sm2_montjadd_alt.native sm2/sm2_montjdouble_alt.native
 
-# All other other instances are standalone
-
-curve25519/%.correct: proofs/%.ml curve25519/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-fastmul/%.correct: proofs/%.ml fastmul/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-generic/%.correct: proofs/%.ml generic/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-p256/%.correct: proofs/%.ml p256/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-p384/%.correct: proofs/%.ml p384/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-p521/%.correct: proofs/%.ml p521/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-secp256k1/%.correct: proofs/%.ml secp256k1/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
-sm2/%.correct: proofs/%.ml sm2/%.o ; ../tools/run-proof.sh arm "$*" "$(HOLLIGHT)" $@
 
 unopt: $(UNOPT_OBJ)
-run_proofs: $(UNOPT_OBJ) $(PROOFS);
+
+build_proofs: $(UNOPT_OBJ) $(PROOF_BINS);
+run_proofs: build_proofs $(PROOF_LOGS);
 
 proofs: run_proofs ; ../tools/count-proofs.sh .
 

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -18,11 +18,13 @@ phases:
       - eval $(opam env)
       - echo $(ocamlc -version)
       - echo $(camlp5 -v)
-      - make
+      - HOLLIGHT_USE_MODULE=1 make
   build:
     commands:
-      - CORE_COUNT=45
+      - BUILD_CORE_COUNT=15
+      - CORE_COUNT=64
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}
       - export HOLDIR=${CODEBUILD_SRC_DIR_hol_light}
+      - make -j ${BUILD_CORE_COUNT} build_proofs
       - make -j ${CORE_COUNT} proofs
       - ../tools/collect-times.sh ${S2N_BIGNUM_ARCH}

--- a/tools/build-proof.sh
+++ b/tools/build-proof.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+if [ "$#" -ne 3 ]; then
+  echo "../tools/build-proof.sh <.ml file path> <hol.sh> <output .native path>"
+  echo "This script builds HOL Light proof using OCaml native compiler and puts the "
+  echo "output binary at <output .native path>."
+  exit 1
+fi
+
+# Return the exit code if any statement fails
+set -e
+
+s2n_bignum_arch=$(basename "$(pwd)")
+
+cd ..
+
+ml_path_noarch=$1
+ml_path=${s2n_bignum_arch}/${ml_path_noarch}
+hol_sh_cmd=$2
+output_path=${s2n_bignum_arch}/$3
+
+export HOLLIGHT_DIR="$(dirname ${hol_sh_cmd})"
+if [ ! -f "${HOLLIGHT_DIR}/hol_lib.cmxa" ]; then
+  echo "hol_lib.cmxa does not exist in HOLLIGHT_DIR('${HOLLIGHT_DIR}')."
+  echo "Did you compile HOL Light with HOLLIGHT_USE_MODULE set to 1?"
+  exit 1
+fi
+
+
+template_ml="$(mktemp).ml"
+echo "Generating a template .ml that loads the file...: ${template_ml}"
+
+(echo 'let s2n_bignum_build_proof_start_time = Unix.time();;'; \
+ echo "loadt \"${ml_path}\";;"; \
+ echo "check_axioms ();;") >> ${template_ml}
+
+spec_found=0
+for spec in $(./tools/collect-specs.sh ${s2n_bignum_arch} $(basename ${ml_path})) ; do
+  echo "Printf.printf \"val ${spec} : thm = %s\n\" (string_of_thm ${spec});;"
+  spec_found=1
+done >> ${template_ml}
+
+if [ $spec_found -eq 0 ]; then
+  echo "Could not find any specification from ${ml_path}."
+  exit 1
+fi
+
+(echo 'let s2n_bignum_build_proof_end_time = Unix.time();;'; \
+ echo 'Printf.printf "Running time: %f sec, Start unixtime: %f, End unixtime: %f\n" (s2n_bignum_build_proof_end_time -. s2n_bignum_build_proof_start_time) s2n_bignum_build_proof_start_time s2n_bignum_build_proof_end_time;;') >> ${template_ml}
+
+
+if [ -d "${HOLLIGHT_DIR}/_opam" ]; then
+  # To use inline_load.ml ... If OCaml version is too old, otherwise, a few String functions fail.
+  eval $(opam env --switch "${HOLLIGHT_DIR}/" --set-switch)
+fi
+
+inlined_prefix="$(mktemp)"
+inlined_ml="${inlined_prefix}.ml"
+inlined_cmx="${inlined_prefix}.cmx"
+ocaml ${HOLLIGHT_DIR}/inline_load.ml ${template_ml} ${inlined_ml}
+
+# Give a large stack size.
+OCAMLRUNPARAM=l=2000000000 \
+ocamlopt.byte -pp "$(${hol_sh_cmd} -pp)" -I "${HOLLIGHT_DIR}" -I +unix -c \
+    hol_lib.cmxa ${inlined_ml} -o ${inlined_cmx} -w -a
+ocamlfind ocamlopt -package zarith,unix -linkpkg hol_lib.cmxa \
+    -I "${HOLLIGHT_DIR}" ${inlined_cmx} \
+    -o "${output_path}"
+
+# Remove the intermediate files to save disk space
+rm ${inlined_cmx} ${template_ml} ${inlined_ml}

--- a/tools/collect-specs.sh
+++ b/tools/collect-specs.sh
@@ -12,7 +12,7 @@ if [ "$#" -eq 2 ]; then
 else
   filepat="*.ml"
 fi
-cd $s2n_bignum_arch
+cd $s2n_bignum_arch > /dev/null
 
 # An env. var for sorting
 export LC_ALL=C

--- a/tools/collect-specs.sh
+++ b/tools/collect-specs.sh
@@ -1,14 +1,19 @@
 #!/bin/bash
-if [ "$#" -ne 1 ]; then
-  echo "collect-specs.sh <dir (e.g., arm)>"
+if [ "$#" -ne 1 ] && [ "$#" -ne 2 ]; then
+  echo "collect-specs.sh <dir (e.g., arm)> <.ml file (optional)>"
   echo "This script collects the names of HOL Light theorems that are"
   echo "specifications of correctness of assembly functions."
   exit 1
 fi
 
 s2n_bignum_arch=$1
+if [ "$#" -eq 2 ]; then
+  filepat="$2"
+else
+  filepat="*.ml"
+fi
 cd $s2n_bignum_arch
 
 # An env. var for sorting
 export LC_ALL=C
-grep 'let [A-Z_0-9]*_SUBROUTINE_CORRECT' proofs/*.ml | cut -f2 -d' ' | sort
+grep 'let [A-Z_0-9]*_SUBROUTINE_CORRECT' proofs/${filepat} | cut -f2 -d' ' | sort

--- a/tools/collect-times.sh
+++ b/tools/collect-times.sh
@@ -7,7 +7,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 s2n_bignum_arch=$1
-cd $s2n_bignum_arch
+cd $s2n_bignum_arch > /dev/null
 
 num_correct_files=`find . -name "*.correct" | wc -l`
 if [ $num_correct_files -eq 0 ]; then

--- a/tools/count-proofs.sh
+++ b/tools/count-proofs.sh
@@ -5,7 +5,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 s2n_bignum_arch=$1
-cd $s2n_bignum_arch
+cd $s2n_bignum_arch > /dev/null
 
 num_correct_files=`find . -name "*.correct" | wc -l`
 if [ $num_correct_files -eq 0 ]; then

--- a/tools/run-proof.sh
+++ b/tools/run-proof.sh
@@ -1,36 +1,29 @@
 #!/bin/bash
-if [ "$#" -ne 4 ]; then
-  echo "../tools/run-proof.sh <dir (arm/x86)>"
-  echo "      <asm filename without .S (e.g., bignum_copy)>"
-  echo "      <HOL Light command> <output log path>"
-  echo "This script runs HOL Light proof at '<dir>/proofs/<asm filename>.ml', and".
-  echo "inspects the log file to check whether all proofs are done successfully."
+if [ "$#" -ne 2 ]; then
+  echo "../tools/run-proof.sh <.native file to run> <output log path>"
+  echo "This script runs precompiled HOL Light proof '<.native file>', prints the output"
+  echo "at <output log path>, and inspects the log file to check whether all proofs "
+  echo "are done successfully."
   exit 1
 fi
 
 # Return the exit code if any statement fails
 set -e
 
+s2n_bignum_arch=$(basename "$(pwd)")
+
 cd ..
 
-s2n_bignum_arch=$1
-asm_filename=$2
-hol_light_cmd=$3
-output_path=${s2n_bignum_arch}/$4
+native_path=${s2n_bignum_arch}/$1
+output_path=${s2n_bignum_arch}/$2
 
-(echo 'Topdirs.dir_directory "+unix";;'; \
- echo 'Topdirs.dir_load Format.std_formatter "unix.cma";;'; \
- echo 'let start_time = Unix.time();;'; \
- echo "loadt \"${s2n_bignum_arch}/proofs/${asm_filename}.ml\";;"; \
- echo "check_axioms ();;"; \
- echo 'let end_time = Unix.time();;'; \
- echo 'Printf.printf "Running time: %f sec, Start unixtime: %f, End unixtime: %f\n" (end_time -. start_time) start_time end_time;;') | eval "$hol_light_cmd" 2>&1 > "$output_path"
+"$native_path" 2>&1 > "$output_path"
 
 # Revert the exit code option since 'grep' may return non-zero.
 set +e
 
 grep -r -i "error\|exception" --include "$output_path"
 if [ $? -eq 0 ]; then
-  echo "${s2n_bignum_arch}/proofs/${asm_filename}.ml had error(s)"
+  echo "${s2n_bignum_arch}/${native_path} had error(s)"
   exit 1
 fi

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -407,7 +407,7 @@ libs2nbignum.a: $(OBJ) ; ar -rc libs2nbignum.a $(OBJ)
 
 winobj: $(WINOBJ) ;
 
-clean:; rm -f libs2nbignum.a */*.o */*.obj */*.correct
+clean:; rm -f libs2nbignum.a */*.o */*.obj */*.correct */*.native
 
 # Dynamically regenerate or destroy the files recording which functions
 # use BMI and/or ADX instructions in the x86 versions. These won't run
@@ -444,48 +444,57 @@ clobber: clean ; rm -f yesbmi_functions nonbmi_functions
 HOLDIR?=$(HOME)/hol-light
 HOLLIGHT:=$(HOLDIR)/hol.sh
 
-PROOFS = $(OBJ:.o=.correct)
+PROOF_BINS = $(OBJ:.o=.native)
+PROOF_LOGS = $(OBJ:.o=.correct)
+
+# Build precompiled native binaries of HOL Light proofs
+
+.SECONDEXPANSION:
+%.native: proofs/$$(*F).ml %.o %.obj ; ../tools/build-proof.sh "$<" "$(HOLLIGHT)" "$@"
+
+# Run them and print the standard output+error at *.correct
+
+%.correct: %.native ; ../tools/run-proof.sh "$<" "$@"
 
 # Cases where a proof uses other proofs for lemmas and/or subroutines
 
-curve25519/curve25519_x25519.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519.ml curve25519/curve25519_x25519.o curve25519/curve25519_x25519.obj ; ../tools/run-proof.sh x86 curve25519_x25519 "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519_alt.ml curve25519/curve25519_x25519_alt.o curve25519/curve25519_x25519_alt.obj ; ../tools/run-proof.sh x86 curve25519_x25519_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_byte.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519_byte.ml curve25519/curve25519_x25519_byte.o curve25519/curve25519_x25519_byte.obj ; ../tools/run-proof.sh x86 curve25519_x25519_byte "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519_byte_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519_byte_alt.ml curve25519/curve25519_x25519_byte_alt.o curve25519/curve25519_x25519_byte_alt.obj ; ../tools/run-proof.sh x86 curve25519_x25519_byte_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519base.ml curve25519/curve25519_x25519base.o curve25519/curve25519_x25519base.obj ; ../tools/run-proof.sh x86 curve25519_x25519base "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519base_alt.ml curve25519/curve25519_x25519base_alt.o curve25519/curve25519_x25519base_alt.obj ; ../tools/run-proof.sh x86 curve25519_x25519base_alt "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_byte.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519base_byte.ml curve25519/curve25519_x25519base_byte.o curve25519/curve25519_x25519base_byte.obj ; ../tools/run-proof.sh x86 curve25519_x25519base_byte "$(HOLLIGHT)" $@
-curve25519/curve25519_x25519base_byte_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/curve25519_x25519base_byte_alt.ml curve25519/curve25519_x25519base_byte_alt.o curve25519/curve25519_x25519base_byte_alt.obj ; ../tools/run-proof.sh x86 curve25519_x25519base_byte_alt "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmulbase.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/edwards25519_scalarmulbase.ml curve25519/edwards25519_scalarmulbase.o curve25519/edwards25519_scalarmulbase.obj ; ../tools/run-proof.sh x86 edwards25519_scalarmulbase "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmulbase_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/edwards25519_scalarmulbase_alt.ml curve25519/edwards25519_scalarmulbase_alt.o curve25519/edwards25519_scalarmulbase_alt.obj ; ../tools/run-proof.sh x86 edwards25519_scalarmulbase_alt "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmuldouble.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/edwards25519_scalarmuldouble.ml curve25519/edwards25519_scalarmuldouble.o curve25519/edwards25519_scalarmuldouble.obj ; ../tools/run-proof.sh x86 edwards25519_scalarmuldouble "$(HOLLIGHT)" $@
-curve25519/edwards25519_scalarmuldouble_alt.correct: curve25519/bignum_inv_p25519.o curve25519/bignum_inv_p25519.obj proofs/edwards25519_scalarmuldouble_alt.ml curve25519/edwards25519_scalarmuldouble_alt.o curve25519/edwards25519_scalarmuldouble_alt.obj ; ../tools/run-proof.sh x86 edwards25519_scalarmuldouble_alt "$(HOLLIGHT)" $@
-generic/bignum_modexp.correct: generic/bignum_amontifier.correct generic/bignum_amontmul.correct generic/bignum_demont.correct generic/bignum_mux.correct proofs/bignum_modexp.ml generic/bignum_modexp.o generic/bignum_modexp.obj ; ../tools/run-proof.sh x86 bignum_modexp "$(HOLLIGHT)" $@
-p256/p256_montjscalarmul.correct:  proofs/p256_montjadd.ml p256/p256_montjadd.o p256/p256_montjadd.obj proofs/p256_montjdouble.ml p256/p256_montjdouble.o p256/p256_montjdouble.obj proofs/p256_montjscalarmul.ml p256/p256_montjscalarmul.o p256/p256_montjscalarmul.obj ; ../tools/run-proof.sh x86 p256_montjscalarmul "$(HOLLIGHT)" $@
-p256/p256_montjscalarmul_alt.correct: proofs/p256_montjadd_alt.ml p256/p256_montjadd_alt.o p256/p256_montjadd_alt.obj proofs/p256_montjdouble_alt.ml p256/p256_montjdouble_alt.o p256/p256_montjdouble_alt.obj proofs/p256_montjscalarmul_alt.ml p256/p256_montjscalarmul_alt.o p256/p256_montjscalarmul_alt.obj ; ../tools/run-proof.sh x86 p256_montjscalarmul_alt "$(HOLLIGHT)" $@
-p256/p256_scalarmul.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o p256/bignum_demont_p256.obj proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o p256/bignum_inv_p256.obj proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o p256/bignum_montmul_p256.obj proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o p256/bignum_montsqr_p256.obj proofs/bignum_tomont_p256.ml p256/bignum_tomont_p256.o p256/bignum_tomont_p256.obj proofs/p256_montjadd.ml p256/p256_montjadd.o p256/p256_montjadd.obj proofs/p256_montjdouble.ml p256/p256_montjdouble.o p256/p256_montjdouble.obj proofs/p256_montjmixadd.ml p256/p256_montjmixadd.o p256/p256_montjmixadd.obj proofs/p256_scalarmul.ml p256/p256_scalarmul.o p256/p256_scalarmul.obj ; ../tools/run-proof.sh x86 p256_scalarmul "$(HOLLIGHT)" $@
-p256/p256_scalarmul_alt.correct: proofs/bignum_demont_p256_alt.ml p256/bignum_demont_p256_alt.o p256/bignum_demont_p256_alt.obj proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o p256/bignum_inv_p256.obj proofs/bignum_montmul_p256_alt.ml p256/bignum_montmul_p256_alt.o p256/bignum_montmul_p256_alt.obj proofs/bignum_montsqr_p256_alt.ml p256/bignum_montsqr_p256_alt.o p256/bignum_montsqr_p256_alt.obj proofs/bignum_tomont_p256_alt.ml p256/bignum_tomont_p256_alt.o p256/bignum_tomont_p256_alt.obj proofs/p256_montjadd_alt.ml p256/p256_montjadd_alt.o p256/p256_montjadd_alt.obj proofs/p256_montjdouble_alt.ml p256/p256_montjdouble_alt.o p256/p256_montjdouble_alt.obj proofs/p256_montjmixadd_alt.ml p256/p256_montjmixadd_alt.o p256/p256_montjmixadd_alt.obj proofs/p256_scalarmul_alt.ml p256/p256_scalarmul_alt.o p256/p256_scalarmul_alt.obj ; ../tools/run-proof.sh x86 p256_scalarmul_alt "$(HOLLIGHT)" $@
-p256/p256_scalarmulbase.correct: proofs/bignum_demont_p256.ml p256/bignum_demont_p256.o p256/bignum_demont_p256.obj proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o p256/bignum_inv_p256.obj proofs/bignum_montmul_p256.ml p256/bignum_montmul_p256.o p256/bignum_montmul_p256.obj proofs/bignum_montsqr_p256.ml p256/bignum_montsqr_p256.o p256/bignum_montsqr_p256.obj proofs/p256_montjmixadd.ml p256/p256_montjmixadd.o p256/p256_montjmixadd.obj proofs/p256_scalarmulbase.ml p256/p256_scalarmulbase.o p256/p256_scalarmulbase.obj ; ../tools/run-proof.sh x86 p256_scalarmulbase "$(HOLLIGHT)" $@
-p256/p256_scalarmulbase_alt.correct: proofs/bignum_demont_p256_alt.ml p256/bignum_demont_p256_alt.o p256/bignum_demont_p256_alt.obj proofs/bignum_inv_p256.ml p256/bignum_inv_p256.o p256/bignum_inv_p256.obj proofs/bignum_montmul_p256_alt.ml p256/bignum_montmul_p256_alt.o p256/bignum_montmul_p256_alt.obj proofs/bignum_montsqr_p256_alt.ml p256/bignum_montsqr_p256_alt.o p256/bignum_montsqr_p256_alt.obj  proofs/p256_montjmixadd_alt.ml p256/p256_montjmixadd_alt.o p256/p256_montjmixadd_alt.obj proofs/p256_scalarmulbase_alt.ml p256/p256_scalarmulbase_alt.o p256/p256_scalarmulbase_alt.obj ; ../tools/run-proof.sh x86 p256_scalarmulbase_alt "$(HOLLIGHT)" $@
-p384/p384_montjscalarmul.correct:  proofs/p384_montjadd.ml p384/p384_montjadd.o p384/p384_montjadd.obj proofs/p384_montjdouble.ml p384/p384_montjdouble.o p384/p384_montjdouble.obj proofs/p384_montjscalarmul.ml p384/p384_montjscalarmul.o p384/p384_montjscalarmul.obj ; ../tools/run-proof.sh x86 p384_montjscalarmul "$(HOLLIGHT)" $@
-p384/p384_montjscalarmul_alt.correct: proofs/p384_montjadd_alt.ml p384/p384_montjadd_alt.o p384/p384_montjadd_alt.obj proofs/p384_montjdouble_alt.ml p384/p384_montjdouble_alt.o p384/p384_montjdouble_alt.obj proofs/p384_montjscalarmul_alt.ml p384/p384_montjscalarmul_alt.o p384/p384_montjscalarmul_alt.obj ; ../tools/run-proof.sh x86 p384_montjscalarmul_alt "$(HOLLIGHT)" $@
-p521/p521_jscalarmul.correct: proofs/bignum_mod_n521_9.ml p521/bignum_mod_n521_9.o p521/bignum_mod_n521_9.obj proofs/bignum_mod_p521_9.ml p521/bignum_mod_p521_9.o p521/bignum_mod_p521_9.obj proofs/p521_jscalarmul.ml p521/p521_jscalarmul.o p521/p521_jscalarmul.obj ; ../tools/run-proof.sh x86 p521_jscalarmul "$(HOLLIGHT)" $@
-p521/p521_jscalarmul_alt.correct: proofs/bignum_mod_n521_9_alt.ml p521/bignum_mod_n521_9_alt.o p521/bignum_mod_n521_9_alt.obj proofs/bignum_mod_p521_9.ml p521/bignum_mod_p521_9.o p521/bignum_mod_p521_9.obj proofs/p521_jscalarmul_alt.ml p521/p521_jscalarmul_alt.o p521/p521_jscalarmul_alt.obj ; ../tools/run-proof.sh x86 p521_jscalarmul_alt "$(HOLLIGHT)" $@
-sm2/sm2_montjscalarmul.correct:  proofs/sm2_montjadd.ml sm2/sm2_montjadd.o sm2/sm2_montjadd.obj proofs/sm2_montjdouble.ml sm2/sm2_montjdouble.o sm2/sm2_montjdouble.obj proofs/sm2_montjscalarmul.ml sm2/sm2_montjscalarmul.o sm2/sm2_montjscalarmul.obj ; ../tools/run-proof.sh x86 sm2_montjscalarmul "$(HOLLIGHT)" $@
-sm2/sm2_montjscalarmul_alt.correct: proofs/sm2_montjadd_alt.ml sm2/sm2_montjadd_alt.o sm2/sm2_montjadd_alt.obj proofs/sm2_montjdouble_alt.ml sm2/sm2_montjdouble_alt.o sm2/sm2_montjdouble_alt.obj proofs/sm2_montjscalarmul_alt.ml sm2/sm2_montjscalarmul_alt.o sm2/sm2_montjscalarmul_alt.obj ; ../tools/run-proof.sh x86 sm2_montjscalarmul_alt "$(HOLLIGHT)" $@
+curve25519/curve25519_x25519.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_byte.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519_byte_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_byte.native: curve25519/bignum_inv_p25519.native
+curve25519/curve25519_x25519base_byte_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmulbase.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmulbase_alt.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmuldouble.native: curve25519/bignum_inv_p25519.native
+curve25519/edwards25519_scalarmuldouble_alt.native: curve25519/bignum_inv_p25519.native
+generic/bignum_modexp.native: generic/bignum_amontifier.native generic/bignum_amontmul.native generic/bignum_demont.native generic/bignum_mux.native
+p256/p256_montjadd.native: p256/bignum_montsqr_p256.native p256/bignum_montmul_p256.native p256/bignum_sub_p256.native
+p256/p256_montjdouble.native: p256/bignum_montsqr_p256.native p256/bignum_montmul_p256.native p256/bignum_sub_p256.native p256/bignum_add_p256.native
+p256/p256_montjscalarmul.native: p256/p256_montjadd.native p256/p256_montjdouble.native
+p256/p256_montjscalarmul_alt.native: p256/p256_montjadd_alt.native p256/p256_montjdouble_alt.native
+p256/p256_scalarmul.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/bignum_tomont_p256.native p256/p256_montjadd.native p256/p256_montjdouble.native p256/p256_montjmixadd.native
+p256/p256_scalarmul_alt.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjadd_alt.native p256/p256_montjdouble_alt.native p256/p256_montjmixadd_alt.native
+p256/p256_scalarmulbase.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjmixadd.native
+p256/p256_scalarmulbase_alt.native: p256/bignum_demont_p256.native p256/bignum_inv_p256.native p256/p256_montjmixadd_alt.native
+p384/p384_montjadd.native: p384/bignum_montsqr_p384.native p384/bignum_montmul_p384.native p384/bignum_sub_p384.native
+p384/p384_montjdouble.native: p384/bignum_montsqr_p384.native p384/bignum_montmul_p384.native p384/bignum_sub_p384.native p384/bignum_add_p384.native
+p384/p384_montjscalarmul.native: \
+    p384/p384_montjadd.native p384/p384_montjdouble.native \
+    p384/bignum_sub_p384.native p384/bignum_add_p384.native
+p384/p384_montjscalarmul_alt.native: p384/p384_montjadd_alt.native p384/p384_montjdouble_alt.native
+p521/p521_jadd.native: p521/bignum_mul_p521.native p521/bignum_sqr_p521.native
+p521/p521_jdouble.native: p521/bignum_mul_p521.native p521/bignum_sqr_p521.native
+p521/p521_jscalarmul.native: p521/bignum_mod_n521_9.native p521/p521_jadd.native p521/p521_jdouble.native
+p521/p521_jscalarmul_alt.native: p521/bignum_mod_n521_9.native
+sm2/sm2_montjscalarmul.native: sm2/sm2_montjadd.native sm2/sm2_montjdouble.native
+sm2/sm2_montjscalarmul_alt.native: sm2/sm2_montjadd_alt.native sm2/sm2_montjdouble_alt.native
 
-# All other other instances are standalone
 
-curve25519/%.correct: proofs/%.ml curve25519/%.o curve25519/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-fastmul/%.correct: proofs/%.ml fastmul/%.o fastmul/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-generic/%.correct: proofs/%.ml generic/%.o generic/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-p256/%.correct: proofs/%.ml p256/%.o p256/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-p384/%.correct: proofs/%.ml p384/%.o p384/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-p521/%.correct: proofs/%.ml p521/%.o p521/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-secp256k1/%.correct: proofs/%.ml secp256k1/%.o secp256k1/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-sm2/%.correct: proofs/%.ml sm2/%.o sm2/%.obj ; ../tools/run-proof.sh x86 "$*" "$(HOLLIGHT)" $@
-
-run_proofs: $(PROOFS);
+build_proofs: $(PROOF_BINS);
+run_proofs: build_proofs $(PROOF_LOGS);
 
 proofs: run_proofs ; ../tools/count-proofs.sh .
 


### PR DESCRIPTION
This patch compiles proofs using native OCaml compiler, and updates `make proofs` to run the newly created `*.native` executable files.

The new `tools/build-proof.sh` script builds a specific `.ml` proof file. It inlines all loads/needs in the `.ml` file using HOL Light's `inline_load.ml`.
Then, it collects all specifications in the original `.ml` file using already existing `tools/collect-specs.sh`, and adds a print statement at the end of the file, to make its standard output pass the proof checker script. It also adds timer and prints the running time of the proof. Then it is compiled with `ocamlopt.byte`.

Building all proofs can be done with `make build_proofs`. This uses a lot of memory, so compared to the previous version `-j` number given to `make` must be reduced.

This also makes the prerequisite lists tidier using the '*.native' items. Each '.native' file is considered as depending on the '.o' file. This makes compilation of a `.native` file having a long dependency chain take a slightly long time (e.g., p256_montjscalarmul), but I thought this was acceptable.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
