### PR TITLE
Enable SHA512 intrinsics from Arm simulator

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -145,9 +145,7 @@ let decode_extendtype = new_definition
     | [0b110:3] -> SXTW
     | [0b111:3] -> SXTX`;;
 
-(* Decodes the 4-byte word w. decode must use language features and
-   functions that can be evaluated by the 'evaluate' function in
-   PURE_DECODE_CONV.
+(* Decodes the 4-byte word w.
    To see the instruction's official bit formats, you will want to read the
    "Arm A64 Instruction Set Architecture" document from online. *)
 let decode = new_definition `!w:int32. decode w =
@@ -917,6 +915,7 @@ let PURE_DECODE_CONV =
               arm_bfmop; arm_ccop; arm_csop; arm_logop; arm_lsvop;
               arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
               arm_movop] rw;
+    add_thms [QLANE] rw;
     add_conv (`Condition`, 1, CONDITION_CONV) rw;
     (* decode functions *)
     add_thms [decode; decode_encode_BL] rw;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -190,7 +190,6 @@ let iclasses =
   (*** SHA256SU1 ***)
   "01011110000xxxxx011000xxxxxxxxxx";
 
-  (*** SHA512 Intrinsics
   (*** SHA512H ***)
   "11001110011xxxxx100000xxxxxxxxxx";
 
@@ -201,7 +200,7 @@ let iclasses =
   "1100111011000000100000xxxxxxxxxx";
 
   (*** SHA512SU1 ***)
-  "11001110011xxxxx100010xxxxxxxxxx";***)
+  "11001110011xxxxx100010xxxxxxxxxx";
 
   (*** SHL (make sure immh is nonzero) ***)
   "0x00111101xxxxxx010101xxxxxxxxxx";

--- a/tools/run-proof.sh
+++ b/tools/run-proof.sh
@@ -22,7 +22,7 @@ output_path=${s2n_bignum_arch}/$2
 # Revert the exit code option since 'grep' may return non-zero.
 set +e
 
-grep -r -i "error\|exception" --include "$output_path"
+grep -i "error:\|exception:" "$output_path"
 if [ $? -eq 0 ]; then
   echo "${s2n_bignum_arch}/${native_path} had error(s)"
   exit 1

--- a/tools/run-sematest.sh
+++ b/tools/run-sematest.sh
@@ -31,8 +31,8 @@ for (( i = 1; i <= $nproc; i++ )) ; do
 
   # Revert the exit code option since 'grep' may return non-zero.
   set +e
-  grep -i "error\|exception" ${log_paths[$i]}
-  if [ $?-eq 0 ]; then
+  grep -i "error:\|exception:" ${log_paths[$i]}
+  if [ $? -eq 0 ]; then
     echo "Simulator $i failed!"
     exit 1
   else


### PR DESCRIPTION
This patch enables cosimulation of SHA512 intrinsics.

Also, this adds missing QLANE rule to Arm decoder, fix error check in run-sematest.sh .

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
