### PR TITLE
Add microarchitectural events for Arm, bump HOL Light version

### DIFF
--- a/arm/Makefile
+++ b/arm/Makefile
@@ -496,7 +496,10 @@ tutorial/rel_veceq.native: tutorial/rel_veceq2.o
 
 unopt: $(UNOPT_OBJ)
 
-build_proofs: $(UNOPT_OBJ) $(PROOF_BINS);
+build_proofs: $(UNOPT_OBJ) $(PROOF_BINS)
+# Conservatively check that there is no redefinition of "check_axioms"
+# '-I' excludes binary files (*.native).
+	! grep -RI "check_axioms" . ../common/
 build_tutorial: $(TUTORIAL_OBJ) $(TUTORIAL_PROOF_BINS);
 run_proofs: build_proofs $(PROOF_LOGS);
 

--- a/arm/proofs/sha256.ml
+++ b/arm/proofs/sha256.ml
@@ -1,3 +1,8 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
 (** Carl Kwan: ARM SHA256 intrinsics in HOL Light **)
 
 needs "Library/words.ml";;

--- a/arm/proofs/sha512.ml
+++ b/arm/proofs/sha512.ml
@@ -1,3 +1,8 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
 (** Carl Kwan: ARM SHA512 intrinsics in HOL Light **)
 
 needs "Library/words.ml";;

--- a/codebuild/proofs.yml
+++ b/codebuild/proofs.yml
@@ -11,7 +11,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
-      - git checkout 4eef6f604636cea7e0a22d287cc015d8fd116b5f
+      - git checkout 868b802c9714be4534e9579c0ab6c0dfca73da86
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)

--- a/codebuild/sematests.yml
+++ b/codebuild/sematests.yml
@@ -14,7 +14,7 @@ phases:
       - opam init --disable-sandboxing
       # Build HOL Light
       - cd ${CODEBUILD_SRC_DIR_hol_light}
-      - git checkout 4eef6f604636cea7e0a22d287cc015d8fd116b5f
+      - git checkout 868b802c9714be4534e9579c0ab6c0dfca73da86
       - make switch-5
       - eval $(opam env)
       - echo $(ocamlc -version)

--- a/common/misc.ml
+++ b/common/misc.ml
@@ -15,17 +15,6 @@ needs "Library/rstc.ml";;
 needs "Library/words.ml";;
 
 (* ------------------------------------------------------------------------- *)
-(* A function that checks no axiom was introduced from s2n-bignum            *)
-(* ------------------------------------------------------------------------- *)
-
-let check_axioms () =
-  let basic_axioms = [INFINITY_AX; SELECT_AX; ETA_AX] in
-  let l = filter (fun th -> not (mem th basic_axioms)) (axioms()) in
-  if l <> [] then
-    let msg = "[" ^ (String.concat ", " (map string_of_thm l)) ^ "]" in
-    failwith ("Unknown axiom exists: " ^ msg);;
-
-(* ------------------------------------------------------------------------- *)
 (* Additional list operations and conversions on them.                       *)
 (* ------------------------------------------------------------------------- *)
 

--- a/x86/Makefile
+++ b/x86/Makefile
@@ -502,6 +502,9 @@ tutorial/rel_simp.native: tutorial/rel_simp2.o
 
 
 build_proofs: $(PROOF_BINS);
+# Conservatively check that there is no redefinition of "check_axioms"
+# '-I' excludes binary files (*.native).
+	! grep -RI "check_axioms" . ../common/
 build_tutorial: $(TUTORIAL_OBJ) $(TUTORIAL_PROOF_BINS);
 run_proofs: build_proofs $(PROOF_LOGS);
 


### PR DESCRIPTION
This patch adds microarchitectural events for Arm.
Even if this is not officially a component of an architectural state,
This is necessary to describe the safety of assembly programs from
side-channel attacks.
We define that an instruction raises a microarchitectural event if
its cycles/power consumption/anything that can be observed by a
traditional side-channel attacker can vary depending on the inputs of
the instruction.
Its kinds (EventLoad/Store/...) describe the events distinguishable from
each other by the attacker, and their parameters describe the values
that are inputs and/or outputs of the instructions that will affect the
observed cycles/etc.
One instruction can raise multiple events (e.g., one that reads PC from
the memory and jumps to the address, even though this case will not exist
in Arm)

This largely imports from the codebase of Abdal in his last summer internship.
There is one important difference that I added: the event on conditional
jump isn't taking its boolean condition anymore, but now the destination PC
of the jumps.
This is because Arm has a jump instruction to the PC stored in a register
(which is `RET` but we also have `arm_BL_ABSOLUTE`).
This implies that the non-interference reasoning on the event list is
slightly more complicated (it will include extra `word_add PC ...`),
but its pattern will not be too complicated I am hoping.

--

Bump HOL Light commit hash, use the upstreamed check_axioms. 

Also check that there is no redefinition of check_axiom in s2n-bignum.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
