### PR TITLE
Use Compute to evaluate Arm's decode function

### DIFF
--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -13,7 +13,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
-      - git checkout 9eccc5e457c56b94a3223821e98f5ec559023c67
+      - git checkout 4eef6f604636cea7e0a22d287cc015d8fd116b5f
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -14,7 +14,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
-      - git checkout 9eccc5e457c56b94a3223821e98f5ec559023c67
+      - git checkout 4eef6f604636cea7e0a22d287cc015d8fd116b5f
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)


### PR DESCRIPTION
This reimplements the `PURE_DECODE_CONV` with the Compute module of HOL Light.
To use the latest `*_COMPUTE_CONV` functions, this bumps the version of HOL Light to the latest one. :)

The main part of this patch was prototyped by @monadius.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
