### PR TITLE
Add MOVAPS, MOVUPS, MOVDQA, MOVDQU

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -319,61 +319,6 @@ let XREG_NE_SP = prove
   CONV_TAC(DEPTH_CONV COMPONENT_READ_OVER_WRITE_CONV) THEN
   REWRITE_TAC[WORD_NE_10]);;
 
-let NORMALIZE_ALIGNED_16_CONV =
-  let pth = prove
-   (`(!n x:int64.
-      16 divides n ==> (aligned 16 (word_add x (word n)) <=> aligned 16 x)) /\
-     (!n x:int64.
-      16 divides n ==> (aligned 16 (word_add (word n) x) <=> aligned 16 x)) /\
-     (!n x:int64.
-      16 divides n ==> (aligned 16 (word_sub x (word n)) <=> aligned 16 x)) /\
-     (!n x:int64.
-      16 divides n ==> (aligned 16 (word_sub (word n) x) <=> aligned 16 x))`,
-    REPEAT STRIP_TAC THEN FIRST (map MATCH_MP_TAC
-     (CONJUNCTS ALIGNED_WORD_ADD_EQ @ CONJUNCTS ALIGNED_WORD_SUB_EQ)) THEN
-    ASM_REWRITE_TAC[ALIGNED_WORD; DIMINDEX_64] THEN
-    CONV_TAC NUM_REDUCE_CONV THEN CONV_TAC DIVIDES_CONV) in
-  let funs = map (PART_MATCH (lhs o rand)) (CONJUNCTS pth) in
-  let conv tm =
-    try let th = tryfind (fun f -> f tm) funs in
-        MP th (EQT_ELIM(DIVIDES_CONV(lhand(concl th))))
-    with Failure _ -> failwith ""
-  and ptm = `aligned 16 :int64->bool` in
-  fun tm ->
-    if is_comb tm && rator tm = ptm then REPEATC conv tm
-    else failwith "NORMALIZE_ALIGNED_16_CONV";;
-
-let SUB_ALIGNED_16_CONV =
-  let ptm = `aligned 16 :int64->bool` in
-  let rec subconv conv tm =
-    match tm with
-    | Comb(ptm',_) when ptm' = ptm -> RAND_CONV conv tm
-    | Comb(l,r) -> COMB_CONV (subconv conv) tm
-    | Abs(x,bod) -> ABS_CONV (subconv conv) tm
-    | _ -> REFL tm in
-  subconv;;
-
-let (ALIGNED_16_TAC:tactic) =
-  let basetac =
-    CONV_TAC
-     (SUB_ALIGNED_16_CONV(TOP_DEPTH_CONV COMPONENT_READ_OVER_WRITE_CONV)) THEN
-    ASM (GEN_REWRITE_TAC
-      (LAND_CONV o SUB_ALIGNED_16_CONV o TOP_DEPTH_CONV)) [] THEN
-    CONV_TAC(ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV) THEN
-    ASSUM_LIST(fun thl ->
-      REWRITE_TAC(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) thl))
-  and trigger = vfree_in `aligned:num->int64->bool` in
-  fun (asl,w) -> if trigger w then basetac (asl,w) else ALL_TAC (asl,w);;
-
-let ALIGNED_16_CONV ths =
-  let baseconv =
-    SUB_ALIGNED_16_CONV(TOP_DEPTH_CONV COMPONENT_READ_OVER_WRITE_CONV) THENC
-    GEN_REWRITE_CONV (SUB_ALIGNED_16_CONV o TOP_DEPTH_CONV) ths THENC
-    ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV THENC
-    REWRITE_CONV(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) ths)
-  and trigger = vfree_in `aligned:num->int64->bool` in
-  fun tm -> if trigger tm then baseconv tm else REFL tm;;
-
 (* ------------------------------------------------------------------------- *)
 (* Support for the "forward symbolic execution" proof style.                 *)
 (* ------------------------------------------------------------------------- *)

--- a/arm/proofs/base.ml
+++ b/arm/proofs/base.ml
@@ -31,6 +31,7 @@ loadt "common/for_hollight.ml";;
 loadt "common/words2.ml";;
 loadt "common/misc.ml";;
 loadt "common/components.ml";;
+loadt "common/alignment.ml";;
 loadt "common/records.ml";;
 loadt "common/relational.ml";;
 loadt "common/interval.ml";;

--- a/common/alignment.ml
+++ b/common/alignment.ml
@@ -1,0 +1,63 @@
+(*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
+ *)
+
+(* ------------------------------------------------------------------------- *)
+(* Additional proof support for SP restriction to "aligned 16".              *)
+(* ------------------------------------------------------------------------- *)
+
+let NORMALIZE_ALIGNED_16_CONV =
+  let pth = prove
+   (`(!n x:int64.
+      16 divides n ==> (aligned 16 (word_add x (word n)) <=> aligned 16 x)) /\
+     (!n x:int64.
+      16 divides n ==> (aligned 16 (word_add (word n) x) <=> aligned 16 x)) /\
+     (!n x:int64.
+      16 divides n ==> (aligned 16 (word_sub x (word n)) <=> aligned 16 x)) /\
+     (!n x:int64.
+      16 divides n ==> (aligned 16 (word_sub (word n) x) <=> aligned 16 x))`,
+    REPEAT STRIP_TAC THEN FIRST (map MATCH_MP_TAC
+     (CONJUNCTS ALIGNED_WORD_ADD_EQ @ CONJUNCTS ALIGNED_WORD_SUB_EQ)) THEN
+    ASM_REWRITE_TAC[ALIGNED_WORD; DIMINDEX_64] THEN
+    CONV_TAC NUM_REDUCE_CONV THEN CONV_TAC DIVIDES_CONV) in
+  let funs = map (PART_MATCH (lhs o rand)) (CONJUNCTS pth) in
+  let conv tm =
+    try let th = tryfind (fun f -> f tm) funs in
+        MP th (EQT_ELIM(DIVIDES_CONV(lhand(concl th))))
+    with Failure _ -> failwith ""
+  and ptm = `aligned 16 :int64->bool` in
+  fun tm ->
+    if is_comb tm && rator tm = ptm then REPEATC conv tm
+    else failwith "NORMALIZE_ALIGNED_16_CONV";;
+
+let SUB_ALIGNED_16_CONV =
+  let ptm = `aligned 16 :int64->bool` in
+  let rec subconv conv tm =
+    match tm with
+    | Comb(ptm',_) when ptm' = ptm -> RAND_CONV conv tm
+    | Comb(l,r) -> COMB_CONV (subconv conv) tm
+    | Abs(x,bod) -> ABS_CONV (subconv conv) tm
+    | _ -> REFL tm in
+  subconv;;
+
+let (ALIGNED_16_TAC:tactic) =
+  let basetac =
+    CONV_TAC
+     (SUB_ALIGNED_16_CONV(TOP_DEPTH_CONV COMPONENT_READ_OVER_WRITE_CONV)) THEN
+    ASM (GEN_REWRITE_TAC
+      (LAND_CONV o SUB_ALIGNED_16_CONV o TOP_DEPTH_CONV)) [] THEN
+    CONV_TAC(ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV) THEN
+    ASSUM_LIST(fun thl ->
+      REWRITE_TAC(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) thl))
+  and trigger = vfree_in `aligned:num->int64->bool` in
+  fun (asl,w) -> if trigger w then basetac (asl,w) else ALL_TAC (asl,w);;
+
+let ALIGNED_16_CONV ths =
+  let baseconv =
+    SUB_ALIGNED_16_CONV(TOP_DEPTH_CONV COMPONENT_READ_OVER_WRITE_CONV) THENC
+    GEN_REWRITE_CONV (SUB_ALIGNED_16_CONV o TOP_DEPTH_CONV) ths THENC
+    ONCE_DEPTH_CONV NORMALIZE_ALIGNED_16_CONV THENC
+    REWRITE_CONV(mapfilter (CONV_RULE NORMALIZE_ALIGNED_16_CONV) ths)
+  and trigger = vfree_in `aligned:num->int64->bool` in
+  fun tm -> if trigger tm then baseconv tm else REFL tm;;

--- a/x86/allowed_asm
+++ b/x86/allowed_asm
@@ -49,6 +49,10 @@
 : mov$
 : movabs$
 : movabsq$
+: movaps$
+: movdqa$
+: movdqu$
+: movups$
 : movl$
 : movq$
 : movw$

--- a/x86/proofs/base.ml
+++ b/x86/proofs/base.ml
@@ -31,6 +31,7 @@ loadt "common/for_hollight.ml";;
 loadt "common/words2.ml";;
 loadt "common/misc.ml";;
 loadt "common/components.ml";;
+loadt "common/alignment.ml";;
 loadt "common/records.ml";;
 loadt "common/relational.ml";;
 loadt "common/interval.ml";;

--- a/x86/proofs/instruction.ml
+++ b/x86/proofs/instruction.ml
@@ -268,6 +268,10 @@ let instruction_INDUCTION,instruction_RECURSION = define_type
    | MOV operand operand
    | MOVSX operand operand
    | MOVZX operand operand
+   | MOVAPS operand operand
+   | MOVDQA operand operand
+   | MOVDQU operand operand
+   | MOVUPS operand operand
    | MUL2 (operand#operand) operand
    | MULX4 (operand#operand) (operand#operand)
    | NEG operand

--- a/x86/proofs/simulator.ml
+++ b/x86/proofs/simulator.ml
@@ -283,7 +283,7 @@ let template =
  `nonoverlapping (word pc,LENGTH ibytes) (stackpointer,256)
   ==> ensures x86
      (\s. bytes_loaded s (word pc) ibytes /\
-          aligned 16 stackpointer /\
+          additional_assumptions /\
           read RIP s = word pc /\
           read RSP s = stackpointer /\
           regfile s = input_state)
@@ -422,7 +422,7 @@ let decode_inst ibytes =
  *** it can be modified in between.
  ***)
 
-let cosimulate_instructions (memopidx: int option) ibytes_list =
+let cosimulate_instructions (memopidx: int option) (add_assum: bool) ibytes_list =
   let ibyte_to_icode_fn =
     fun ibyte -> (itlist (fun h t -> num h +/ num 256 */ t) (List.rev ibyte) num_0) in
   let icodes = map ibyte_to_icode_fn ibytes_list in
@@ -462,10 +462,15 @@ let cosimulate_instructions (memopidx: int option) ibytes_list =
     (* Synthesize q registers from two 64 ints *)
     let output_state = output_state_raw in
 
+    let add_assum_subst =
+      if add_assum
+      then `aligned 16 (stackpointer:int64):bool`,`additional_assumptions:bool`
+      else `T:bool`,`additional_assumptions:bool` in
     let goal = subst
       [ibyteterm,`ibytes:byte list`;
        mk_flist(map mk_numeral input_state),`input_state:num list`;
-       mk_flist(map mk_numeral output_state),`output_state:num list`]
+       mk_flist(map mk_numeral output_state),`output_state:num list`;
+       add_assum_subst]
       template in
 
     let execth = X86_MK_EXEC_RULE(REFL ibyteterm) in
@@ -502,7 +507,7 @@ let cosimulate_instructions (memopidx: int option) ibytes_list =
 
 let run_random_regsimulation () =
   let ibytes:int list = random_instruction iclasses in
-  cosimulate_instructions None [ibytes];;
+  cosimulate_instructions None false [ibytes];;
 
 (* ------------------------------------------------------------------------- *)
 (* Setting up safe self-contained tests for memory accessing instructions.   *)
@@ -733,118 +738,122 @@ let cosimulate_sse_mov_aligned_rsp_harness(pfx, opcode) =
    pfx @ rex @ opcode @ [0x4c; sib; disp*16];  (* INST [rsp + scale*rcx + displacement], imm1/9 *)
   ];;
 
+(* Each mem simulation is a pair consists of a list of instructions
+  to execute and a bool representing whether additional assumptions
+  are needed. Currently the additional assumption is for stack
+  alignment for certain instructions. *)
 let mem_iclasses = [
   (* ADC r/m64, r64 *)
-  cosimulate_mem_full_harness([0x11]);
-  cosimulate_mem_base_disp_harness([0x11]);
-  cosimulate_mem_rsp_harness([0x11]);
+  (cosimulate_mem_full_harness([0x11]), false);
+  (cosimulate_mem_base_disp_harness([0x11]), false);
+  (cosimulate_mem_rsp_harness([0x11]), false);
   (* ADC r64, r/m64 *)
-  cosimulate_mem_full_harness([0x13]);
-  cosimulate_mem_base_disp_harness([0x13]);
-  cosimulate_mem_rsp_harness([0x013]);
+  (cosimulate_mem_full_harness([0x13]), false);
+  (cosimulate_mem_base_disp_harness([0x13]), false);
+  (cosimulate_mem_rsp_harness([0x013]), false);
   (* ADD r/m64, r64 *)
-  cosimulate_mem_full_harness([0x01]);
-  cosimulate_mem_base_disp_harness([0x01]);
-  cosimulate_mem_rsp_harness([0x01]);
+  (cosimulate_mem_full_harness([0x01]), false);
+  (cosimulate_mem_base_disp_harness([0x01]), false);
+  (cosimulate_mem_rsp_harness([0x01]), false);
   (* ADD r64, r/m64 *)
-  cosimulate_mem_full_harness([0x03]);
-  cosimulate_mem_base_disp_harness([0x03]);
-  cosimulate_mem_rsp_harness([0x03]);
+  (cosimulate_mem_full_harness([0x03]), false);
+  (cosimulate_mem_base_disp_harness([0x03]), false);
+  (cosimulate_mem_rsp_harness([0x03]), false);
   (* CMOVA r64, r/m64 *)
-  cosimulate_mem_full_harness([0x0F; 0x47]);
-  cosimulate_mem_base_disp_harness([0x0F; 0x47]);
-  cosimulate_mem_rsp_harness([0x0F; 0x47]);
+  (cosimulate_mem_full_harness([0x0F; 0x47]), false);
+  (cosimulate_mem_base_disp_harness([0x0F; 0x47]), false);
+  (cosimulate_mem_rsp_harness([0x0F; 0x47]), false);
   (* CMOVB r64, r/m64 *)
-  cosimulate_mem_full_harness([0x0F; 0x42]);
-  cosimulate_mem_base_disp_harness([0x0F; 0x42]);
-  cosimulate_mem_rsp_harness([0x0F; 0x42]);
+  (cosimulate_mem_full_harness([0x0F; 0x42]), false);
+  (cosimulate_mem_base_disp_harness([0x0F; 0x42]), false);
+  (cosimulate_mem_rsp_harness([0x0F; 0x42]), false);
   (* MOV r/m64, r64 *)
-  cosimulate_mem_full_harness([0x89]);
-  cosimulate_mem_base_disp_harness([0x89]);
-  cosimulate_mem_rsp_harness([0x89]);
+  (cosimulate_mem_full_harness([0x89]), false);
+  (cosimulate_mem_base_disp_harness([0x89]), false);
+  (cosimulate_mem_rsp_harness([0x89]), false);
   (* MOV r64, r/m64 *)
-  cosimulate_mem_full_harness([0x8B]);
-  cosimulate_mem_base_disp_harness([0x8B]);
-  cosimulate_mem_rsp_harness([0x8B]);
+  (cosimulate_mem_full_harness([0x8B]), false);
+  (cosimulate_mem_base_disp_harness([0x8B]), false);
+  (cosimulate_mem_rsp_harness([0x8B]), false);
   (* MOVAPS xmm1, xmm2/m128 *)
-  cosimulate_sse_mov_aligned_full_harness([], [0x0f; 0x28]);
-  cosimulate_sse_mov_aligned_base_disp_harness([], [0x0f; 0x28]);
-  cosimulate_sse_mov_aligned_rsp_harness([], [0x0f; 0x28]);
+  (cosimulate_sse_mov_aligned_full_harness([], [0x0f; 0x28]), true);
+  (cosimulate_sse_mov_aligned_base_disp_harness([], [0x0f; 0x28]), true);
+  (cosimulate_sse_mov_aligned_rsp_harness([], [0x0f; 0x28]), true);
   (* MOVAPS xmm2/m128, xmm1 *)
-  cosimulate_sse_mov_aligned_full_harness([], [0x0f; 0x29]);
-  cosimulate_sse_mov_aligned_base_disp_harness([], [0x0f; 0x29]);
-  cosimulate_sse_mov_aligned_rsp_harness([], [0x0f; 0x29]);
+  (cosimulate_sse_mov_aligned_full_harness([], [0x0f; 0x29]), true);
+  (cosimulate_sse_mov_aligned_base_disp_harness([], [0x0f; 0x29]), true);
+  (cosimulate_sse_mov_aligned_rsp_harness([], [0x0f; 0x29]), true);
   (* MOVDQA xmm1, xmm2/m128 *)
-  cosimulate_sse_mov_aligned_full_harness([0x66], [0x0f; 0x6f]);
-  cosimulate_sse_mov_aligned_base_disp_harness([0x66], [0x0f; 0x6f]);
-  cosimulate_sse_mov_aligned_rsp_harness([0x66], [0x0f; 0x6f]);
+  (cosimulate_sse_mov_aligned_full_harness([0x66], [0x0f; 0x6f]), true);
+  (cosimulate_sse_mov_aligned_base_disp_harness([0x66], [0x0f; 0x6f]), true);
+  (cosimulate_sse_mov_aligned_rsp_harness([0x66], [0x0f; 0x6f]), true);
   (* MOVDQA xmm2/m128, xmm1 *)
-  cosimulate_sse_mov_aligned_full_harness([0x66], [0x0f; 0x7f]);
-  cosimulate_sse_mov_aligned_base_disp_harness([0x66], [0x0f; 0x7f]);
-  cosimulate_sse_mov_aligned_rsp_harness([0x66], [0x0f; 0x7f]);
+  (cosimulate_sse_mov_aligned_full_harness([0x66], [0x0f; 0x7f]), true);
+  (cosimulate_sse_mov_aligned_base_disp_harness([0x66], [0x0f; 0x7f]), true);
+  (cosimulate_sse_mov_aligned_rsp_harness([0x66], [0x0f; 0x7f]), true);
   (* MOVDQU xmm1, xmm2/m128 *)
-  cosimulate_sse_mov_unaligned_full_harness([0xf3], [0x0f; 0x6f]);
-  cosimulate_sse_mov_unaligned_base_disp_harness([0xf3], [0x0f; 0x6f]);
-  cosimulate_sse_mov_unaligned_rsp_harness([0xf3], [0x0f; 0x6f]);
+  (cosimulate_sse_mov_unaligned_full_harness([0xf3], [0x0f; 0x6f]), false);
+  (cosimulate_sse_mov_unaligned_base_disp_harness([0xf3], [0x0f; 0x6f]), false);
+  (cosimulate_sse_mov_unaligned_rsp_harness([0xf3], [0x0f; 0x6f]), false);
   (* MOVDQU xmm2/m128, xmm1 *)
-  cosimulate_sse_mov_unaligned_full_harness([0xf3], [0x0f; 0x7f]);
-  cosimulate_sse_mov_unaligned_base_disp_harness([0xf3], [0x0f; 0x7f]);
-  cosimulate_sse_mov_unaligned_rsp_harness([0xf3], [0x0f; 0x7f]);
+  (cosimulate_sse_mov_unaligned_full_harness([0xf3], [0x0f; 0x7f]), false);
+  (cosimulate_sse_mov_unaligned_base_disp_harness([0xf3], [0x0f; 0x7f]), false);
+  (cosimulate_sse_mov_unaligned_rsp_harness([0xf3], [0x0f; 0x7f]), false);
   (* MOVUPS xmm1, xmm2/m128 *)
-  cosimulate_sse_mov_unaligned_full_harness([], [0x0f; 0x10]);
-  cosimulate_sse_mov_unaligned_base_disp_harness([], [0x0f; 0x10]);
-  cosimulate_sse_mov_unaligned_rsp_harness([], [0x0f; 0x10]);
+  (cosimulate_sse_mov_unaligned_full_harness([], [0x0f; 0x10]), false);
+  (cosimulate_sse_mov_unaligned_base_disp_harness([], [0x0f; 0x10]), false);
+  (cosimulate_sse_mov_unaligned_rsp_harness([], [0x0f; 0x10]), false);
   (* MOVUPS xmm2/m128, xmm1 *)
-  cosimulate_sse_mov_unaligned_full_harness([], [0x0f; 0x11]);
-  cosimulate_sse_mov_unaligned_base_disp_harness([], [0x0f; 0x11]);
-  cosimulate_sse_mov_unaligned_rsp_harness([], [0x0f; 0x11]);
+  (cosimulate_sse_mov_unaligned_full_harness([], [0x0f; 0x11]), false);
+  (cosimulate_sse_mov_unaligned_base_disp_harness([], [0x0f; 0x11]), false);
+  (cosimulate_sse_mov_unaligned_rsp_harness([], [0x0f; 0x11]), false);
   (* MUL r/m64 *)
-  cosimulate_mul_full_harness();
-  cosimulate_mul_base_disp_harness();
-  cosimulate_mul_rsp_harness();
+  (cosimulate_mul_full_harness(), false);
+  (cosimulate_mul_base_disp_harness(), false);
+  (cosimulate_mul_rsp_harness(), false);
   (* OR r/m64, r64 *)
-  cosimulate_mem_full_harness([0x09]);
-  cosimulate_mem_base_disp_harness([0x09]);
-  cosimulate_mem_rsp_harness([0x09]);
+  (cosimulate_mem_full_harness([0x09]), false);
+  (cosimulate_mem_base_disp_harness([0x09]), false);
+  (cosimulate_mem_rsp_harness([0x09]), false);
   (* OR r64, r/m64 *)
-  cosimulate_mem_full_harness([0x0B]);
-  cosimulate_mem_base_disp_harness([0x0B]);
-  cosimulate_mem_rsp_harness([0x0B]);
+  (cosimulate_mem_full_harness([0x0B]), false);
+  (cosimulate_mem_base_disp_harness([0x0B]), false);
+  (cosimulate_mem_rsp_harness([0x0B]), false);
   (* PUSH r64 *)
-  cosimulate_push_harness();
+  (cosimulate_push_harness(), false);
   (* POP r64 *)
-  cosimulate_pop_harness();
+  (cosimulate_pop_harness(), false);
   (* SBB r/m64, r64 *)
-  cosimulate_mem_full_harness([0x19]);
-  cosimulate_mem_base_disp_harness([0x19]);
-  cosimulate_mem_rsp_harness([0x19]);
+  (cosimulate_mem_full_harness([0x19]), false);
+  (cosimulate_mem_base_disp_harness([0x19]), false);
+  (cosimulate_mem_rsp_harness([0x19]), false);
   (* SBB r64, r/m64 *)
-  cosimulate_mem_full_harness([0x1B]);
-  cosimulate_mem_base_disp_harness([0x1B]);
-  cosimulate_mem_rsp_harness([0x1B]);
+  (cosimulate_mem_full_harness([0x1B]), false);
+  (cosimulate_mem_base_disp_harness([0x1B]), false);
+  (cosimulate_mem_rsp_harness([0x1B]), false);
   (* SUB r/m64, r64 *)
-  cosimulate_mem_full_harness([0x29]);
-  cosimulate_mem_base_disp_harness([0x29]);
-  cosimulate_mem_rsp_harness([0x29]);
+  (cosimulate_mem_full_harness([0x29]), false);
+  (cosimulate_mem_base_disp_harness([0x29]), false);
+  (cosimulate_mem_rsp_harness([0x29]), false);
   (* SUB r64, r/m64 *)
-  cosimulate_mem_full_harness([0x2B]);
-  cosimulate_mem_base_disp_harness([0x2B]);
-  cosimulate_mem_rsp_harness([0x2B]);
+  (cosimulate_mem_full_harness([0x2B]), false);
+  (cosimulate_mem_base_disp_harness([0x2B]), false);
+  (cosimulate_mem_rsp_harness([0x2B]), false);
   (* XOR r/m64, r64 *)
-  cosimulate_mem_full_harness([0x31]);
-  cosimulate_mem_base_disp_harness([0x31]);
-  cosimulate_mem_rsp_harness([0x31]);
+  (cosimulate_mem_full_harness([0x31]), false);
+  (cosimulate_mem_base_disp_harness([0x31]), false);
+  (cosimulate_mem_rsp_harness([0x31]), false);
   (* XOR r64, r/m64 *)
-  cosimulate_mem_full_harness([0x33]);
-  cosimulate_mem_base_disp_harness([0x33]);
-  cosimulate_mem_rsp_harness([0x33]);
+  (cosimulate_mem_full_harness([0x33]), false);
+  (cosimulate_mem_base_disp_harness([0x33]), false);
+  (cosimulate_mem_rsp_harness([0x33]), false);
   ];;
 
 let run_random_memopsimulation() =
-  let icodes = el (Random.int (length mem_iclasses)) mem_iclasses in
+  let icodes,add_assum = el (Random.int (length mem_iclasses)) mem_iclasses in
   let _ = assert (length icodes >= 2) in
   let memop_index = length icodes - 2 in
-  cosimulate_instructions (Some memop_index) icodes;;
+  cosimulate_instructions (Some memop_index) add_assum icodes;;
 
 (* ------------------------------------------------------------------------- *)
 (* Keep running tests till a failure happens then return it.                 *)


### PR DESCRIPTION
*Description of changes:*

This PR adds SSE/SSE2 instructions `MOVAPS`, `MOVUPS`, `MOVDQA`, `MOVDQU` for AES-XTS on x86_64. Below are the detailed changes made:
1. `MOVAPS` and `MOVDQA` are 16-bytes aligned. To reason about alignment, the conversions and tactics could be reused from Arm. Therefore I copied related code from `arm/proofs/arm.ml` and created a new file in `common` called `alignment.ml` to make both `arm/proofs/base.ml` and `x86/proofs/base.ml` load it.
2. Added several harnesses for cosimulation testing of the four MOVxxx instructions. 
3. The `x86_CONV` conversion function is updated to allow handling of alignment related transformations. 
4. Added an assumption `additional_assumption` to `template`. When alignment is required for an instruction, `additional_assumption` is substituted with `align 16 stackpointer`; otherwise, it is `T`.
[OLD_VERSION: Added a precondition `aligned 16 stackpointer` to definition of `template` in x86/proofs/simulator.ml. This is a valid addition because Intel x86_86 stackpointer is 16-bytes aligned. See [Intel® 64 and IA-32 Architectures Software Developer's Manual Volume 1: Basic Architecture](https://cdrdv2.intel.com/v1/dl/getContent/671436), 6.2.2. stack alignment.]
5. Minor refactoring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
