### PR TITLE
Enable memory operations in ARM cosimulator

### DIFF
--- a/arm/proofs/simulator.c
+++ b/arm/proofs/simulator.c
@@ -7,22 +7,27 @@
 // regs[0 ~ 31]:  X registers
 // regs[32 + 2*i]: Qi.d[0]
 // regs[32 + 2*i+1]: Qi.d[1]
-static uint64_t regs[32 + /*Q registers */2 * 32];
+// regs[96..127]: [SP,...SP+255]
+
+#define STATESIZE 128
+static uint64_t regs[STATESIZE];
 
 extern uint64_t harness(uint64_t *regfile);
 
 void print_regs()
 { uint64_t i;
   for (i = 0; i < 32; ++i)
-    printf("   %sX%ld = 0x%016lx\n",((i<10)?" ":""),i,regs[i]);
+    printf("   %sX%"PRId64" = 0x%016"PRIx64"\n",((i<10)?" ":""),i,regs[i]);
   for (i = 0; i < 32; ++i)
-    printf("   %sQ%ld.{d[0], d[1]} = { 0x%016lx, 0x%016lx }\n",((i<10)?" ":""),i,regs[32+i*2],regs[32+i*2+1]);
+    printf("   %sQ%"PRId64".{d[0], d[1]} = { 0x%016"PRIx64", 0x%016"PRIx64" }\n",((i<10)?" ":""),i,regs[32+i*2],regs[32+i*2+1]);
+  for (i = 0; i < 32; ++i)
+    printf("SP[%"PRId64"] = 0x%016"PRIx64"\n",i,regs[96+i]);
 }
 
 int main(int argc, char *argv[])
 { uint64_t retval, i;
 
-  for (i = 1; i < argc && i <= 32 + 2 * 32; ++i)
+  for (i = 1; i < argc && i <= STATESIZE; ++i)
     regs[i-1] = strtoul(argv[i],NULL,0);
 
   if (DEBUG)
@@ -33,11 +38,11 @@ int main(int argc, char *argv[])
   retval = harness(regs);
 
   if (DEBUG)
-   { printf("Called it and got %lu\n",retval);
+   { printf("Called it and got %"PRIu64"\n",retval);
      print_regs();
    }
   else
-   { for (i = 0; i < 32 + 2 * 32; ++i) printf("%lu ",regs[i]);
+   { for (i = 0; i < STATESIZE; ++i) printf("%"PRIu64" ",regs[i]);
      printf("\n");
    }
 

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -181,7 +181,7 @@ and tac_after memop =
 
 (*** Cosimulate a list of ARM instruction codes against hardware.
  *** To pass, the formal simulation has to agree with the hardware,
- *** only modify the 256-byte buffer [RSP,..,RSP+255] and also
+ *** only modify the 256-byte buffer [SP,..,SP+255] and also
  *** leave the final SP value the same as the initial value, though
  *** it can be modified in between.
  ***)

--- a/arm/proofs/template.S
+++ b/arm/proofs/template.S
@@ -3,23 +3,30 @@
 //
 //         uint64_t harness(uint64_t *regfile);
 //
-// Copies state from "regfile" into registers and flags:
+// Copies state from "regfile" into registers, flags and a small buffer
+// starting at the stack pointer.
 //
 //         X0 = regfile[0]
 //         X1 = regfile[1]
 //         ...
 //         X30 = regfile[30]
+//
 //         NF:ZF:CF:VF = regfile[31] & 0xF
+//
 //         Q0.d[0] = regfile[32]
 //         Q0.d[1] = regfile[33]
 //         ...
 //         Q31.d[1] = regfile[95]
 //
+//         [SP+0,..,SP+7] = reg[96]
+//         ...
+//         [SP+248,...,SP+255] = reg[127]
+//
 // executes the instruction at "modinst", then copies the new state
 // back into the same array, also returning new value X0 directly.
 // -------------------------------------------------------------------------
 
-        .globl  harness
+        .globl  harness, _harness
         .text
         .balign 4
 
@@ -28,8 +35,9 @@
 #define pccode x20
 
 harness:
+_harness:
 
-// Save non-modifiable input registers and input arguments on the stack
+// Save non-modifiable input registers
 
                 str     q31, [sp, -16]!
                 str     q30, [sp, -16]!
@@ -70,7 +78,46 @@ harness:
                 stp     x22, x23,  [sp, -16]!
                 stp     x20, x21,  [sp, -16]!
                 stp     x18, x19,  [sp, -16]!
+
+// Also save the "regfile" pointer on the stack
+
                 stp     x0, x1,    [sp, -16]!
+
+// Create little 256-byte buffer and copy in the contents
+
+                sub     sp, sp, #256
+                ldr     q31, [regfile, 768]
+                str     q31, [sp]
+                ldr     q31, [regfile, 768+1*16]
+                str     q31, [sp, 1*16]
+                ldr     q31, [regfile, 768+2*16]
+                str     q31, [sp, 2*16]
+                ldr     q31, [regfile, 768+3*16]
+                str     q31, [sp, 3*16]
+                ldr     q31, [regfile, 768+4*16]
+                str     q31, [sp, 4*16]
+                ldr     q31, [regfile, 768+5*16]
+                str     q31, [sp, 5*16]
+                ldr     q31, [regfile, 768+6*16]
+                str     q31, [sp, 6*16]
+                ldr     q31, [regfile, 768+7*16]
+                str     q31, [sp, 7*16]
+                ldr     q31, [regfile, 768+8*16]
+                str     q31, [sp, 8*16]
+                ldr     q31, [regfile, 768+9*16]
+                str     q31, [sp, 9*16]
+                ldr     q31, [regfile, 768+10*16]
+                str     q31, [sp, 10*16]
+                ldr     q31, [regfile, 768+11*16]
+                str     q31, [sp, 11*16]
+                ldr     q31, [regfile, 768+12*16]
+                str     q31, [sp, 12*16]
+                ldr     q31, [regfile, 768+13*16]
+                str     q31, [sp, 13*16]
+                ldr     q31, [regfile, 768+14*16]
+                str     q31, [sp, 14*16]
+                ldr     q31, [regfile, 768+15*16]
+                str     q31, [sp, 15*16]
 
 // Load new register contents from regfile (last overwrites args)
 
@@ -133,7 +180,7 @@ modinst:
 // Copy new state back to the buffer
 
                 stp     x0, x1, [sp, -16]!
-                ldr     regfile, [sp, 16]
+                ldr     regfile, [sp, 256+16]
 
                 str     q31, [regfile, 16*47]
                 str     q30, [regfile, 16*46]
@@ -192,9 +239,46 @@ modinst:
 
                 stp     x2, x3,    [regfile, 16*0]
 
+// Copy back contents of the buffer and deallocate stack
+// This includes getting rid of the space for "regfile"
+// which is still safely in  x0 now
+
+                ldr     q31, [sp]
+                str     q31, [regfile, 768]
+                ldr     q31, [sp, 1*16]
+                str     q31, [regfile, 768+1*16]
+                ldr     q31, [sp, 2*16]
+                str     q31, [regfile, 768+2*16]
+                ldr     q31, [sp, 3*16]
+                str     q31, [regfile, 768+3*16]
+                ldr     q31, [sp, 4*16]
+                str     q31, [regfile, 768+4*16]
+                ldr     q31, [sp, 5*16]
+                str     q31, [regfile, 768+5*16]
+                ldr     q31, [sp, 6*16]
+                str     q31, [regfile, 768+6*16]
+                ldr     q31, [sp, 7*16]
+                str     q31, [regfile, 768+7*16]
+                ldr     q31, [sp, 8*16]
+                str     q31, [regfile, 768+8*16]
+                ldr     q31, [sp, 9*16]
+                str     q31, [regfile, 768+9*16]
+                ldr     q31, [sp, 10*16]
+                str     q31, [regfile, 768+10*16]
+                ldr     q31, [sp, 11*16]
+                str     q31, [regfile, 768+11*16]
+                ldr     q31, [sp, 12*16]
+                str     q31, [regfile, 768+12*16]
+                ldr     q31, [sp, 13*16]
+                str     q31, [regfile, 768+13*16]
+                ldr     q31, [sp, 14*16]
+                str     q31, [regfile, 768+14*16]
+                ldr     q31, [sp, 15*16]
+                str     q31, [regfile, 768+15*16]
+                add     sp, sp, #256+16
+
 // Load back the preserved registers
 
-                add     sp, sp, 16
                 ldp     x18, x19, [sp], #16
                 ldp     x20, x21, [sp], #16
                 ldp     x22, x23, [sp], #16


### PR DESCRIPTION
This enables cosimulation of LD1/ST1/LD2/ST2 in the simulation setup as well as the existing register-to-register instructions. Adding more memory operations should now be relatively routine, although some individual coding is needed to set up self-contained stack-safe test sequences, as done for the present operations in "cosimulate_ldst_12()". The main changes to support memory operations in the simulator are:

- Factor out the main cosimulation code from the random selection of instructions, and also generalize cosimulation to accept any list of instructions, not just a single one.

- Save and check additional state during cosimulation, a 256-byte buffer at SP,...,SP+255. The stack pointer value must be the same before and after, and the results in other registers independent of that value.

- Complicate the tactics a bit in the memory case to re-express memory assignments in a way that makes sure they are applicable, in the final resort reducing everything to byte arrays.

- For memory operations, set up a self-contained test harness that satisfies the constraints above, i.e. maintains original stack pointer and does not write outside [SP],...,[SP+255], but still tests the memory operation over a good range of instances.

There are a few other minor changes that make the code slightly more portable, and in particular make it run cleanly on Mac OS using Clang there is now a "_harness" as well as "harness" entry point name for the test harness, and the printf-ing of uint64_t uses more strictly portable macros.

At the moment, about 10% of runs are the memory operations and 90% are the original register-to-register instructions. The latter should work in much the same way, with only a slight slowdown from the additional infrastructure.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
