### PR TITLE
Update NONOVERLAPPING_TAC to successfully process subtractions

### DIFF
--- a/common/misc.ml
+++ b/common/misc.ml
@@ -1175,9 +1175,13 @@ let ASSEMBLER_SIMPLIFY_TAC =
    (`!a b. a < a + bitval b <=> b`,
     REPEAT GEN_TAC THEN ASM_CASES_TAC `b:bool` THEN
     ASM_REWRITE_TAC[BITVAL_CLAUSES] THEN ARITH_TAC) in
-  (fun aslw ->
+  (fun (asl,w) ->
+    (* filter assumptions of form 'e = e' because it can make asm_rewrite
+       tactics in ASSEMBLER_SIMPLIFY_TAC run forever *)
+    let asl = filter (fun (_,th) ->
+      let c = concl th in not (is_eq c) || (lhs c <> rhs c)) asl in
     GEN_REWRITE_TAC (LAND_CONV o ONCE_DEPTH_CONV) !extra_early_rewrite_rules
-      aslw) THEN
+      (asl,w)) THEN
   ASM_REWRITE_TAC[WORD_XOR_REFL; WORD_ADD_0; WORD_AND_REFL; WORD_OR_REFL;
                   WORD_ZX_BITVAL; WORD_SUB_REFL; WORD_OR_0; WORD_ZX_0; NOT_LT;
                   WORD_SX_0; SUB_EQ_0; SUB_REFL; LE_REFL; LT_REFL; NOT_LE] THEN


### PR DESCRIPTION
This patch updates `NONOVERLAPPING_TAC` to successfully deal with subtractions. An example that can be now resolved with it is as follows:

```
g `nonoverlapping (x:int64,k) (y:int64,k2) /\ 4 <= i /\ i < k
   ==> nonoverlapping (word_add x (word_sub (word i) (word 4)), 4) (y,k2)`;;

e(REWRITE_TAC[NONOVERLAPPING_CLAUSES]);;
e(STRIP_TAC);;
e(NONOVERLAPPING_TAC);;
```

To achieve this, this patch (1) updates the normalizer to convert `word_sub (word x) (word y)` to `x - y` if `y <= x`, and (2) makes `cmp` eventually rely on `prove_le` rather than quickly raising a failure. Invoking `prove_le` can be quite expensive though; Therefore this patch also has an implication which is making `NONOVERLAPPING_TAC` a step toward being even more 'automatic' while being more expensive.

Orthogonally, this patch updates the assembly simplifier tactic to recognize assumptions of the form `.. |- x = x` and filter them out because this can cause infinite loops in its following ASM_REWRITE tactics.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
