### PR TITLE
Adding instructions for SHA3

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -511,6 +511,10 @@ let decode = new_definition `!w:int32. decode w =
   | [0b11001110011:11; Rm:5; 0b100010:6; Rn:5; Rd:5] ->
     // SHA512SU1
     SOME (arm_SHA512SU1 (QREG' Rd) (QREG' Rn) (QREG' Rm))
+  
+  | [0b11001110011:11; Rm:5; 0b100011:6; Rn:5; Rd:5] ->
+    // RAX1
+    SOME (arm_RAX1 (QREG' Rd) (QREG' Rn) (QREG' Rm))
 
   | [0:1; q; 0b0011110:7; immh:4; immb:3; 0b010101:6; Rn:5; Rd:5] ->
     // SHL
@@ -666,6 +670,18 @@ let decode = new_definition `!w:int32. decode w =
       // part is 1 or 0 according to op, pairs is elements / 2
       if op then SOME(arm_ZIP2 (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
       else SOME(arm_ZIP1 (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
+
+  | [0b11001110000:11; Rm:5; 0:1; Ra:5; Rn:5; Rd:5] ->
+    // EOR3
+    SOME (arm_EOR3 (QREG' Rd) (QREG' Rn) (QREG' Rm) (QREG' Ra))
+
+  | [0b11001110001:11; Rm:5; 0:1; Ra:5; Rn:5; Rd:5] ->
+    // BCAX
+    SOME (arm_BCAX (QREG' Rd) (QREG' Rn) (QREG' Rm) (QREG' Ra))
+  
+  | [0b11001110100:11; Rm:5; imm6:6; Rn:5; Rd:5] ->
+    // XAR
+    SOME (arm_XAR (QREG' Rd) (QREG' Rn) (QREG' Rm) imm6)
 
  | _ -> NONE`;;
 

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -683,7 +683,7 @@ let decode = new_definition `!w:int32. decode w =
     // XAR
     SOME (arm_XAR (QREG' Rd) (QREG' Rn) (QREG' Rm) imm6)
 
- | _ -> NONE`;;
+  | _ -> NONE`;;
 
 (* ------------------------------------------------------------------------- *)
 (* Decode tactics.                                                           *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2012,7 +2012,7 @@ let arm_RAX1 = define
       and m:int128 = read Rm s 
       and hi:int64 = word_subword m (64,64)
       and lo:int64 = word_subword m (0,64) in
-      let d' = word_xor n (word_join (word_rol hi 1) (word_rol lo 1))
+      let d' = word_xor n (word_join (word_rol hi 1) (word_rol lo 1)) in
       (Rd := d') s`;;
 
 (* ------------------------------------------------------------------------- *)
@@ -2025,7 +2025,7 @@ let arm_EOR3 = define
       let n:int128 = read Rn s
       and m:int128 = read Rm s
       and a:int128 = read Ra s in
-      let d':int128 = word_xor (word_xor n m) a
+      let d':int128 = word_xor (word_xor n m) a in
       (Rd := d') s`;;
 
 let arm_BCAX = define 
@@ -2034,7 +2034,7 @@ let arm_BCAX = define
       let n:int128 = read Rn s
       and m:int128 = read Rm s
       and a:int128 = read Ra s in
-      let d':int128 = word_xor n (word_and m (word_not a))
+      let d':int128 = word_xor n (word_and m (word_not a)) in
       (Rd := d') s`;;
 
 (* ------------------------------------------------------------------------- *)
@@ -2048,9 +2048,9 @@ let arm_xar = define
       and m:int128 = read Rm s
       and tmp:int128 = word_xor n m
       and hi:int64 = word_subword tmp (64,64)
-      and lo:int64 = word_subword tmp (0,64)
-      let d':int128 = word_join (word_ror hi imm6) (word_ror lo imm6)
-  `;;
+      and lo:int64 = word_subword tmp (0,64) in
+      let d':int128 = word_join (word_ror hi imm6) (word_ror lo imm6) in
+      (Rd := d') s`;;
 
 (* ------------------------------------------------------------------------- *)
 (* Pseudo-instructions that are defined by ARM as aliases.                   *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2009,8 +2009,8 @@ let arm_RAX1 = define
  `arm_RAX1 Rd Rn Rm =
     \s:armstate.
       let n:int128 = read Rn s
-      and m:int128 = read Rm s 
-      and hi:int64 = word_subword m (64,64)
+      and m:int128 = read Rm s in
+      let hi:int64 = word_subword m (64,64)
       and lo:int64 = word_subword m (0,64) in
       let d' = word_xor n (word_join (word_rol hi 1) (word_rol lo 1)) in
       (Rd := d') s`;;
@@ -2045,11 +2045,11 @@ let arm_XAR = define
   `arm_XAR Rd Rn Rm imm6 =
     \s:armstate.
       let n:int128 = read Rn s
-      and m:int128 = read Rm s
-      and tmp:int128 = word_xor n m
-      and hi:int64 = word_subword tmp (64,64)
+      and m:int128 = read Rm s in
+      let tmp:int128 = word_xor n m in
+      let hi:int64 = word_subword tmp (64,64)
       and lo:int64 = word_subword tmp (0,64) in
-      let d':int128 = word_join (word_ror hi imm6) (word_ror lo imm6) in
+      let d':int128 = word_join (word_ror hi (val imm6)) (word_ror lo (val imm6)) in
       (Rd := d') s`;;
 
 (* ------------------------------------------------------------------------- *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2041,8 +2041,8 @@ let arm_BCAX = define
 (* XAR : Exclusive-OR and Rotate                                             *)
 (* ------------------------------------------------------------------------- *)
 
-let arm_xar = define
-  `arm_xar Rd Rn Rm imm6 =
+let arm_XAR = define
+  `arm_XAR Rd Rn Rm imm6 =
     \s:armstate.
       let n:int128 = read Rn s
       and m:int128 = read Rm s
@@ -2476,12 +2476,12 @@ let ARM_OPERATION_CLAUSES =
     (*** Alphabetically sorted, new alphabet appears in the next line ***)
       [arm_ADC; arm_ADCS_ALT; arm_ADD; arm_ADD_VEC_ALT; arm_ADDS_ALT; arm_ADR;
        arm_AND; arm_AND_VEC; arm_ANDS; arm_ASR; arm_ASRV;
-       arm_B; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIT;
+       arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIT;
        arm_BL; arm_BL_ABSOLUTE; arm_Bcond;
        arm_CBNZ_ALT; arm_CBZ_ALT; arm_CCMN; arm_CCMP; arm_CLZ; arm_CSEL;
        arm_CSINC; arm_CSINV; arm_CSNEG;
        arm_DUP_GEN_ALT;
-       arm_EON; arm_EOR; arm_EXT; arm_EXTR;
+       arm_EON; arm_EOR; arm_EOR3; arm_EXT; arm_EXTR;
        arm_FCSEL; arm_INS; arm_INS_GEN;
        arm_LSL; arm_LSLV; arm_LSR; arm_LSRV;
        arm_MADD;
@@ -2502,7 +2502,7 @@ let ARM_OPERATION_CLAUSES =
        arm_UMSUBL; arm_UMULL_VEC_ALT; arm_UMULL2_VEC_ALT; arm_UMULH;
        arm_USHR_VEC_ALT; arm_USRA_VEC_ALT; arm_UZP1_ALT;
        arm_UZP2_ALT;
-       arm_XTN_ALT;
+       arm_XAR; arm_XTN_ALT;
        arm_ZIP1_ALT; arm_ZIP2_ALT;
     (*** 32-bit backups since the ALT forms are 64-bit only ***)
        INST_TYPE[`:32`,`:N`] arm_ADCS;
@@ -2510,6 +2510,7 @@ let ARM_OPERATION_CLAUSES =
        INST_TYPE[`:32`,`:N`] arm_SBCS;
        INST_TYPE[`:32`,`:N`] arm_SUBS;
     (*** SHA256 & SHA512 instructions from Carl Kwan ***)
+       arm_RAX1
        arm_SHA256H;
        arm_SHA256H2;
        arm_SHA256SU0;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2005,6 +2005,53 @@ let arm_SHA512SU1 = define
         let d' = sha512su1 d n m in
         (Rd := d') s`;;
 
+let arm_RAX1 = define
+ `arm_RAX1 Rd Rn Rm =
+    \s:armstate.
+      let n:int128 = read Rn s
+      and m:int128 = read Rm s 
+      and hi:int64 = word_subword m (64,64)
+      and lo:int64 = word_subword m (0,64) in
+      let d' = word_xor n (word_join (word_rol hi 1) (word_rol lo 1))
+      (Rd := d') s`;;
+
+(* ------------------------------------------------------------------------- *)
+(* Cryptographic four-register                                               *)
+(* ------------------------------------------------------------------------- *)
+
+let arm_EOR3 = define 
+ `arm_EOR3 Rd Rn Rm Ra =
+    \s:armstate.
+      let n:int128 = read Rn s
+      and m:int128 = read Rm s
+      and a:int128 = read Ra s in
+      let d':int128 = word_xor (word_xor n m) a
+      (Rd := d') s`;;
+
+let arm_BCAX = define 
+ `arm_BCAX Rd Rn Rm Ra =
+    \s:armstate.
+      let n:int128 = read Rn s
+      and m:int128 = read Rm s
+      and a:int128 = read Ra s in
+      let d':int128 = word_xor n (word_and m (word_not a))
+      (Rd := d') s`;;
+
+(* ------------------------------------------------------------------------- *)
+(* XAR : Exclusive-OR and Rotate                                             *)
+(* ------------------------------------------------------------------------- *)
+
+let arm_xar = define
+  `arm_xar Rd Rn Rm imm6 =
+    \s:armstate.
+      let n:int128 = read Rn s
+      and m:int128 = read Rm s
+      and tmp:int128 = word_xor n m
+      and hi:int64 = word_subword tmp (64,64)
+      and lo:int64 = word_subword tmp (0,64)
+      let d':int128 = word_join (word_ror hi imm6) (word_ror lo imm6)
+  `;;
+
 (* ------------------------------------------------------------------------- *)
 (* Pseudo-instructions that are defined by ARM as aliases.                   *)
 (* ------------------------------------------------------------------------- *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2510,7 +2510,7 @@ let ARM_OPERATION_CLAUSES =
        INST_TYPE[`:32`,`:N`] arm_SBCS;
        INST_TYPE[`:32`,`:N`] arm_SUBS;
     (*** SHA256 & SHA512 instructions from Carl Kwan ***)
-       arm_RAX1
+       arm_RAX1;
        arm_SHA256H;
        arm_SHA256H2;
        arm_SHA256SU0;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -319,20 +319,17 @@ let iclasses =
   "00001110100xxxxx011110xxxxxxxxxx"; (* q=0, size!=3 *)
 
   (*** EOR3 ***)
-  (** "11001110000xxxxx0xxxxxxxxxxxxxxx"; 
-  *)
+  "11001110000xxxxx0xxxxxxxxxxxxxxx"; 
+ 
 
   (*** BCAX ***)
-  (** "11001110001xxxxx0xxxxxxxxxxxxxxx"; 
-  *)
+  "11001110001xxxxx0xxxxxxxxxxxxxxx";
 
   (*** RAX1 ***)
-  (** "11001110011xxxxx100011xxxxxxxxxx"; 
-  *)
+  "11001110011xxxxx100011xxxxxxxxxx"; 
 
   (*** XAR ***)
-  (** "11001110100xxxxxxxxxxxxxxxxxxxxx"; 
-  *)
+  "11001110100xxxxxxxxxxxxxxxxxxxxx";
 ];;
 
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -317,6 +317,22 @@ let iclasses =
   "01001110xx0xxxxx011110xxxxxxxxxx"; (* q=1 *)
   "000011100x0xxxxx011110xxxxxxxxxx"; (* q=0, size!=3 *)
   "00001110100xxxxx011110xxxxxxxxxx"; (* q=0, size!=3 *)
+
+  (*** EOR3 ***)
+  (** "11001110000xxxxx0xxxxxxxxxxxxxxx"; 
+  *)
+
+  (*** BCAX ***)
+  (** "11001110001xxxxx0xxxxxxxxxxxxxxx"; 
+  *)
+
+  (*** RAX1 ***)
+  (** "11001110011xxxxx100011xxxxxxxxxx"; 
+  *)
+
+  (*** XAR ***)
+  (** "11001110100xxxxxxxxxxxxxxxxxxxxx"; 
+  *)
 ];;
 
 


### PR DESCRIPTION
*Description of changes:*

This PR adds instructions for SHA3 implemention from https://github.com/pq-code-package/mlkem-native/blob/main/fips202/native/aarch64/keccak_f1600_x1_v84a_asm_clean.S

The added instructions are: EOR3, BCAX, XAR and RAX1. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
