### PR TITLE
Compile simulators for speed

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -422,6 +422,8 @@ PROOF_LOGS = $(OBJ:.o=.correct)
 
 # Build precompiled native binaries of HOL Light proofs
 
+proofs/simulator.native: proofs/simulator.ml ; ../tools/build-proof.sh proofs/simulator.ml "$(HOLLIGHT)" "$@"
+
 .SECONDEXPANSION:
 %.native: proofs/$$(*F).ml %.o ; ../tools/build-proof.sh "$<" "$(HOLLIGHT)" "$@"
 
@@ -489,7 +491,5 @@ FORCE: ;
 # A portable way of getting the number of max. cores:
 # https://stackoverflow.com/a/23569003/1488216
 NUM_CORES_FOR_SEMATEST = $(shell getconf _NPROCESSORS_ONLN)
-sematest: FORCE $(OBJ) proofs/simulator_iclasses.ml
-	(printf "#use \"proofs/simulator_iclasses.ml\";;\ncheck_insns();;\n") | eval "$(HOLLIGHT)" 2>&1 | tee simulator_iclasses_log.txt
-	! grep -i "error\|exception" simulator_iclasses_log.txt
-	../tools/run-sematest.sh arm $(NUM_CORES_FOR_SEMATEST) "$(HOLLIGHT)"
+sematest: FORCE $(OBJ) proofs/simulator_iclasses.ml proofs/simulator.native
+	../tools/run-sematest.sh arm $(NUM_CORES_FOR_SEMATEST)

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -85,6 +85,8 @@ let random_instruction iclasses =
 
 loadt "arm/proofs/simulator_iclasses.ml";;
 
+check_insns();;
+
 (* ------------------------------------------------------------------------- *)
 (* Run a random example.                                                     *)
 (* ------------------------------------------------------------------------- *)

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -450,7 +450,7 @@ let check_insns () =
         let p = (Filename.concat dirpath p) in
         if Sys.is_directory p then
           traverse_objs p checkfn
-        else if Filename.extension p = ".o" then
+        else if Filename.extension p = ".o" && p <> "arm/proofs/simulator.o" then
           checkfn p
         else ()
       ) dirs in
@@ -507,5 +507,5 @@ let check_insns () =
         Printf.printf "Passed: %s\n%!" objpath;
         close_in fin
       end in
-  (* Makefile will run this script from arm/. *)
-  traverse_objs "." checkfn;;
+  (* Makefile will run this script from the root dir of s2n-bignum/. *)
+  traverse_objs "arm/" checkfn;;

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -19,7 +19,7 @@ phases:
       - eval $(opam env)
       - echo $(ocamlc -version)
       - echo $(camlp5 -v)
-      - make
+      - HOLLIGHT_USE_MODULE=1 make
   build:
     commands:
       - cd ${CODEBUILD_SRC_DIR}/${S2N_BIGNUM_ARCH}

--- a/tools/build-proof.sh
+++ b/tools/build-proof.sh
@@ -39,11 +39,6 @@ for spec in $(./tools/collect-specs.sh ${s2n_bignum_arch} $(basename ${ml_path})
   spec_found=1
 done >> ${template_ml}
 
-if [ $spec_found -eq 0 ]; then
-  echo "Could not find any specification from ${ml_path}."
-  exit 1
-fi
-
 (echo 'let s2n_bignum_build_proof_end_time = Unix.time();;'; \
  echo 'Printf.printf "Running time: %f sec, Start unixtime: %f, End unixtime: %f\n" (s2n_bignum_build_proof_end_time -. s2n_bignum_build_proof_start_time) s2n_bignum_build_proof_start_time s2n_bignum_build_proof_end_time;;') >> ${template_ml}
 

--- a/tools/run-sematest.sh
+++ b/tools/run-sematest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-if [ "$#" -ne 3 ]; then
-  echo "run-sematest.sh <dir (e.g., arm)> <N> <HOL Light command>"
-  echo "This script runs the simulator ('<dir>/proofs/simulator.ml') that tests the semantics "
+if [ "$#" -ne 2 ]; then
+  echo "run-sematest.sh <dir (e.g., arm)> <N>"
+  echo "This script runs the simulator ('<dir>/proofs/simulator.native') that tests the semantics "
   echo "of instructions. It launches N simulators in parallel, and uses the given "
   echo "HOL Light command to run them."
   echo "The current directory where this script is run must be <dir>."
@@ -10,15 +10,14 @@ fi
 
 s2n_bignum_arch=$1
 nproc=$2
-hol_light_cmd=$3
-simulator_path=${s2n_bignum_arch}/proofs/simulator.ml
+simulator_path=${s2n_bignum_arch}/proofs/simulator.native
 
 log_paths=()
 children_pids=()
 for (( i = 1; i <= $nproc; i++ )) ; do
   log_path=`mktemp`
   log_paths[$i]=$log_path
-  (cd ..; (echo "loadt \"${simulator_path}\";;") | eval "$hol_light_cmd" >$log_path 2>&1) &
+  (cd ..; "${simulator_path}" >$log_path 2>&1) &
   background_pid=$!
   children_pids[$i]=$background_pid
   echo "- Child $i (pid $background_pid) has started (log path: $log_path)"

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -440,6 +440,8 @@ PROOF_LOGS = $(OBJ:.o=.correct)
 
 # Build precompiled native binaries of HOL Light proofs
 
+proofs/simulator.native: proofs/simulator.ml ; ../tools/build-proof.sh proofs/simulator.ml "$(HOLLIGHT)" "$@"
+
 .SECONDEXPANSION:
 %.native: proofs/$$(*F).ml %.o %.obj ; ../tools/build-proof.sh "$<" "$(HOLLIGHT)" "$@"
 
@@ -497,4 +499,4 @@ FORCE: ;
 # A portable way of getting the number of max. cores:
 # https://stackoverflow.com/a/23569003/1488216
 NUM_CORES_FOR_SEMATEST = $(shell getconf _NPROCESSORS_ONLN)
-sematest: x86-insns.ml FORCE; cat x86-insns.ml; ../tools/run-sematest.sh x86 $(NUM_CORES_FOR_SEMATEST) "$(HOLLIGHT)"
+sematest: x86-insns.ml FORCE proofs/simulator.native; cat x86-insns.ml; ../tools/run-sematest.sh x86 $(NUM_CORES_FOR_SEMATEST)


### PR DESCRIPTION
This patch natively compiles simulators for speed and runs them.

Resolves https://github.com/awslabs/s2n-bignum/issues/161 .

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
