### PR TITLE
Add LD1R, FMOV and SRI instructions

### DIFF
--- a/arm/proofs/base.ml
+++ b/arm/proofs/base.ml
@@ -60,8 +60,8 @@ extra_word_CONV :=
 
 loadt "arm/proofs/aes.ml";;
 
-extra_word_CONV := [AESE_REDUCE_CONV; AESMC_REDUCE_CONV; 
-                    AESD_REDUCE_CONV; AESIMC_REDUCE_CONV] 
+extra_word_CONV := [AESE_REDUCE_CONV; AESMC_REDUCE_CONV;
+                    AESD_REDUCE_CONV; AESIMC_REDUCE_CONV]
                     @ (!extra_word_CONV);;
 
 (* ------------------------------------------------------------------------- *)

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -347,7 +347,7 @@ let decode = new_definition `!w:int32. decode w =
     SOME (arm_ldst2 is_ld Rt (XREG_SP Rn) (Postimmediate_Offset (word 32)) 128 esize)
 
   // LD1R, Post-immediate offset, size 64 and 128
-  | [0b0:1; q; 0b001101110:9; Rm:5; 0b1100:4; size:2; Rn:5; Rt:5] ->
+  | [0b0:1; q; 0b001101110111111100:18; size:2; Rn:5; Rt:5] ->
     let esize = 8 * (2 EXP (val size)) in
     let datasize = if q then 128 else 64 in
     let off = word (esize DIV 8) in

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -426,11 +426,7 @@ let decode = new_definition `!w:int32. decode w =
       else
         let immb = abc in
         let Rn = defgh in
-        let highest_set_bit =
-          if bit 3 immh then 3 else
-          if bit 2 immh then 2 else
-          if bit 1 immh then 1 else 0 in
-        let esize = 8 * (2 EXP highest_set_bit) in
+        let esize = 8 * 2 EXP (3 - word_clz immh) in
         let datasize = if q then 128 else 64 in
         let elements = datasize DIV esize in
         let shift = (esize * 2) - val(word_join immh immb:(7)word) in
@@ -444,11 +440,7 @@ let decode = new_definition `!w:int32. decode w =
       if bit 3 immh /\ ~q then NONE // "UNDEFINED"
       else if ~q then NONE // 64-bit case is unsupported
       else
-        let highest_set_bit =
-          if bit 3 immh then 3 else
-          if bit 2 immh then 2 else
-          if bit 1 immh then 1 else 0 in
-        let esize = 8 * (2 EXP highest_set_bit) in
+        let esize = 8 * 2 EXP (3 - word_clz immh) in
         let datasize = 128 in
         let elements = datasize DIV esize in
         let shift = val (word_join immh immb:(7)word) - esize in
@@ -459,11 +451,7 @@ let decode = new_definition `!w:int32. decode w =
       let Rn = defgh in
       if bit 3 immh /\ ~q then NONE
       else
-        let highest_set_bit =
-          if bit 3 immh then 3 else
-          if bit 2 immh then 2 else
-          if bit 1 immh then 1 else 0 in
-        let esize = 8 * (2 EXP highest_set_bit) in
+        let esize = 8 * 2 EXP (3 - word_clz immh) in
         let datasize = if q then 128 else 64 in
         let shift = (esize * 2) - val (word_join immh immb:(7)word) in
         SOME (arm_SRI_VEC (QREG' Rd) (QREG' Rn) shift esize datasize)
@@ -479,12 +467,12 @@ let decode = new_definition `!w:int32. decode w =
       if rmode0
       // FMOV D[1]
       then if opcode0
-           then SOME (arm_FMOV_ItoF 1 (XREG' Rn) (QREG' Rd))
-           else SOME (arm_FMOV_FtoI 1 (QREG' Rn) (XREG' Rd))
+           then SOME (arm_FMOV_ItoF (QREG' Rd) (XREG' Rn) 1)
+           else SOME (arm_FMOV_FtoI (XREG' Rd) (QREG' Rn) 1)
       // FMOV
       else if opcode0
-           then SOME (arm_FMOV_ItoF 0 (XREG' Rn) (QREG' Rd))
-           else SOME (arm_FMOV_FtoI 0 (QREG' Rn) (XREG' Rd))
+           then SOME (arm_FMOV_ItoF (QREG' Rd) (XREG' Rn) 0)
+           else SOME (arm_FMOV_FtoI (XREG' Rd) (QREG' Rn) 0)
 
   | [0:1; q; 0b101111:6; sz:2; L:1; M:1; R:4; 0b0100:4; H:1; 0:1; Rn:5; Rd:5] ->
     // MLS (by element)
@@ -621,9 +609,7 @@ let decode = new_definition `!w:int32. decode w =
     else if immh = (word 0b0:(4)word) then NONE // "asimdimm case"
     else if bit 3 immh then NONE // "UNDEFINED"
     else
-      let highest_set_bit =
-        if bit 2 immh then 2 else if bit 1 immh then 1 else 0 in
-      let esize = 8 * (2 EXP highest_set_bit) in
+      let esize = 8 * 2 EXP (3 - word_clz immh) in
       // datasize is 64, part is 0
       let elements = 64 DIV esize in
       let shift = (2 * esize) - val(word_join immh immb: (7)word) in

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2162,7 +2162,7 @@ let arm_ST2 = define
            (if offset_writesback off
             then Rn := word_add address (offset_writeback off)
             else (=))
-          else ASSIGNS entirety) s`;;
+         else ASSIGNS entirety) s`;;
 
 let arm_LD1R = define
   `arm_LD1R (Rt:(armstate,(128)word)component) Rn off esize datasize =

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1181,7 +1181,7 @@ let arm_MOVZ = define
 (* arm_FMOV_FtoI and arm_FMOV_ItoF could not be merged
   due to type resolution failure *)
 let arm_FMOV_FtoI = define
- `arm_FMOV_FtoI (part:num) Rn Rd =
+ `arm_FMOV_FtoI Rd Rn (part:num) =
     \s. let n:(128)word = read Rn s in
         let intval:(64)word =
           if part = 0
@@ -1190,13 +1190,12 @@ let arm_FMOV_FtoI = define
         (Rd := intval) s
     `;;
 let arm_FMOV_ItoF = define
- `arm_FMOV_ItoF (part:num) Rn Rd =
+ `arm_FMOV_ItoF Rd Rn (part:num) =
     \s. let fltval:(64)word = read Rn s in
         let d:(128)word = read Rd s in
         if part = 0
         then (Rd := word_zx fltval:(128)word) s
-        else (Rd := (word_join:(64)word->(64)word->(128)word)
-                      fltval (word_subword d (0, 64))) s
+        else (Rd := word_insert d (64, 64) fltval) s
     `;;
 
 let arm_MSUB = define

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1177,6 +1177,28 @@ let arm_MOVZ = define
  `arm_MOVZ (Rd:(armstate,N word)component) (imm:int16) pos =
     Rd := word (val imm * 2 EXP pos)`;;
 
+(* Only double precision is implemented *)
+(* arm_FMOV_FtoI and arm_FMOV_ItoF could not be merged
+  due to type resolution failure *)
+let arm_FMOV_FtoI = define
+ `arm_FMOV_FtoI (part:num) Rn Rd =
+    \s. let n:(128)word = read Rn s in
+        let intval:(64)word =
+          if part = 0
+          then word_subword n (0, 64)
+          else word_subword n (64, 64) in
+        (Rd := intval) s
+    `;;
+let arm_FMOV_ItoF = define
+ `arm_FMOV_ItoF (part:num) Rn Rd =
+    \s. let fltval:(64)word = read Rn s in
+        let d:(128)word = read Rd s in
+        if part = 0
+        then (Rd := word_zx fltval:(128)word) s
+        else (Rd := (word_join:(64)word->(64)word->(128)word)
+                      fltval (word_subword d (0, 64))) s
+    `;;
+
 let arm_MSUB = define
  `arm_MSUB Rd Rn Rm Ra =
     \s. let n:N word = read Rn s
@@ -1369,6 +1391,40 @@ let arm_SLI_VEC = define
           else simd16 (\ni di. word_or
               (word_shl ni shiftamnt) (word_and di (word mask))) n d in
         (Rd := d) s`;;
+
+(* SRI (vector) *)
+let arm_SRI_VEC = define
+ `arm_SRI_VEC Rd Rn shiftamnt esize datasize =
+   \s. let n:(128)word = read Rn s in
+       let d:(128)word = read Rd s in
+       let mask = (2 EXP (esize - shiftamnt)) - 1 in
+       if datasize = 128 then
+         let d:(128)word = if esize = 64 then
+             simd2 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) n d
+           else if esize = 32 then
+             simd4 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) n d
+           else if esize = 16 then
+             simd8 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) n d
+           else
+             simd16 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) n d in
+         (Rd := d) s
+       else
+         let nd:(64)word = word_subword n (0, 64) in
+         let dd:(64)word = word_subword d (0, 64) in
+         let dd:(64)word = if esize = 32 then
+             simd2 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) nd dd
+           else if esize = 16 then
+             simd4 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) nd dd
+           else
+             simd8 (\ni di. word_or
+               (word_ushr ni shiftamnt) (word_and di (word_not (word mask)))) nd dd in
+         (Rd := word_zx dd:(128)word) s`;;
 
 let arm_SHRN = define
  `arm_SHRN Rd Rn amnt esize = // esize is Rd's element size
@@ -2106,6 +2162,39 @@ let arm_ST2 = define
            (if offset_writesback off
             then Rn := word_add address (offset_writeback off)
             else (=))
+          else ASSIGNS entirety) s`;;
+
+let arm_LD1R = define
+  `arm_LD1R (Rt:(armstate,(128)word)component) Rn off esize datasize =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            (offset_writesback off ==> orthogonal_components Rt Rn)
+         then
+           (if datasize = 128 then
+              let (replicated:128 word) =
+                (if esize = 64 then
+                  word_duplicate ((read (memory :> wbytes addr) s):(64)word)
+                else if esize = 32 then
+                  word_duplicate ((read (memory :> wbytes addr) s):(32)word)
+                else if esize = 16 then
+                  word_duplicate ((read (memory :> wbytes addr) s):(16)word)
+                else
+                  word_duplicate ((read (memory :> wbytes addr) s):(8)word)) in
+              (Rt := replicated)
+            else
+              let (replicated:64 word) =
+                (if esize = 64 then read (memory :> wbytes addr) s
+                else if esize = 32 then
+                  word_duplicate ((read (memory :> wbytes addr) s):(32)word)
+                else if esize = 16 then
+                  word_duplicate ((read (memory :> wbytes addr) s):(16)word)
+                else
+                  word_duplicate ((read (memory :> wbytes addr) s):(8)word)) in
+              (Rt := (word_zx replicated):(128)word)) ,,
+            (if offset_writesback off
+             then Rn := word_add base (offset_writeback off)
+             else (=))
          else ASSIGNS entirety) s`;;
 
 (* ------------------------------------------------------------------------- *)
@@ -2659,6 +2748,7 @@ let arm_SHL_VEC_ALT =    EXPAND_SIMD_RULE arm_SHL_VEC;;
 let arm_SSHR_VEC_ALT =   EXPAND_SIMD_RULE arm_SSHR_VEC;;
 let arm_SHRN_ALT =       EXPAND_SIMD_RULE arm_SHRN;;
 let arm_SLI_VEC_ALT =    EXPAND_SIMD_RULE arm_SLI_VEC;;
+let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
 let arm_TRN1_ALT =       EXPAND_SIMD_RULE arm_TRN1;;
 let arm_TRN2_ALT =       EXPAND_SIMD_RULE arm_TRN2;;
@@ -2702,7 +2792,7 @@ let ARM_OPERATION_CLAUSES =
        arm_CSINC; arm_CSINV; arm_CSNEG;
        arm_DUP_GEN_ALT;
        arm_EON; arm_EOR; arm_EOR3; arm_EXT; arm_EXTR;
-       arm_FCSEL; arm_INS; arm_INS_GEN;
+       arm_FCSEL; arm_FMOV_FtoI; arm_FMOV_ItoF; arm_INS; arm_INS_GEN;
        arm_LSL; arm_LSLV; arm_LSR; arm_LSRV;
        arm_MADD;
        arm_MLS_VEC_ALT;
@@ -2713,7 +2803,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SBC; arm_SBCS_ALT; arm_SBFM; arm_SHL_VEC_ALT; arm_SHRN_ALT;
        arm_SRSHR_VEC_ALT;
        arm_SSHR_VEC_ALT;
-       arm_SLI_VEC_ALT; arm_SMULH;
+       arm_SLI_VEC_ALT; arm_SRI_VEC_ALT; arm_SMULH;
        arm_SQDMULH_VEC_ALT;
        arm_SQRDMULH_VEC_ALT;
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
@@ -2748,4 +2838,4 @@ let ARM_OPERATION_CLAUSES =
 let ARM_LOAD_STORE_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)
       [arm_LDR; arm_STR; arm_LDRB; arm_STRB; arm_LDP; arm_STP;
-       arm_LD2_ALT; arm_ST2_ALT];;
+       arm_LD2_ALT; arm_ST2_ALT; arm_LD1R];;

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -319,7 +319,27 @@ let cosimulate_ldst_12() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
-let memclasses = [cosimulate_ldst_12];;
+let cosimulate_ld1r() =
+  let q = Random.int 2
+  and size = Random.int 4
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  let stackoff =
+    if rn = 31 then Random.int 14 * 16
+    else Random.int 224 in
+  let stackoff' = (Int.shift_left 8 size)/8 + stackoff in
+  let code =
+    pow2 30 */ num q +/
+    pow2 12 */ num 0b001101110111111100 +/
+    pow2 10 */ num size +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 stackoff']
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
+let memclasses = [cosimulate_ldst_12; cosimulate_ld1r];;
 
 let run_random_memopsimulation() =
   let icodes = el (Random.int (length memclasses)) memclasses () in

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -133,6 +133,10 @@ let iclasses =
   "00011110001xxxxxxxxx11xxxxxxxxxx";
   "00011110011xxxxxxxxx11xxxxxxxxxx";
 
+  (*** FMOV, double precision ***)
+  "100111101010111x000000xxxxxxxxxx";
+  "100111100110011x000000xxxxxxxxxx";
+
   (*** INS, or MOV (element) ***)
   "01101110000xxxx10xxxx1xxxxxxxxxx";
   "01101110000xxx100xxxx1xxxxxxxxxx";
@@ -251,6 +255,12 @@ let iclasses =
   "011011110001xxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
   "0110111100001xxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
 
+  (*** SRI (vector) ***)
+  "0x10111101xxxxxx010001xxxxxxxxxx"; (* immh!=0 *)
+  "0x101111001xxxxx010001xxxxxxxxxx"; (* immh!=0 *)
+  "0x1011110001xxxx010001xxxxxxxxxx"; (* immh!=0 *)
+  "0x10111100001xxx010001xxxxxxxxxx"; (* immh!=0 *)
+
   (*** SUB ***)
   "01101110xx1xxxxx100001xxxxxxxxxx"; (* 128 bits *)
   "001011100x1xxxxx100001xxxxxxxxxx"; (* 64 bits, size=0 or 1 *)
@@ -318,14 +328,14 @@ let iclasses =
   "00001110100xxxxx011110xxxxxxxxxx"; (* q=0, size!=3 *)
 
   (*** EOR3 ***)
-  "11001110000xxxxx0xxxxxxxxxxxxxxx"; 
- 
+  "11001110000xxxxx0xxxxxxxxxxxxxxx";
+
 
   (*** BCAX ***)
   "11001110001xxxxx0xxxxxxxxxxxxxxx";
 
   (*** RAX1 ***)
-  "11001110011xxxxx100011xxxxxxxxxx"; 
+  "11001110011xxxxx100011xxxxxxxxxx";
 
   (*** XAR ***)
   "11001110100xxxxxxxxxxxxxxxxxxxxx";
@@ -415,6 +425,9 @@ let check_insns () =
 
     (*** st2 (2 register, Post-immediate offset) ***)
     "0x001100100111111000xxxxxxxxxxxx";
+
+    (*** ld1r (post immediate ofs) ***)
+    "0x001101110111111100xxxxxxxxxxxx";
 
     (*** stp ***)
     "x010100010xxxxxxxxxxxxxxxxxxxxxx";


### PR DESCRIPTION
*Description of changes:*

Adding a couple more Arm instructions used in SHA3 and AES-XTS:
1. LD1R post-immediate offset 
2. FMOV (general) double-precision
3. SRI (vector)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
