### PR TITLE
Avoid underflow of negative constant immediates in load/stores

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -272,11 +272,8 @@ let ARM_EXEC_CONV =
                    bytes128 (word_add b (word 0)) = bytes128 b`,
                   REWRITE_TAC[WORD_ADD_0])
   and rth = prove
-   (`word_add (read SP s) (iword (-- &16)) =
-     word_sub (read SP s) (word 16) /\
-     word_add (word_add (read SP s) (iword (-- &16))) (word 8) =
-     word_sub (read SP s) (word 8)`,
-    CONJ_TAC THEN CONV_TAC WORD_RULE) in
+   (`word_add (x:(N)word) (iword (-- &n)) =
+     word_sub x (word n)`, CONV_TAC WORD_RULE) in
   ((GEN_REWRITE_CONV I ARM_LOAD_STORE_CLAUSES THENC
     REWRITE_CONV [offset_writesback; offset_writeback;
                   OFFSET_ADDRESS_CLAUSES] THENC


### PR DESCRIPTION
This patch prevents negative constant immediates in loads and stores like `ldp _, _, [_, -16]` from introducing a constant that is a result of underflow, e.g., `18446744073709551600`. Instead, `-16` is represented as `word_sub _ (word 16)`.

In addition, this canonicalizes `word_sub (word_add baseptr ofs) ofs2)` to `word_add baseptr (word_sub ofs ofs2)` whenever possible because this makes symbolic analysis on memory instructions with negative constants easier because the base pointers appear clearly after this canonicalization.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
