### PR TITLE
Fix Mac ARM multiline macros

### DIFF
--- a/arm/curve25519/bignum_inv_p25519.S
+++ b/arm/curve25519/bignum_inv_p25519.S
@@ -80,618 +80,618 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_inv_p25519):

--- a/arm/curve25519/bignum_invsqrt_p25519.S
+++ b/arm/curve25519/bignum_invsqrt_p25519.S
@@ -50,23 +50,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      bignum_invsqrt_p25519_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      bignum_invsqrt_p25519_nsqr_p25519
 
 S2N_BN_SYMBOL(bignum_invsqrt_p25519):

--- a/arm/curve25519/bignum_invsqrt_p25519_alt.S
+++ b/arm/curve25519/bignum_invsqrt_p25519_alt.S
@@ -50,23 +50,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      bignum_invsqrt_p25519_alt_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      bignum_invsqrt_p25519_alt_nsqr_p25519
 
 S2N_BN_SYMBOL(bignum_invsqrt_p25519_alt):

--- a/arm/curve25519/bignum_madd_n25519.S
+++ b/arm/curve25519/bignum_madd_n25519.S
@@ -39,9 +39,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Single round of modular reduction mod_n25519, mapping
@@ -50,27 +50,27 @@
 // close to the loop body of the bignum_mod_n25519 function.
 
 #define reduce(m4,m3,m2,m1,m0)                          \
-        extr    q, m4, m3, #60;                         \
-        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
-        sub     q, q, m4, lsr #60;                      \
-        and     t0, m4, #0xF000000000000000;            \
-        add     m3, m3, t0;                             \
-        mul     t0, n0, q;                              \
-        mul     t1, n1, q;                              \
-        umulh   t2, n0, q;                              \
-        adds    t1, t1, t2;                             \
-        umulh   t2, n1, q;                              \
-        adc     t2, t2, xzr;                            \
-        subs    m0, m0, t0;                             \
-        sbcs    m1, m1, t1;                             \
-        sbcs    m2, m2, t2;                             \
-        sbcs    m3, m3, xzr;                            \
-        csel    t0, n0, xzr, cc;                        \
-        csel    t1, n1, xzr, cc;                        \
-        adds    m0, m0, t0;                             \
-        and     t2, t0, #0x1000000000000000;            \
-        adcs    m1, m1, t1;                             \
-        adcs    m2, m2, xzr;                            \
+        extr    q, m4, m3, #60 __LF                        \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF __LF           \
+        sub     q, q, m4, lsr #60 __LF                     \
+        and     t0, m4, #0xF000000000000000 __LF           \
+        add     m3, m3, t0 __LF                            \
+        mul     t0, n0, q __LF                             \
+        mul     t1, n1, q __LF                             \
+        umulh   t2, n0, q __LF                             \
+        adds    t1, t1, t2 __LF                            \
+        umulh   t2, n1, q __LF                             \
+        adc     t2, t2, xzr __LF                           \
+        subs    m0, m0, t0 __LF                            \
+        sbcs    m1, m1, t1 __LF                            \
+        sbcs    m2, m2, t2 __LF                            \
+        sbcs    m3, m3, xzr __LF                           \
+        csel    t0, n0, xzr, cc __LF                       \
+        csel    t1, n1, xzr, cc __LF                       \
+        adds    m0, m0, t0 __LF                            \
+        and     t2, t0, #0x1000000000000000 __LF           \
+        adcs    m1, m1, t1 __LF                            \
+        adcs    m2, m2, xzr __LF                           \
         adc     m3, m3, t2
 
 // Special case of "reduce" with m4 = 0. As well as not using m4,
@@ -78,24 +78,24 @@
 // versus min (floor(m/2^252)) (2^63-1).
 
 #define reduce0(m3,m2,m1,m0)                            \
-        lsr     q, m3, #60;                             \
-        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
-        mul     t0, n0, q;                              \
-        mul     t1, n1, q;                              \
-        umulh   t2, n0, q;                              \
-        adds    t1, t1, t2;                             \
-        umulh   t2, n1, q;                              \
-        adc     t2, t2, xzr;                            \
-        subs    m0, m0, t0;                             \
-        sbcs    m1, m1, t1;                             \
-        sbcs    m2, m2, t2;                             \
-        sbcs    m3, m3, xzr;                            \
-        csel    t0, n0, xzr, cc;                        \
-        csel    t1, n1, xzr, cc;                        \
-        adds    m0, m0, t0;                             \
-        and     t2, t0, #0x1000000000000000;            \
-        adcs    m1, m1, t1;                             \
-        adcs    m2, m2, xzr;                            \
+        lsr     q, m3, #60 __LF                            \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF __LF           \
+        mul     t0, n0, q __LF                             \
+        mul     t1, n1, q __LF                             \
+        umulh   t2, n0, q __LF                             \
+        adds    t1, t1, t2 __LF                            \
+        umulh   t2, n1, q __LF                             \
+        adc     t2, t2, xzr __LF                           \
+        subs    m0, m0, t0 __LF                            \
+        sbcs    m1, m1, t1 __LF                            \
+        sbcs    m2, m2, t2 __LF                            \
+        sbcs    m3, m3, xzr __LF                           \
+        csel    t0, n0, xzr, cc __LF                       \
+        csel    t1, n1, xzr, cc __LF                       \
+        adds    m0, m0, t0 __LF                            \
+        and     t2, t0, #0x1000000000000000 __LF           \
+        adcs    m1, m1, t1 __LF                            \
+        adcs    m2, m2, xzr __LF                           \
         adc     m3, m3, t2
 
 S2N_BN_SYMBOL(bignum_madd_n25519):

--- a/arm/curve25519/bignum_madd_n25519_alt.S
+++ b/arm/curve25519/bignum_madd_n25519_alt.S
@@ -39,9 +39,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Single round of modular reduction mod_n25519, mapping
@@ -50,27 +50,27 @@
 // close to the loop body of the bignum_mod_n25519 function.
 
 #define reduce(m4,m3,m2,m1,m0)                          \
-        extr    q, m4, m3, #60;                         \
-        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
-        sub     q, q, m4, lsr #60;                      \
-        and     t0, m4, #0xF000000000000000;            \
-        add     m3, m3, t0;                             \
-        mul     t0, n0, q;                              \
-        mul     t1, n1, q;                              \
-        umulh   t2, n0, q;                              \
-        adds    t1, t1, t2;                             \
-        umulh   t2, n1, q;                              \
-        adc     t2, t2, xzr;                            \
-        subs    m0, m0, t0;                             \
-        sbcs    m1, m1, t1;                             \
-        sbcs    m2, m2, t2;                             \
-        sbcs    m3, m3, xzr;                            \
-        csel    t0, n0, xzr, cc;                        \
-        csel    t1, n1, xzr, cc;                        \
-        adds    m0, m0, t0;                             \
-        and     t2, t0, #0x1000000000000000;            \
-        adcs    m1, m1, t1;                             \
-        adcs    m2, m2, xzr;                            \
+        extr    q, m4, m3, #60 __LF                        \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF __LF           \
+        sub     q, q, m4, lsr #60 __LF                     \
+        and     t0, m4, #0xF000000000000000 __LF           \
+        add     m3, m3, t0 __LF                            \
+        mul     t0, n0, q __LF                             \
+        mul     t1, n1, q __LF                             \
+        umulh   t2, n0, q __LF                             \
+        adds    t1, t1, t2 __LF                            \
+        umulh   t2, n1, q __LF                             \
+        adc     t2, t2, xzr __LF                           \
+        subs    m0, m0, t0 __LF                            \
+        sbcs    m1, m1, t1 __LF                            \
+        sbcs    m2, m2, t2 __LF                            \
+        sbcs    m3, m3, xzr __LF                           \
+        csel    t0, n0, xzr, cc __LF                       \
+        csel    t1, n1, xzr, cc __LF                       \
+        adds    m0, m0, t0 __LF                            \
+        and     t2, t0, #0x1000000000000000 __LF           \
+        adcs    m1, m1, t1 __LF                            \
+        adcs    m2, m2, xzr __LF                           \
         adc     m3, m3, t2
 
 // Special case of "reduce" with m4 = 0. As well as not using m4,
@@ -78,24 +78,24 @@
 // versus min (floor(m/2^252)) (2^63-1).
 
 #define reduce0(m3,m2,m1,m0)                            \
-        lsr     q, m3, #60;                             \
-        and     m3, m3, #0x0FFFFFFFFFFFFFFF;            \
-        mul     t0, n0, q;                              \
-        mul     t1, n1, q;                              \
-        umulh   t2, n0, q;                              \
-        adds    t1, t1, t2;                             \
-        umulh   t2, n1, q;                              \
-        adc     t2, t2, xzr;                            \
-        subs    m0, m0, t0;                             \
-        sbcs    m1, m1, t1;                             \
-        sbcs    m2, m2, t2;                             \
-        sbcs    m3, m3, xzr;                            \
-        csel    t0, n0, xzr, cc;                        \
-        csel    t1, n1, xzr, cc;                        \
-        adds    m0, m0, t0;                             \
-        and     t2, t0, #0x1000000000000000;            \
-        adcs    m1, m1, t1;                             \
-        adcs    m2, m2, xzr;                            \
+        lsr     q, m3, #60 __LF                            \
+        and     m3, m3, #0x0FFFFFFFFFFFFFFF __LF           \
+        mul     t0, n0, q __LF                             \
+        mul     t1, n1, q __LF                             \
+        umulh   t2, n0, q __LF                             \
+        adds    t1, t1, t2 __LF                            \
+        umulh   t2, n1, q __LF                             \
+        adc     t2, t2, xzr __LF                           \
+        subs    m0, m0, t0 __LF                            \
+        sbcs    m1, m1, t1 __LF                            \
+        sbcs    m2, m2, t2 __LF                            \
+        sbcs    m3, m3, xzr __LF                           \
+        csel    t0, n0, xzr, cc __LF                       \
+        csel    t1, n1, xzr, cc __LF                       \
+        adds    m0, m0, t0 __LF                            \
+        and     t2, t0, #0x1000000000000000 __LF           \
+        adcs    m1, m1, t1 __LF                            \
+        adcs    m2, m2, xzr __LF                           \
         adc     m3, m3, t2
 
 S2N_BN_SYMBOL(bignum_madd_n25519_alt):

--- a/arm/curve25519/bignum_mod_m25519_4.S
+++ b/arm/curve25519/bignum_mod_m25519_4.S
@@ -36,9 +36,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_m25519_4):

--- a/arm/curve25519/bignum_mod_n25519.S
+++ b/arm/curve25519/bignum_mod_n25519.S
@@ -45,9 +45,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n25519):

--- a/arm/curve25519/bignum_mod_n25519_4.S
+++ b/arm/curve25519/bignum_mod_n25519_4.S
@@ -39,9 +39,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n25519_4):

--- a/arm/curve25519/bignum_sqrt_p25519.S
+++ b/arm/curve25519/bignum_sqrt_p25519.S
@@ -50,23 +50,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      bignum_sqrt_p25519_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      bignum_sqrt_p25519_nsqr_p25519
 
 S2N_BN_SYMBOL(bignum_sqrt_p25519):

--- a/arm/curve25519/bignum_sqrt_p25519_alt.S
+++ b/arm/curve25519/bignum_sqrt_p25519_alt.S
@@ -50,23 +50,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      bignum_sqrt_p25519_alt_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      bignum_sqrt_p25519_alt_nsqr_p25519
 
 S2N_BN_SYMBOL(bignum_sqrt_p25519_alt):

--- a/arm/curve25519/curve25519_ladderstep.S
+++ b/arm/curve25519/curve25519_ladderstep.S
@@ -80,502 +80,502 @@
 // call to those subroutines.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 #define sqr_p25519(P0,P1)                       \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umaddl  x11, w11, w13, x11;             \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        mov     x10, #0x13;                     \
-        tst     x5, #0x8000000000000000;        \
-        csel    x10, x10, xzr, pl;              \
-        subs    x2, x2, x10;                    \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, xzr;                    \
-        sbc     x5, x5, xzr;                    \
-        and     x5, x5, #0x7fffffffffffffff;    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umaddl  x11, w11, w13, x11 __LF            \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        mov     x10, #0x13 __LF                    \
+        tst     x5, #0x8000000000000000 __LF       \
+        csel    x10, x10, xzr, pl __LF             \
+        subs    x2, x2, x10 __LF                   \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, xzr __LF                   \
+        sbc     x5, x5, xzr __LF                   \
+        and     x5, x5, #0x7fffffffffffffff __LF   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -583,150 +583,150 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umull   x11, w11, w13;                  \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umull   x11, w11, w13 __LF                 \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Plain 4-digit add without any normalization
 // With inputs < p_25519 (indeed < 2^255) it still gives a 4-digit result
 
 #define add_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x4, x5, [p2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [p1+16];                \
-        ldp     x6, x7, [p2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [p0];                   \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x4, x5, [p2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [p1+16] __LF               \
+        ldp     x6, x7, [p2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [p0] __LF                  \
         stp     x2, x3, [p0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -735,21 +735,21 @@
 // implicitly
 
 #define sub_4(p0,p1,p2)                         \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -759,41 +759,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -802,71 +802,71 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 // Paired multiplex: (w,z) := if NZ then (y,x) else (x,y)
 
 #define muxpair_4(p0,p1,p2,p3)                  \
-        ldp     x0, x1, [p2];                   \
-        ldp     x2, x3, [p3];                   \
-        csel    x4, x0, x2, eq;                 \
-        csel    x6, x0, x2, ne;                 \
-        csel    x5, x1, x3, eq;                 \
-        csel    x7, x1, x3, ne;                 \
-        stp     x4, x5, [p0];                   \
-        stp     x6, x7, [p1];                   \
-        ldp     x0, x1, [p2+16];                \
-        ldp     x2, x3, [p3+16];                \
-        csel    x4, x0, x2, eq;                 \
-        csel    x6, x0, x2, ne;                 \
-        csel    x5, x1, x3, eq;                 \
-        csel    x7, x1, x3, ne;                 \
-        stp     x4, x5, [p0+16];                \
+        ldp     x0, x1, [p2] __LF                  \
+        ldp     x2, x3, [p3] __LF                  \
+        csel    x4, x0, x2, eq __LF                \
+        csel    x6, x0, x2, ne __LF                \
+        csel    x5, x1, x3, eq __LF                \
+        csel    x7, x1, x3, ne __LF                \
+        stp     x4, x5, [p0] __LF                  \
+        stp     x6, x7, [p1] __LF                  \
+        ldp     x0, x1, [p2+16] __LF               \
+        ldp     x2, x3, [p3+16] __LF               \
+        csel    x4, x0, x2, eq __LF                \
+        csel    x6, x0, x2, ne __LF                \
+        csel    x5, x1, x3, eq __LF                \
+        csel    x7, x1, x3, ne __LF                \
+        stp     x4, x5, [p0+16] __LF               \
         stp     x6, x7, [p1+16]
 
 S2N_BN_SYMBOL(curve25519_ladderstep):

--- a/arm/curve25519/curve25519_ladderstep_alt.S
+++ b/arm/curve25519/curve25519_ladderstep_alt.S
@@ -80,284 +80,284 @@
 // call to those subroutines.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 #define sqr_p25519(P0,P1)                       \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        orr     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        madd    x7, x3, x2, x3;                 \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, xzr;                  \
-        csel    x3, x3, xzr, cc;                \
-        subs    x8, x8, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        and     x11, x11, #0x7fffffffffffffff;  \
-        stp     x8, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        orr     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        madd    x7, x3, x2, x3 __LF                \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x7fffffffffffffff __LF \
+        stp     x8, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -365,92 +365,92 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Plain 4-digit add without any normalization
 // With inputs < p_25519 (indeed < 2^255) it still gives a 4-digit result
 
 #define add_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x4, x5, [p2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [p1+16];                \
-        ldp     x6, x7, [p2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [p0];                   \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x4, x5, [p2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [p1+16] __LF               \
+        ldp     x6, x7, [p2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [p0] __LF                  \
         stp     x2, x3, [p0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -459,21 +459,21 @@
 // implicitly
 
 #define sub_4(p0,p1,p2)                         \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -483,41 +483,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -526,71 +526,71 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 // Paired multiplex: (w,z) := if NZ then (y,x) else (x,y)
 
 #define muxpair_4(p0,p1,p2,p3)                  \
-        ldp     x0, x1, [p2];                   \
-        ldp     x2, x3, [p3];                   \
-        csel    x4, x0, x2, eq;                 \
-        csel    x6, x0, x2, ne;                 \
-        csel    x5, x1, x3, eq;                 \
-        csel    x7, x1, x3, ne;                 \
-        stp     x4, x5, [p0];                   \
-        stp     x6, x7, [p1];                   \
-        ldp     x0, x1, [p2+16];                \
-        ldp     x2, x3, [p3+16];                \
-        csel    x4, x0, x2, eq;                 \
-        csel    x6, x0, x2, ne;                 \
-        csel    x5, x1, x3, eq;                 \
-        csel    x7, x1, x3, ne;                 \
-        stp     x4, x5, [p0+16];                \
+        ldp     x0, x1, [p2] __LF                  \
+        ldp     x2, x3, [p3] __LF                  \
+        csel    x4, x0, x2, eq __LF                \
+        csel    x6, x0, x2, ne __LF                \
+        csel    x5, x1, x3, eq __LF                \
+        csel    x7, x1, x3, ne __LF                \
+        stp     x4, x5, [p0] __LF                  \
+        stp     x6, x7, [p1] __LF                  \
+        ldp     x0, x1, [p2+16] __LF               \
+        ldp     x2, x3, [p3+16] __LF               \
+        csel    x4, x0, x2, eq __LF                \
+        csel    x6, x0, x2, ne __LF                \
+        csel    x5, x1, x3, eq __LF                \
+        csel    x7, x1, x3, ne __LF                \
+        stp     x4, x5, [p0+16] __LF               \
         stp     x6, x7, [p1+16]
 
 S2N_BN_SYMBOL(curve25519_ladderstep_alt):

--- a/arm/curve25519/curve25519_pxscalarmul.S
+++ b/arm/curve25519/curve25519_pxscalarmul.S
@@ -79,502 +79,502 @@
 // call to those subroutines.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 #define sqr_p25519(P0,P1)                       \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umaddl  x11, w11, w13, x11;             \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        mov     x10, #0x13;                     \
-        tst     x5, #0x8000000000000000;        \
-        csel    x10, x10, xzr, pl;              \
-        subs    x2, x2, x10;                    \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, xzr;                    \
-        sbc     x5, x5, xzr;                    \
-        and     x5, x5, #0x7fffffffffffffff;    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umaddl  x11, w11, w13, x11 __LF            \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        mov     x10, #0x13 __LF                    \
+        tst     x5, #0x8000000000000000 __LF       \
+        csel    x10, x10, xzr, pl __LF             \
+        subs    x2, x2, x10 __LF                   \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, xzr __LF                   \
+        sbc     x5, x5, xzr __LF                   \
+        and     x5, x5, #0x7fffffffffffffff __LF   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -582,150 +582,150 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umull   x11, w11, w13;                  \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umull   x11, w11, w13 __LF                 \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Plain 4-digit add without any normalization
 // With inputs < p_25519 (indeed < 2^255) it still gives a 4-digit result
 
 #define add_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x4, x5, [p2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [p1+16];                \
-        ldp     x6, x7, [p2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [p0];                   \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x4, x5, [p2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [p1+16] __LF               \
+        ldp     x6, x7, [p2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [p0] __LF                  \
         stp     x2, x3, [p0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -734,21 +734,21 @@
 // implicitly
 
 #define sub_4(p0,p1,p2)                         \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -758,41 +758,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -801,51 +801,51 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 S2N_BN_SYMBOL(curve25519_pxscalarmul):

--- a/arm/curve25519/curve25519_pxscalarmul_alt.S
+++ b/arm/curve25519/curve25519_pxscalarmul_alt.S
@@ -79,284 +79,284 @@
 // call to those subroutines.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 #define sqr_p25519(P0,P1)                       \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        orr     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        madd    x7, x3, x2, x3;                 \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, xzr;                  \
-        csel    x3, x3, xzr, cc;                \
-        subs    x8, x8, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        and     x11, x11, #0x7fffffffffffffff;  \
-        stp     x8, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        orr     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        madd    x7, x3, x2, x3 __LF                \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x7fffffffffffffff __LF \
+        stp     x8, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -364,92 +364,92 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Plain 4-digit add without any normalization
 // With inputs < p_25519 (indeed < 2^255) it still gives a 4-digit result
 
 #define add_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x4, x5, [p2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [p1+16];                \
-        ldp     x6, x7, [p2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [p0];                   \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x4, x5, [p2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [p1+16] __LF               \
+        ldp     x6, x7, [p2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [p0] __LF                  \
         stp     x2, x3, [p0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -458,21 +458,21 @@
 // implicitly
 
 #define sub_4(p0,p1,p2)                         \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -482,41 +482,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -525,51 +525,51 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 S2N_BN_SYMBOL(curve25519_pxscalarmul_alt):

--- a/arm/curve25519/curve25519_x25519_alt.S
+++ b/arm/curve25519/curve25519_x25519_alt.S
@@ -79,204 +79,204 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -284,77 +284,77 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -364,41 +364,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -407,51 +407,51 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519_alt):

--- a/arm/curve25519/curve25519_x25519_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519_byte_alt.S
@@ -79,204 +79,204 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -284,77 +284,77 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Modular addition with double modulus 2 * p_25519 = 2^256 - 38.
@@ -364,41 +364,41 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(p0,p1,p2)                    \
-        ldp     x5, x6, [p1];                   \
-        ldp     x4, x3, [p2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [p1+16];                \
-        ldp     x4, x3, [p2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [p0];                   \
+        ldp     x5, x6, [p1] __LF                  \
+        ldp     x4, x3, [p2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [p1+16] __LF               \
+        ldp     x4, x3, [p2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [p0] __LF                  \
         stp     x7, x8, [p0+16]
 
 // Combined z = c * x + y with reduction only < 2 * p_25519
@@ -407,51 +407,51 @@
 // high mul in the final part.
 
 #define cmadd_4(p0,p2,p3)                       \
-        ldp     x7, x8, [p2];                   \
-        ldp     x9, x10, [p2+16];               \
-        mul     x3, x1, x7;                     \
-        mul     x4, x1, x8;                     \
-        mul     x5, x1, x9;                     \
-        mul     x6, x1, x10;                    \
-        umulh   x7, x1, x7;                     \
-        umulh   x8, x1, x8;                     \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        adds    x4, x4, x7;                     \
-        adcs    x5, x5, x8;                     \
-        adcs    x6, x6, x9;                     \
-        adc     x10, x10, xzr;                  \
-        ldp     x7, x8, [p3];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x7, x8, [p3+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adc     x10, x10, xzr;                  \
-        cmn     x6, x6;                         \
-        bic     x6, x6, #0x8000000000000000;    \
-        adc     x8, x10, x10;                   \
-        mov     x9, #19;                        \
-        mul     x7, x8, x9;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [p0];                   \
+        ldp     x7, x8, [p2] __LF                  \
+        ldp     x9, x10, [p2+16] __LF              \
+        mul     x3, x1, x7 __LF                    \
+        mul     x4, x1, x8 __LF                    \
+        mul     x5, x1, x9 __LF                    \
+        mul     x6, x1, x10 __LF                   \
+        umulh   x7, x1, x7 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        adds    x4, x4, x7 __LF                    \
+        adcs    x5, x5, x8 __LF                    \
+        adcs    x6, x6, x9 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        ldp     x7, x8, [p3] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x7, x8, [p3+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x6, x6 __LF                        \
+        bic     x6, x6, #0x8000000000000000 __LF   \
+        adc     x8, x10, x10 __LF                  \
+        mov     x9, #19 __LF                       \
+        mul     x7, x8, x9 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [p0] __LF                  \
         stp     x5, x6, [p0+16]
 
 // Multiplex: z := if NZ then x else y
 
 #define mux_4(p0,p1,p2)                         \
-        ldp     x0, x1, [p1];                   \
-        ldp     x2, x3, [p2];                   \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
-        stp     x0, x1, [p0];                   \
-        ldp     x0, x1, [p1+16];                \
-        ldp     x2, x3, [p2+16];                \
-        csel    x0, x0, x2, ne;                 \
-        csel    x1, x1, x3, ne;                 \
+        ldp     x0, x1, [p1] __LF                  \
+        ldp     x2, x3, [p2] __LF                  \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
+        stp     x0, x1, [p0] __LF                  \
+        ldp     x0, x1, [p1+16] __LF               \
+        ldp     x2, x3, [p2+16] __LF               \
+        csel    x0, x0, x2, ne __LF                \
+        csel    x1, x1, x3, ne __LF                \
         stp     x0, x1, [p0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519_byte_alt):

--- a/arm/curve25519/curve25519_x25519base.S
+++ b/arm/curve25519/curve25519_x25519base.S
@@ -78,382 +78,382 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -463,37 +463,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519base):

--- a/arm/curve25519/curve25519_x25519base_alt.S
+++ b/arm/curve25519/curve25519_x25519base_alt.S
@@ -78,224 +78,224 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -305,37 +305,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519base_alt):

--- a/arm/curve25519/curve25519_x25519base_byte.S
+++ b/arm/curve25519/curve25519_x25519base_byte.S
@@ -78,382 +78,382 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -463,37 +463,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519base_byte):

--- a/arm/curve25519/curve25519_x25519base_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519base_byte_alt.S
@@ -78,224 +78,224 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -305,37 +305,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(curve25519_x25519base_byte_alt):

--- a/arm/curve25519/edwards25519_decode.S
+++ b/arm/curve25519/edwards25519_decode.S
@@ -59,23 +59,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      edwards25519_decode_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      edwards25519_decode_nsqr_p25519
 
 S2N_BN_SYMBOL(edwards25519_decode):

--- a/arm/curve25519/edwards25519_decode_alt.S
+++ b/arm/curve25519/edwards25519_decode_alt.S
@@ -59,23 +59,23 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macros wrapping up calls to the local subroutines
 
 #define mulp(dest,src1,src2)                                            \
-        add     x0, dest;                                               \
-        add     x1, src1;                                               \
-        add     x2, src2;                                               \
+        add     x0, dest __LF                                              \
+        add     x1, src1 __LF                                              \
+        add     x2, src2 __LF                                              \
         bl      edwards25519_decode_alt_mul_p25519
 
 #define nsqr(dest,n,src)                                                \
-        add     x0, dest;                                               \
-        mov     x1, n;                                                  \
-        add     x2, src;                                                \
+        add     x0, dest __LF                                              \
+        mov     x1, n __LF                                                 \
+        add     x2, src __LF                                               \
         bl      edwards25519_decode_alt_nsqr_p25519
 
 S2N_BN_SYMBOL(edwards25519_decode_alt):

--- a/arm/curve25519/edwards25519_epadd.S
+++ b/arm/curve25519/edwards25519_epadd.S
@@ -66,362 +66,362 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Plain 4-digit add and doubling without any normalization
@@ -429,25 +429,25 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 #define double_4(P0,P1)                         \
-        ldp     x0, x1, [P1];                   \
-        adds    x0, x0, x0;                     \
-        adcs    x1, x1, x1;                     \
-        ldp     x2, x3, [P1+16];                \
-        adcs    x2, x2, x2;                     \
-        adc     x3, x3, x3;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        adds    x0, x0, x0 __LF                    \
+        adcs    x1, x1, x1 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        adcs    x2, x2, x2 __LF                    \
+        adc     x3, x3, x3 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -456,84 +456,84 @@
 // implicitly
 
 #define sub_4(P0,P1,P2)                         \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition with inputs double modulus 2 * p_25519 = 2^256 - 38
 // and in general only guaranteeing a 4-digit result, not even < 2 * p_25519.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Load the constant k_25519 = 2 * d_25519 using immediate operations
 
 #define load_k25519(P0)                         \
-        movz    x0, #0xf159;                    \
-        movz    x1, #0xb156;                    \
-        movz    x2, #0xd130;                    \
-        movz    x3, #0xfce7;                    \
-        movk    x0, #0x26b2, lsl #16;           \
-        movk    x1, #0x8283, lsl #16;           \
-        movk    x2, #0xeef3, lsl #16;           \
-        movk    x3, #0x56df, lsl #16;           \
-        movk    x0, #0x9b94, lsl #32;           \
-        movk    x1, #0x149a, lsl #32;           \
-        movk    x2, #0x80f2, lsl #32;           \
-        movk    x3, #0xd9dc, lsl #32;           \
-        movk    x0, #0xebd6, lsl #48;           \
-        movk    x1, #0x00e0, lsl #48;           \
-        movk    x2, #0x198e, lsl #48;           \
-        movk    x3, #0x2406, lsl #48;           \
-        stp     x0, x1, [P0];                   \
+        movz    x0, #0xf159 __LF                   \
+        movz    x1, #0xb156 __LF                   \
+        movz    x2, #0xd130 __LF                   \
+        movz    x3, #0xfce7 __LF                   \
+        movk    x0, #0x26b2, lsl #16 __LF          \
+        movk    x1, #0x8283, lsl #16 __LF          \
+        movk    x2, #0xeef3, lsl #16 __LF          \
+        movk    x3, #0x56df, lsl #16 __LF          \
+        movk    x0, #0x9b94, lsl #32 __LF          \
+        movk    x1, #0x149a, lsl #32 __LF          \
+        movk    x2, #0x80f2, lsl #32 __LF          \
+        movk    x3, #0xd9dc, lsl #32 __LF          \
+        movk    x0, #0xebd6, lsl #48 __LF          \
+        movk    x1, #0x00e0, lsl #48 __LF          \
+        movk    x2, #0x198e, lsl #48 __LF          \
+        movk    x3, #0x2406, lsl #48 __LF          \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_epadd):

--- a/arm/curve25519/edwards25519_epadd_alt.S
+++ b/arm/curve25519/edwards25519_epadd_alt.S
@@ -66,204 +66,204 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Plain 4-digit add and doubling without any normalization
@@ -271,25 +271,25 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 #define double_4(P0,P1)                         \
-        ldp     x0, x1, [P1];                   \
-        adds    x0, x0, x0;                     \
-        adcs    x1, x1, x1;                     \
-        ldp     x2, x3, [P1+16];                \
-        adcs    x2, x2, x2;                     \
-        adc     x3, x3, x3;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        adds    x0, x0, x0 __LF                    \
+        adcs    x1, x1, x1 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        adcs    x2, x2, x2 __LF                    \
+        adc     x3, x3, x3 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -298,84 +298,84 @@
 // implicitly
 
 #define sub_4(P0,P1,P2)                         \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition with inputs double modulus 2 * p_25519 = 2^256 - 38
 // and in general only guaranteeing a 4-digit result, not even < 2 * p_25519.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Load the constant k_25519 = 2 * d_25519 using immediate operations
 
 #define load_k25519(P0)                         \
-        movz    x0, #0xf159;                    \
-        movz    x1, #0xb156;                    \
-        movz    x2, #0xd130;                    \
-        movz    x3, #0xfce7;                    \
-        movk    x0, #0x26b2, lsl #16;           \
-        movk    x1, #0x8283, lsl #16;           \
-        movk    x2, #0xeef3, lsl #16;           \
-        movk    x3, #0x56df, lsl #16;           \
-        movk    x0, #0x9b94, lsl #32;           \
-        movk    x1, #0x149a, lsl #32;           \
-        movk    x2, #0x80f2, lsl #32;           \
-        movk    x3, #0xd9dc, lsl #32;           \
-        movk    x0, #0xebd6, lsl #48;           \
-        movk    x1, #0x00e0, lsl #48;           \
-        movk    x2, #0x198e, lsl #48;           \
-        movk    x3, #0x2406, lsl #48;           \
-        stp     x0, x1, [P0];                   \
+        movz    x0, #0xf159 __LF                   \
+        movz    x1, #0xb156 __LF                   \
+        movz    x2, #0xd130 __LF                   \
+        movz    x3, #0xfce7 __LF                   \
+        movk    x0, #0x26b2, lsl #16 __LF          \
+        movk    x1, #0x8283, lsl #16 __LF          \
+        movk    x2, #0xeef3, lsl #16 __LF          \
+        movk    x3, #0x56df, lsl #16 __LF          \
+        movk    x0, #0x9b94, lsl #32 __LF          \
+        movk    x1, #0x149a, lsl #32 __LF          \
+        movk    x2, #0x80f2, lsl #32 __LF          \
+        movk    x3, #0xd9dc, lsl #32 __LF          \
+        movk    x0, #0xebd6, lsl #48 __LF          \
+        movk    x1, #0x00e0, lsl #48 __LF          \
+        movk    x2, #0x198e, lsl #48 __LF          \
+        movk    x3, #0x2406, lsl #48 __LF          \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_epadd_alt):

--- a/arm/curve25519/edwards25519_epdouble.S
+++ b/arm/curve25519/edwards25519_epdouble.S
@@ -61,185 +61,185 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -247,135 +247,135 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umull   x11, w11, w13;                  \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umull   x11, w11, w13 __LF                 \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Plain 4-digit adding without any normalization.
@@ -383,35 +383,35 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -421,37 +421,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_epdouble):

--- a/arm/curve25519/edwards25519_epdouble_alt.S
+++ b/arm/curve25519/edwards25519_epdouble_alt.S
@@ -61,105 +61,105 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -167,77 +167,77 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Plain 4-digit adding without any normalization.
@@ -245,35 +245,35 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -283,37 +283,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_epdouble_alt):

--- a/arm/curve25519/edwards25519_pdouble.S
+++ b/arm/curve25519/edwards25519_pdouble.S
@@ -57,185 +57,185 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -243,135 +243,135 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umull   x11, w11, w13;                  \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umull   x11, w11, w13 __LF                 \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Plain 4-digit adding without any normalization.
@@ -379,35 +379,35 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -417,37 +417,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_pdouble):

--- a/arm/curve25519/edwards25519_pdouble_alt.S
+++ b/arm/curve25519/edwards25519_pdouble_alt.S
@@ -57,105 +57,105 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -163,77 +163,77 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Plain 4-digit adding without any normalization.
@@ -241,35 +241,35 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -279,37 +279,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_pdouble_alt):

--- a/arm/curve25519/edwards25519_pepadd.S
+++ b/arm/curve25519/edwards25519_pepadd.S
@@ -67,362 +67,362 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Plain 4-digit add and doubling without any normalization
@@ -430,25 +430,25 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 #define double_4(P0,P1)                         \
-        ldp     x0, x1, [P1];                   \
-        adds    x0, x0, x0;                     \
-        adcs    x1, x1, x1;                     \
-        ldp     x2, x3, [P1+16];                \
-        adcs    x2, x2, x2;                     \
-        adc     x3, x3, x3;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        adds    x0, x0, x0 __LF                    \
+        adcs    x1, x1, x1 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        adcs    x2, x2, x2 __LF                    \
+        adc     x3, x3, x3 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -457,62 +457,62 @@
 // implicitly
 
 #define sub_4(P0,P1,P2)                         \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition with inputs double modulus 2 * p_25519 = 2^256 - 38
 // and in general only guaranteeing a 4-digit result, not even < 2 * p_25519.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_pepadd):

--- a/arm/curve25519/edwards25519_pepadd_alt.S
+++ b/arm/curve25519/edwards25519_pepadd_alt.S
@@ -67,204 +67,204 @@
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Plain 4-digit add and doubling without any normalization
@@ -272,25 +272,25 @@
 // indeed one < 2 * p_25519 for normalized inputs.
 
 #define add_4(P0,P1,P2)                         \
-        ldp     x0, x1, [P1];                   \
-        ldp     x4, x5, [P2];                   \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        ldp     x2, x3, [P1+16];                \
-        ldp     x6, x7, [P2+16];                \
-        adcs    x2, x2, x6;                     \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        ldp     x4, x5, [P2] __LF                  \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        adcs    x2, x2, x6 __LF                    \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 #define double_4(P0,P1)                         \
-        ldp     x0, x1, [P1];                   \
-        adds    x0, x0, x0;                     \
-        adcs    x1, x1, x1;                     \
-        ldp     x2, x3, [P1+16];                \
-        adcs    x2, x2, x2;                     \
-        adc     x3, x3, x3;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x0, x1, [P1] __LF                  \
+        adds    x0, x0, x0 __LF                    \
+        adcs    x1, x1, x1 __LF                    \
+        ldp     x2, x3, [P1+16] __LF               \
+        adcs    x2, x2, x2 __LF                    \
+        adc     x3, x3, x3 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // Subtraction of a pair of numbers < p_25519 just sufficient
@@ -299,62 +299,62 @@
 // implicitly
 
 #define sub_4(P0,P1,P2)                         \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x3, #19;                        \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        mov     x4, #0x8000000000000000;        \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x3, #19 __LF                       \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        mov     x4, #0x8000000000000000 __LF       \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition with inputs double modulus 2 * p_25519 = 2^256 - 38
 // and in general only guaranteeing a 4-digit result, not even < 2 * p_25519.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_pepadd_alt):

--- a/arm/curve25519/edwards25519_scalarmulbase.S
+++ b/arm/curve25519/edwards25519_scalarmulbase.S
@@ -77,391 +77,391 @@
 // Load 64-bit immediate into a register
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macro wrapping up the basic field operation bignum_mul_p25519, only
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -471,37 +471,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_scalarmulbase):

--- a/arm/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/arm/curve25519/edwards25519_scalarmulbase_alt.S
@@ -77,233 +77,233 @@
 // Load 64-bit immediate into a register
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macro wrapping up the basic field operation bignum_mul_p25519_alt, only
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -313,37 +313,37 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt):

--- a/arm/curve25519/edwards25519_scalarmuldouble.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble.S
@@ -99,371 +99,371 @@
 // Load 64-bit immediate into a register
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macro wrapping up the basic field operation bignum_mul_p25519, only
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umaddl  x5, w5, w0, x5;                 \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        mov     x3, #0x13;                      \
-        tst     x10, #0x8000000000000000;       \
-        csel    x3, x3, xzr, pl;                \
-        subs    x7, x7, x3;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        and     x10, x10, #0x7fffffffffffffff;  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umaddl  x5, w5, w0, x5 __LF                \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        tst     x10, #0x8000000000000000 __LF      \
+        csel    x3, x3, xzr, pl __LF               \
+        subs    x7, x7, x3 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        and     x10, x10, #0x7fffffffffffffff __LF \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        umull   x7, w3, w5;                     \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x8, w16, w0;                    \
-        umull   x16, w3, w16;                   \
-        adds    x7, x7, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x8, x8, x15;                    \
-        adds    x7, x7, x16, lsl #32;           \
-        lsr     x16, x16, #32;                  \
-        adc     x8, x8, x16;                    \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        umull   x11, w3, w5;                    \
-        lsr     x0, x3, #32;                    \
-        umull   x15, w0, w5;                    \
-        lsr     x16, x5, #32;                   \
-        umull   x12, w16, w0;                   \
-        umull   x16, w3, w16;                   \
-        adds    x11, x11, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x12, x12, x15;                  \
-        adds    x11, x11, x16, lsl #32;         \
-        lsr     x16, x16, #32;                  \
-        adc     x12, x12, x16;                  \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x16, cc;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, cc;                     \
-        cinv    x16, x16, cc;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, cc;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, cc;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, cc;                     \
-        csetm   x9, cc;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, cc;                     \
-        cinv    x9, x9, cc;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #0x1;                       \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #0x1;                      \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x3, #0x26;                      \
-        umull   x4, w11, w3;                    \
-        add     x4, x4, w7, uxtw;               \
-        lsr     x7, x7, #32;                    \
-        lsr     x11, x11, #32;                  \
-        umaddl  x11, w11, w3, x7;               \
-        mov     x7, x4;                         \
-        umull   x4, w12, w3;                    \
-        add     x4, x4, w8, uxtw;               \
-        lsr     x8, x8, #32;                    \
-        lsr     x12, x12, #32;                  \
-        umaddl  x12, w12, w3, x8;               \
-        mov     x8, x4;                         \
-        umull   x4, w13, w3;                    \
-        add     x4, x4, w9, uxtw;               \
-        lsr     x9, x9, #32;                    \
-        lsr     x13, x13, #32;                  \
-        umaddl  x13, w13, w3, x9;               \
-        mov     x9, x4;                         \
-        umull   x4, w14, w3;                    \
-        add     x4, x4, w10, uxtw;              \
-        lsr     x10, x10, #32;                  \
-        lsr     x14, x14, #32;                  \
-        umaddl  x14, w14, w3, x10;              \
-        mov     x10, x4;                        \
-        lsr     x0, x14, #31;                   \
-        mov     x5, #0x13;                      \
-        umull   x5, w5, w0;                     \
-        add     x7, x7, x5;                     \
-        adds    x7, x7, x11, lsl #32;           \
-        extr    x3, x12, x11, #32;              \
-        adcs    x8, x8, x3;                     \
-        extr    x3, x13, x12, #32;              \
-        adcs    x9, x9, x3;                     \
-        extr    x3, x14, x13, #32;              \
-        lsl     x5, x0, #63;                    \
-        eor     x10, x10, x5;                   \
-        adc     x10, x10, x3;                   \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        umull   x7, w3, w5 __LF                    \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x8, w16, w0 __LF                   \
+        umull   x16, w3, w16 __LF                  \
+        adds    x7, x7, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x8, x8, x15 __LF                   \
+        adds    x7, x7, x16, lsl #32 __LF          \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x8, x8, x16 __LF                   \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        umull   x11, w3, w5 __LF                   \
+        lsr     x0, x3, #32 __LF                   \
+        umull   x15, w0, w5 __LF                   \
+        lsr     x16, x5, #32 __LF                  \
+        umull   x12, w16, w0 __LF                  \
+        umull   x16, w3, w16 __LF                  \
+        adds    x11, x11, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x12, x12, x15 __LF                 \
+        adds    x11, x11, x16, lsl #32 __LF        \
+        lsr     x16, x16, #32 __LF                 \
+        adc     x12, x12, x16 __LF                 \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x16, cc __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, cc __LF                    \
+        cinv    x16, x16, cc __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, cc __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, cc __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, cc __LF                    \
+        csetm   x9, cc __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, cc __LF                    \
+        cinv    x9, x9, cc __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #0x1 __LF                      \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #0x1 __LF                     \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x3, #0x26 __LF                     \
+        umull   x4, w11, w3 __LF                   \
+        add     x4, x4, w7, uxtw __LF              \
+        lsr     x7, x7, #32 __LF                   \
+        lsr     x11, x11, #32 __LF                 \
+        umaddl  x11, w11, w3, x7 __LF              \
+        mov     x7, x4 __LF                        \
+        umull   x4, w12, w3 __LF                   \
+        add     x4, x4, w8, uxtw __LF              \
+        lsr     x8, x8, #32 __LF                   \
+        lsr     x12, x12, #32 __LF                 \
+        umaddl  x12, w12, w3, x8 __LF              \
+        mov     x8, x4 __LF                        \
+        umull   x4, w13, w3 __LF                   \
+        add     x4, x4, w9, uxtw __LF              \
+        lsr     x9, x9, #32 __LF                   \
+        lsr     x13, x13, #32 __LF                 \
+        umaddl  x13, w13, w3, x9 __LF              \
+        mov     x9, x4 __LF                        \
+        umull   x4, w14, w3 __LF                   \
+        add     x4, x4, w10, uxtw __LF             \
+        lsr     x10, x10, #32 __LF                 \
+        lsr     x14, x14, #32 __LF                 \
+        umaddl  x14, w14, w3, x10 __LF             \
+        mov     x10, x4 __LF                       \
+        lsr     x0, x14, #31 __LF                  \
+        mov     x5, #0x13 __LF                     \
+        umull   x5, w5, w0 __LF                    \
+        add     x7, x7, x5 __LF                    \
+        adds    x7, x7, x11, lsl #32 __LF          \
+        extr    x3, x12, x11, #32 __LF             \
+        adcs    x8, x8, x3 __LF                    \
+        extr    x3, x13, x12, #32 __LF             \
+        adcs    x9, x9, x3 __LF                    \
+        extr    x3, x14, x13, #32 __LF             \
+        lsl     x5, x0, #63 __LF                   \
+        eor     x10, x10, x5 __LF                  \
+        adc     x10, x10, x3 __LF                  \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -471,155 +471,155 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, cc;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, cc;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x10, #0x26;                     \
-        umull   x12, w6, w10;                   \
-        add     x12, x12, w2, uxtw;             \
-        lsr     x2, x2, #32;                    \
-        lsr     x6, x6, #32;                    \
-        umaddl  x6, w6, w10, x2;                \
-        mov     x2, x12;                        \
-        umull   x12, w7, w10;                   \
-        add     x12, x12, w3, uxtw;             \
-        lsr     x3, x3, #32;                    \
-        lsr     x7, x7, #32;                    \
-        umaddl  x7, w7, w10, x3;                \
-        mov     x3, x12;                        \
-        umull   x12, w8, w10;                   \
-        add     x12, x12, w4, uxtw;             \
-        lsr     x4, x4, #32;                    \
-        lsr     x8, x8, #32;                    \
-        umaddl  x8, w8, w10, x4;                \
-        mov     x4, x12;                        \
-        umull   x12, w9, w10;                   \
-        add     x12, x12, w5, uxtw;             \
-        lsr     x5, x5, #32;                    \
-        lsr     x9, x9, #32;                    \
-        umaddl  x9, w9, w10, x5;                \
-        mov     x5, x12;                        \
-        lsr     x13, x9, #31;                   \
-        mov     x11, #0x13;                     \
-        umull   x11, w11, w13;                  \
-        add     x2, x2, x11;                    \
-        adds    x2, x2, x6, lsl #32;            \
-        extr    x10, x7, x6, #32;               \
-        adcs    x3, x3, x10;                    \
-        extr    x10, x8, x7, #32;               \
-        adcs    x4, x4, x10;                    \
-        extr    x10, x9, x8, #32;               \
-        lsl     x11, x13, #63;                  \
-        eor     x5, x5, x11;                    \
-        adc     x5, x5, x10;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, cc __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, cc __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x10, #0x26 __LF                    \
+        umull   x12, w6, w10 __LF                  \
+        add     x12, x12, w2, uxtw __LF            \
+        lsr     x2, x2, #32 __LF                   \
+        lsr     x6, x6, #32 __LF                   \
+        umaddl  x6, w6, w10, x2 __LF               \
+        mov     x2, x12 __LF                       \
+        umull   x12, w7, w10 __LF                  \
+        add     x12, x12, w3, uxtw __LF            \
+        lsr     x3, x3, #32 __LF                   \
+        lsr     x7, x7, #32 __LF                   \
+        umaddl  x7, w7, w10, x3 __LF               \
+        mov     x3, x12 __LF                       \
+        umull   x12, w8, w10 __LF                  \
+        add     x12, x12, w4, uxtw __LF            \
+        lsr     x4, x4, #32 __LF                   \
+        lsr     x8, x8, #32 __LF                   \
+        umaddl  x8, w8, w10, x4 __LF               \
+        mov     x4, x12 __LF                       \
+        umull   x12, w9, w10 __LF                  \
+        add     x12, x12, w5, uxtw __LF            \
+        lsr     x5, x5, #32 __LF                   \
+        lsr     x9, x9, #32 __LF                   \
+        umaddl  x9, w9, w10, x5 __LF               \
+        mov     x5, x12 __LF                       \
+        lsr     x13, x9, #31 __LF                  \
+        mov     x11, #0x13 __LF                    \
+        umull   x11, w11, w13 __LF                 \
+        add     x2, x2, x11 __LF                   \
+        adds    x2, x2, x6, lsl #32 __LF           \
+        extr    x10, x7, x6, #32 __LF              \
+        adcs    x3, x3, x10 __LF                   \
+        extr    x10, x8, x7, #32 __LF              \
+        adcs    x4, x4, x10 __LF                   \
+        extr    x10, x9, x8, #32 __LF              \
+        lsl     x11, x13, #63 __LF                 \
+        eor     x5, x5, x11 __LF                   \
+        adc     x5, x5, x10 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -629,59 +629,59 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Load the constant k_25519 = 2 * d_25519 using immediate operations
 
 #define load_k25519(P0)                         \
-        movz    x0, #0xf159;                    \
-        movz    x1, #0xb156;                    \
-        movz    x2, #0xd130;                    \
-        movz    x3, #0xfce7;                    \
-        movk    x0, #0x26b2, lsl #16;           \
-        movk    x1, #0x8283, lsl #16;           \
-        movk    x2, #0xeef3, lsl #16;           \
-        movk    x3, #0x56df, lsl #16;           \
-        movk    x0, #0x9b94, lsl #32;           \
-        movk    x1, #0x149a, lsl #32;           \
-        movk    x2, #0x80f2, lsl #32;           \
-        movk    x3, #0xd9dc, lsl #32;           \
-        movk    x0, #0xebd6, lsl #48;           \
-        movk    x1, #0x00e0, lsl #48;           \
-        movk    x2, #0x198e, lsl #48;           \
-        movk    x3, #0x2406, lsl #48;           \
-        stp     x0, x1, [P0];                   \
+        movz    x0, #0xf159 __LF                   \
+        movz    x1, #0xb156 __LF                   \
+        movz    x2, #0xd130 __LF                   \
+        movz    x3, #0xfce7 __LF                   \
+        movk    x0, #0x26b2, lsl #16 __LF          \
+        movk    x1, #0x8283, lsl #16 __LF          \
+        movk    x2, #0xeef3, lsl #16 __LF          \
+        movk    x3, #0x56df, lsl #16 __LF          \
+        movk    x0, #0x9b94, lsl #32 __LF          \
+        movk    x1, #0x149a, lsl #32 __LF          \
+        movk    x2, #0x80f2, lsl #32 __LF          \
+        movk    x3, #0xd9dc, lsl #32 __LF          \
+        movk    x0, #0xebd6, lsl #48 __LF          \
+        movk    x1, #0x00e0, lsl #48 __LF          \
+        movk    x2, #0x198e, lsl #48 __LF          \
+        movk    x3, #0x2406, lsl #48 __LF          \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_scalarmuldouble):

--- a/arm/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -99,213 +99,213 @@
 // Load 64-bit immediate into a register
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // Macro wrapping up the basic field operation bignum_mul_p25519_alt, only
 // trivially different from a pure function call to that subroutine.
 
 #define mul_p25519(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        orr     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        madd    x11, x7, x8, x7;                \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x15, x15, xzr;                  \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        and     x15, x15, #0x7fffffffffffffff;  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        orr     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        madd    x11, x7, x8, x7 __LF               \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x15, x15, xzr __LF                 \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        and     x15, x15, #0x7fffffffffffffff __LF \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // A version of multiplication that only guarantees output < 2 * p_25519.
 // This basically skips the +1 and final correction in quotient estimation.
 
 #define mul_4(P0,P1,P2)                         \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x15, x3, x9;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x16, x3, x10;                   \
-        adcs    x15, x15, x11;                  \
-        adc     x16, x16, xzr;                  \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x16, x16, x11;                  \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x16, x16, x11;                  \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x5, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x5, x8;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x6, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x26;                      \
-        mul     x11, x7, x16;                   \
-        umulh   x9, x7, x16;                    \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x15, x15, x11;                  \
-        cset    x16, cs;                        \
-        adds    x15, x15, x4;                   \
-        adc     x16, x16, x5;                   \
-        cmn     x15, x15;                       \
-        bic     x15, x15, #0x8000000000000000;  \
-        adc     x8, x16, x16;                   \
-        mov     x7, #0x13;                      \
-        mul     x11, x7, x8;                    \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adc     x15, x15, xzr;                  \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x15, x3, x9 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x16, x3, x10 __LF                  \
+        adcs    x15, x15, x11 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x26 __LF                     \
+        mul     x11, x7, x16 __LF                  \
+        umulh   x9, x7, x16 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x15, x15, x11 __LF                 \
+        cset    x16, cs __LF                       \
+        adds    x15, x15, x4 __LF                  \
+        adc     x16, x16, x5 __LF                  \
+        cmn     x15, x15 __LF                      \
+        bic     x15, x15, #0x8000000000000000 __LF \
+        adc     x8, x16, x16 __LF                  \
+        mov     x7, #0x13 __LF                     \
+        mul     x11, x7, x8 __LF                   \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adc     x15, x15, xzr __LF                 \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x15, [P0+16]
 
 // Squaring just giving a result < 2 * p_25519, which is done by
@@ -313,97 +313,97 @@
 // optional correction.
 
 #define sqr_4(P0,P1)                            \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x26;                      \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        cmn     x11, x11;                       \
-        bic     x11, x11, #0x8000000000000000;  \
-        adc     x2, x12, x12;                   \
-        mov     x3, #0x13;                      \
-        mul     x7, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x26 __LF                     \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        cmn     x11, x11 __LF                      \
+        bic     x11, x11, #0x8000000000000000 __LF \
+        adc     x2, x12, x12 __LF                  \
+        mov     x3, #0x13 __LF                     \
+        mul     x7, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Modular subtraction with double modulus 2 * p_25519 = 2^256 - 38
 
 #define sub_twice4(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #38;                        \
-        csel    x3, x4, xzr, lo;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #38 __LF                       \
+        csel    x3, x4, xzr, lo __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Modular addition and doubling with double modulus 2 * p_25519 = 2^256 - 38.
@@ -413,59 +413,59 @@
 // at least one of them is reduced double modulo.
 
 #define add_twice4(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x8;                     \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2+16];                \
-        adcs    x5, x5, x7;                     \
-        adcs    x6, x6, x8;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2+16] __LF               \
+        adcs    x5, x5, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 #define double_twice4(P0,P1)                    \
-        ldp     x3, x4, [P1];                   \
-        adds    x3, x3, x3;                     \
-        adcs    x4, x4, x4;                     \
-        ldp     x5, x6, [P1+16];                \
-        adcs    x5, x5, x5;                     \
-        adcs    x6, x6, x6;                     \
-        mov     x9, #38;                        \
-        csel    x9, x9, xzr, cs;                \
-        adds    x3, x3, x9;                     \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adc     x6, x6, xzr;                    \
-        stp     x3, x4, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        adds    x3, x3, x3 __LF                    \
+        adcs    x4, x4, x4 __LF                    \
+        ldp     x5, x6, [P1+16] __LF               \
+        adcs    x5, x5, x5 __LF                    \
+        adcs    x6, x6, x6 __LF                    \
+        mov     x9, #38 __LF                       \
+        csel    x9, x9, xzr, cs __LF               \
+        adds    x3, x3, x9 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // Load the constant k_25519 = 2 * d_25519 using immediate operations
 
 #define load_k25519(P0)                         \
-        movz    x0, #0xf159;                    \
-        movz    x1, #0xb156;                    \
-        movz    x2, #0xd130;                    \
-        movz    x3, #0xfce7;                    \
-        movk    x0, #0x26b2, lsl #16;           \
-        movk    x1, #0x8283, lsl #16;           \
-        movk    x2, #0xeef3, lsl #16;           \
-        movk    x3, #0x56df, lsl #16;           \
-        movk    x0, #0x9b94, lsl #32;           \
-        movk    x1, #0x149a, lsl #32;           \
-        movk    x2, #0x80f2, lsl #32;           \
-        movk    x3, #0xd9dc, lsl #32;           \
-        movk    x0, #0xebd6, lsl #48;           \
-        movk    x1, #0x00e0, lsl #48;           \
-        movk    x2, #0x198e, lsl #48;           \
-        movk    x3, #0x2406, lsl #48;           \
-        stp     x0, x1, [P0];                   \
+        movz    x0, #0xf159 __LF                   \
+        movz    x1, #0xb156 __LF                   \
+        movz    x2, #0xd130 __LF                   \
+        movz    x3, #0xfce7 __LF                   \
+        movk    x0, #0x26b2, lsl #16 __LF          \
+        movk    x1, #0x8283, lsl #16 __LF          \
+        movk    x2, #0xeef3, lsl #16 __LF          \
+        movk    x3, #0x56df, lsl #16 __LF          \
+        movk    x0, #0x9b94, lsl #32 __LF          \
+        movk    x1, #0x149a, lsl #32 __LF          \
+        movk    x2, #0x80f2, lsl #32 __LF          \
+        movk    x3, #0xd9dc, lsl #32 __LF          \
+        movk    x0, #0xebd6, lsl #48 __LF          \
+        movk    x1, #0x00e0, lsl #48 __LF          \
+        movk    x2, #0x198e, lsl #48 __LF          \
+        movk    x3, #0x2406, lsl #48 __LF          \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt):

--- a/arm/fastmul/bignum_sqr_4_8.S
+++ b/arm/fastmul/bignum_sqr_4_8.S
@@ -22,27 +22,27 @@
 // ---------------------------------------------------------------------------
 
 #define sqr2(s3,s2,s1,s0, a1,a1short,a0,a0short, t2,t1,t0,t0short) \
-        umull   s0, a0short, a0short;           \
-        lsr     t0, a0, #32;                    \
-        umull   s1, t0short, t0short;           \
-        umull   t0, a0short, t0short;           \
-        adds    s0, s0, t0, lsl #33;            \
-        lsr     t0, t0, #31;                    \
-        adc     s1, s1, t0;                     \
-        umull   s2, a1short, a1short;           \
-        lsr     t0, a1, #32;                    \
-        umull   s3, t0short, t0short;           \
-        umull   t0, a1short, t0short;           \
-        mul     t1, a0, a1;                     \
-        umulh   t2, a0, a1;                     \
-        adds    s2, s2, t0, lsl #33;            \
-        lsr     t0, t0, #31;                    \
-        adc     s3, s3, t0;                     \
-        adds    t1, t1, t1;                     \
-        adcs    t2, t2, t2;                     \
-        adc     s3, s3, xzr;                    \
-        adds    s1, s1, t1;                     \
-        adcs    s2, s2, t2;                     \
+        umull   s0, a0short, a0short __LF          \
+        lsr     t0, a0, #32 __LF                   \
+        umull   s1, t0short, t0short __LF          \
+        umull   t0, a0short, t0short __LF          \
+        adds    s0, s0, t0, lsl #33 __LF           \
+        lsr     t0, t0, #31 __LF                   \
+        adc     s1, s1, t0 __LF                    \
+        umull   s2, a1short, a1short __LF          \
+        lsr     t0, a1, #32 __LF                   \
+        umull   s3, t0short, t0short __LF          \
+        umull   t0, a1short, t0short __LF          \
+        mul     t1, a0, a1 __LF                    \
+        umulh   t2, a0, a1 __LF                    \
+        adds    s2, s2, t0, lsl #33 __LF           \
+        lsr     t0, t0, #31 __LF                   \
+        adc     s3, s3, t0 __LF                    \
+        adds    t1, t1, t1 __LF                    \
+        adcs    t2, t2, t2 __LF                    \
+        adc     s3, s3, xzr __LF                   \
+        adds    s1, s1, t1 __LF                    \
+        adcs    s2, s2, t2 __LF                    \
         adc     s3, s3, xzr
 
 // Main code

--- a/arm/fastmul/unopt/bignum_emontredc_8n_base.S
+++ b/arm/fastmul/unopt/bignum_emontredc_8n_base.S
@@ -29,18 +29,18 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffnadd(b,a, c,h,l,t, x,y, w,z) \
-        subs    t, x, y ; \
-        cneg    t, t, cc ; \
-        csetm   c, cc ; \
-        subs    h, w, z ; \
-        cneg    h, h, cc ; \
-        mul     l, t, h ; \
-        umulh   h, t, h ; \
-        cinv    c, c, cc ; \
-        adds    xzr, c, #1 ; \
-        eor     l, l, c ; \
-        adcs    a, a, l ; \
-        eor     h, h, c ; \
+        subs    t, x, y  __LF\
+        cneg    t, t, cc  __LF\
+        csetm   c, cc  __LF\
+        subs    h, w, z  __LF\
+        cneg    h, h, cc  __LF\
+        mul     l, t, h  __LF\
+        umulh   h, t, h  __LF\
+        cinv    c, c, cc  __LF\
+        adds    xzr, c, #1  __LF\
+        eor     l, l, c  __LF\
+        adcs    a, a, l  __LF\
+        eor     h, h, c  __LF\
         adcs    b, b, h
 
 // The inputs, though k gets processed so we use a different name

--- a/arm/p256/bignum_deamont_p256.S
+++ b/arm/p256/bignum_deamont_p256.S
@@ -31,7 +31,7 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/bignum_deamont_p256.S
+++ b/arm/p256/bignum_deamont_p256.S
@@ -31,17 +31,17 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence [d4;..;d1] := [d3;d2;d1;0] + (2^256 - 2^224 + 2^192 + 2^96) * w */ \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
         adc     d4, d0, xzr
 
 // Input parameters

--- a/arm/p256/bignum_demont_p256.S
+++ b/arm/p256/bignum_demont_p256.S
@@ -31,7 +31,7 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/bignum_demont_p256.S
+++ b/arm/p256/bignum_demont_p256.S
@@ -31,17 +31,17 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence [d4;..;d1] := [d3;d2;d1;0] + (2^256 - 2^224 + 2^192 + 2^96) * w */ \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
         adc     d4, d0, xzr
 
 // Input parameters

--- a/arm/p256/bignum_inv_p256.S
+++ b/arm/p256/bignum_inv_p256.S
@@ -85,37 +85,37 @@
 #define amontred(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
 /* We only know the input is -2^316 < x < 2^316. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_256.     */      \
-        mov     t0, #0xe000000000000000;                            \
-        adds    d0, d0, t0;                                         \
-        sbcs    d1, d1, xzr;                                        \
-        mov     t1, #0x000000001fffffff;                            \
-        adcs    d2, d2, t1;                                         \
-        mov     t2, #0x2000000000000000;                            \
-        adcs    d3, d3, t2;                                         \
-        mov     t0, #0x1fffffffe0000000;                            \
-        adc     d4, d4, t0;                                         \
-/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
+        mov     t0, #0xe000000000000000 __LF                           \
+        adds    d0, d0, t0 __LF                                        \
+        sbcs    d1, d1, xzr __LF                                       \
+        mov     t1, #0x000000001fffffff __LF                           \
+        adcs    d2, d2, t1 __LF                                        \
+        mov     t2, #0x2000000000000000 __LF                           \
+        adcs    d3, d3, t2 __LF                                        \
+        mov     t0, #0x1fffffffe0000000 __LF                           \
+        adc     d4, d4, t0 __LF                                        \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence basic [d4;d3;d2;d1] += (2^256 - 2^224 + 2^192 + 2^96) * w  */      \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
-        adcs    d4, d4, d0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
+        adcs    d4, d4, d0 __LF                                        \
 /* Now capture top carry and subtract p_256 if set (almost-Montgomery) */   \
-        mov     t0, #0xffffffffffffffff;                            \
-        mov     t1, #0x00000000ffffffff;                            \
-        mov     t2, #0xffffffff00000001;                            \
-        csel    t0, t0, xzr, cs;                                    \
-        csel    t1, t1, xzr, cs;                                    \
-        csel    t2, t2, xzr, cs;                                    \
-        subs    d1, d1, t0;                                         \
-        sbcs    d2, d2, t1;                                         \
-        sbcs    d3, d3, xzr;                                        \
+        mov     t0, #0xffffffffffffffff __LF                           \
+        mov     t1, #0x00000000ffffffff __LF                           \
+        mov     t2, #0xffffffff00000001 __LF                           \
+        csel    t0, t0, xzr, cs __LF                                   \
+        csel    t1, t1, xzr, cs __LF                                   \
+        csel    t2, t2, xzr, cs __LF                                   \
+        subs    d1, d1, t0 __LF                                        \
+        sbcs    d2, d2, t1 __LF                                        \
+        sbcs    d3, d3, xzr __LF                                       \
         sbc     d4, d4, t2
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -126,610 +126,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_inv_p256):

--- a/arm/p256/bignum_inv_p256.S
+++ b/arm/p256/bignum_inv_p256.S
@@ -94,7 +94,7 @@
         adcs    d3, d3, t2 __LF                                        \
         mov     t0, #0x1fffffffe0000000 __LF                           \
         adc     d4, d4, t0 __LF                                        \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
+/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/bignum_mod_n256.S
+++ b/arm/p256/bignum_mod_n256.S
@@ -48,9 +48,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n256):

--- a/arm/p256/bignum_mod_n256_4.S
+++ b/arm/p256/bignum_mod_n256_4.S
@@ -35,9 +35,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n256_4):

--- a/arm/p256/bignum_montinv_p256.S
+++ b/arm/p256/bignum_montinv_p256.S
@@ -107,7 +107,7 @@
         adcs    d3, d3, t2 __LF                                        \
         mov     t0, #0x1fffffffe0000000 __LF                           \
         adc     d4, d4, t0 __LF                                        \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
+/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/bignum_montinv_p256.S
+++ b/arm/p256/bignum_montinv_p256.S
@@ -82,9 +82,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // ---------------------------------------------------------------------------
@@ -98,37 +98,37 @@
 #define amontred(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
 /* We only know the input is -2^316 < x < 2^316. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_256.     */      \
-        mov     t0, #0xe000000000000000;                            \
-        adds    d0, d0, t0;                                         \
-        sbcs    d1, d1, xzr;                                        \
-        mov     t1, #0x000000001fffffff;                            \
-        adcs    d2, d2, t1;                                         \
-        mov     t2, #0x2000000000000000;                            \
-        adcs    d3, d3, t2;                                         \
-        mov     t0, #0x1fffffffe0000000;                            \
-        adc     d4, d4, t0;                                         \
-/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
+        mov     t0, #0xe000000000000000 __LF                           \
+        adds    d0, d0, t0 __LF                                        \
+        sbcs    d1, d1, xzr __LF                                       \
+        mov     t1, #0x000000001fffffff __LF                           \
+        adcs    d2, d2, t1 __LF                                        \
+        mov     t2, #0x2000000000000000 __LF                           \
+        adcs    d3, d3, t2 __LF                                        \
+        mov     t0, #0x1fffffffe0000000 __LF                           \
+        adc     d4, d4, t0 __LF                                        \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence basic [d4;d3;d2;d1] += (2^256 - 2^224 + 2^192 + 2^96) * w  */      \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
-        adcs    d4, d4, d0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
+        adcs    d4, d4, d0 __LF                                        \
 /* Now capture top carry and subtract p_256 if set (almost-Montgomery) */   \
-        mov     t0, #0xffffffffffffffff;                            \
-        mov     t1, #0x00000000ffffffff;                            \
-        mov     t2, #0xffffffff00000001;                            \
-        csel    t0, t0, xzr, cs;                                    \
-        csel    t1, t1, xzr, cs;                                    \
-        csel    t2, t2, xzr, cs;                                    \
-        subs    d1, d1, t0;                                         \
-        sbcs    d2, d2, t1;                                         \
-        sbcs    d3, d3, xzr;                                        \
+        mov     t0, #0xffffffffffffffff __LF                           \
+        mov     t1, #0x00000000ffffffff __LF                           \
+        mov     t2, #0xffffffff00000001 __LF                           \
+        csel    t0, t0, xzr, cs __LF                                   \
+        csel    t1, t1, xzr, cs __LF                                   \
+        csel    t2, t2, xzr, cs __LF                                   \
+        subs    d1, d1, t0 __LF                                        \
+        sbcs    d2, d2, t1 __LF                                        \
+        sbcs    d3, d3, xzr __LF                                       \
         sbc     d4, d4, t2
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -139,610 +139,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_montinv_p256):

--- a/arm/p256/bignum_montmul_p256_alt.S
+++ b/arm/p256/bignum_montmul_p256_alt.S
@@ -31,12 +31,12 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, tmp,mc)                            \
-        adds    d1, d1, d0, lsl #32;                                \
-        lsr     tmp, d0, #32;                                       \
-        adcs    d2, d2, tmp;                                        \
-        mul     tmp, d0, mc;                                        \
-        umulh   d4, d0, mc;                                         \
-        adcs    d3, d3, tmp;                                        \
+        adds    d1, d1, d0, lsl #32 __LF                               \
+        lsr     tmp, d0, #32 __LF                                      \
+        adcs    d2, d2, tmp __LF                                       \
+        mul     tmp, d0, mc __LF                                       \
+        umulh   d4, d0, mc __LF                                        \
+        adcs    d3, d3, tmp __LF                                       \
         adc     d4, d4, xzr
 
 #define z x0

--- a/arm/p256/bignum_montsqr_p256_alt.S
+++ b/arm/p256/bignum_montsqr_p256_alt.S
@@ -30,12 +30,12 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, tmp,mc)                            \
-        adds    d1, d1, d0, lsl #32;                                \
-        lsr     tmp, d0, #32;                                       \
-        adcs    d2, d2, tmp;                                        \
-        mul     tmp, d0, mc;                                        \
-        umulh   d4, d0, mc;                                         \
-        adcs    d3, d3, tmp;                                        \
+        adds    d1, d1, d0, lsl #32 __LF                               \
+        lsr     tmp, d0, #32 __LF                                      \
+        adcs    d2, d2, tmp __LF                                       \
+        mul     tmp, d0, mc __LF                                       \
+        umulh   d4, d0, mc __LF                                        \
+        adcs    d3, d3, tmp __LF                                       \
         adc     d4, d4, xzr
 
 #define z x0

--- a/arm/p256/bignum_tomont_p256.S
+++ b/arm/p256/bignum_tomont_p256.S
@@ -28,37 +28,37 @@
 #define modstep_p256(d4, d3,d2,d1,d0, t1,t2,t3)                             \
 /* Writing the input as z = 2^256 * h + 2^192 * l + t = 2^192 * hl + t,  */ \
 /* our quotient approximation is MIN ((hl + hl>>32 + 1)>>64) (2^64 - 1). */ \
-        subs    xzr, xzr, xzr; /* Set carry flag for +1 */          \
-        extr    t3, d4, d3, #32;                                    \
-        adcs    xzr, d3, t3;                                        \
-        lsr     t3, d4, #32;                                        \
-        adcs    t3, d4, t3;                                         \
-        csetm   d0, cs;                                             \
-        orr     t3, t3, d0;                                         \
+        subs    xzr, xzr, xzr __LF/* Set carry flag for +1 */          \
+        extr    t3, d4, d3, #32 __LF                                   \
+        adcs    xzr, d3, t3 __LF                                       \
+        lsr     t3, d4, #32 __LF                                       \
+        adcs    t3, d4, t3 __LF                                        \
+        csetm   d0, cs __LF                                            \
+        orr     t3, t3, d0 __LF                                        \
 /* First do [t2;t1] = 2^32 * q, which we use twice                       */ \
-        lsl     t1, t3, #32;                                        \
-        lsr     t2, t3, #32;                                        \
+        lsl     t1, t3, #32 __LF                                       \
+        lsr     t2, t3, #32 __LF                                       \
 /* Add 2^224 * q to sum                                                  */ \
-        adds    d3, d3, t1;                                         \
-        adc     d4, d4, t2;                                         \
+        adds    d3, d3, t1 __LF                                        \
+        adc     d4, d4, t2 __LF                                        \
 /* Accumulate [t2;t1;d0] = (2^96 - 1) * q                                */ \
-        subs    d0, xzr, t3;                                        \
-        sbcs    t1, t1, xzr;                                        \
-        sbc     t2, t2, xzr;                                        \
+        subs    d0, xzr, t3 __LF                                       \
+        sbcs    t1, t1, xzr __LF                                       \
+        sbc     t2, t2, xzr __LF                                       \
 /* Subtract (2^256 + 2^192 + 2^96 - 1) * q                               */ \
-        subs    d0, xzr, d0;                                        \
-        sbcs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, t3;                                         \
+        subs    d0, xzr, d0 __LF                                       \
+        sbcs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, t3 __LF                                        \
 /* Use top word as mask to correct                                       */ \
-        adds    d0, d0, d4;                                         \
-        mov     t1, #0x00000000ffffffff;                            \
-        and     t1, t1, d4;                                         \
-        adcs    d1, d1, t1;                                         \
-        adcs    d2, d2, xzr;                                        \
-        mov     t1, #0xffffffff00000001;                            \
-        and     t1, t1, d4;                                         \
+        adds    d0, d0, d4 __LF                                        \
+        mov     t1, #0x00000000ffffffff __LF                           \
+        and     t1, t1, d4 __LF                                        \
+        adcs    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, xzr __LF                                       \
+        mov     t1, #0xffffffff00000001 __LF                           \
+        and     t1, t1, d4 __LF                                        \
         adc     d3, d3, t1
 
 #define d0 x2

--- a/arm/p256/p256_montjadd_alt.S
+++ b/arm/p256/p256_montjadd_alt.S
@@ -77,338 +77,338 @@
 // Corresponds to bignum_montmul_p256_alt except registers
 
 #define montmul_p256(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x10, #0xffffffff00000001;       \
-        adds    x13, x13, x12, lsl #32;         \
-        lsr     x11, x12, #32;                  \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x12, x10;                  \
-        umulh   x12, x12, x10;                  \
-        adcs    x0, x0, x11;                    \
-        adc     x12, x12, xzr;                  \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        adds    x14, x14, x13, lsl #32;         \
-        lsr     x11, x13, #32;                  \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x13, x10;                  \
-        umulh   x13, x13, x10;                  \
-        adcs    x12, x12, x11;                  \
-        adc     x13, x13, xzr;                  \
-        adds    x0, x0, x14, lsl #32;           \
-        lsr     x11, x14, #32;                  \
-        adcs    x12, x12, x11;                  \
-        mul     x11, x14, x10;                  \
-        umulh   x14, x14, x10;                  \
-        adcs    x13, x13, x11;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x12, x12, x0, lsl #32;          \
-        lsr     x11, x0, #32;                   \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x0, x10;                   \
-        umulh   x0, x0, x10;                    \
-        adcs    x14, x14, x11;                  \
-        adc     x0, x0, xzr;                    \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff;               \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        sbcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x10;                    \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x10, #0xffffffff00000001 __LF      \
+        adds    x13, x13, x12, lsl #32 __LF        \
+        lsr     x11, x12, #32 __LF                 \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x12, x10 __LF                 \
+        umulh   x12, x12, x10 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x12, x12, xzr __LF                 \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        adds    x14, x14, x13, lsl #32 __LF        \
+        lsr     x11, x13, #32 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x13, x10 __LF                 \
+        umulh   x13, x13, x10 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        adds    x0, x0, x14, lsl #32 __LF          \
+        lsr     x11, x14, #32 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        mul     x11, x14, x10 __LF                 \
+        umulh   x14, x14, x10 __LF                 \
+        adcs    x13, x13, x11 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x12, x12, x0, lsl #32 __LF         \
+        lsr     x11, x0, #32 __LF                  \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x0, x10 __LF                  \
+        umulh   x0, x0, x10 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        adc     x0, x0, xzr __LF                   \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff __LF              \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        sbcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x10 __LF                   \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_montsqr_p256_alt
 
 #define montsqr_p256(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        adds    x9, x9, x8, lsl #32;            \
-        lsr     x3, x8, #32;                    \
-        adcs    x10, x10, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x8, x3;                     \
-        umulh   x8, x8, x3;                     \
-        adcs    x11, x11, x2;                   \
-        adc     x8, x8, xzr;                    \
-        adds    x10, x10, x9, lsl #32;          \
-        lsr     x3, x9, #32;                    \
-        adcs    x11, x11, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x9, x3;                     \
-        umulh   x9, x9, x3;                     \
-        adcs    x8, x8, x2;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x11, x11, x10, lsl #32;         \
-        lsr     x3, x10, #32;                   \
-        adcs    x8, x8, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x10, x3;                    \
-        umulh   x10, x10, x3;                   \
-        adcs    x9, x9, x2;                     \
-        adc     x10, x10, xzr;                  \
-        adds    x8, x8, x11, lsl #32;           \
-        lsr     x3, x11, #32;                   \
-        adcs    x9, x9, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x11, x3;                    \
-        umulh   x11, x11, x3;                   \
-        adcs    x10, x10, x2;                   \
-        adc     x11, x11, xzr;                  \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, cs;                         \
-        mov     x3, #0xffffffff;                \
-        mov     x5, #0xffffffff00000001;        \
-        adds    x12, x8, #0x1;                  \
-        sbcs    x13, x9, x3;                    \
-        sbcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, cc;                \
-        csel    x9, x9, x13, cc;                \
-        csel    x10, x10, x14, cc;              \
-        csel    x11, x11, x7, cc;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        adds    x9, x9, x8, lsl #32 __LF           \
+        lsr     x3, x8, #32 __LF                   \
+        adcs    x10, x10, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x8, x3 __LF                    \
+        umulh   x8, x8, x3 __LF                    \
+        adcs    x11, x11, x2 __LF                  \
+        adc     x8, x8, xzr __LF                   \
+        adds    x10, x10, x9, lsl #32 __LF         \
+        lsr     x3, x9, #32 __LF                   \
+        adcs    x11, x11, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x9, x3 __LF                    \
+        umulh   x9, x9, x3 __LF                    \
+        adcs    x8, x8, x2 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x11, x11, x10, lsl #32 __LF        \
+        lsr     x3, x10, #32 __LF                  \
+        adcs    x8, x8, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x10, x3 __LF                   \
+        umulh   x10, x10, x3 __LF                  \
+        adcs    x9, x9, x2 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        adds    x8, x8, x11, lsl #32 __LF          \
+        lsr     x3, x11, #32 __LF                  \
+        adcs    x9, x9, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x11, x3 __LF                   \
+        umulh   x11, x11, x3 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, cs __LF                        \
+        mov     x3, #0xffffffff __LF               \
+        mov     x5, #0xffffffff00000001 __LF       \
+        adds    x12, x8, #0x1 __LF                 \
+        sbcs    x13, x9, x3 __LF                   \
+        sbcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, cc __LF               \
+        csel    x9, x9, x13, cc __LF               \
+        csel    x10, x10, x14, cc __LF             \
+        csel    x11, x11, x7, cc __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Almost-Montgomery variant which we use when an input to other muls
 // with the other argument fully reduced (which is always safe).
 
 #define amontsqr_p256(P0,P1)                    \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        adds    x9, x9, x8, lsl #32;            \
-        lsr     x3, x8, #32;                    \
-        adcs    x10, x10, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x8, x3;                     \
-        umulh   x8, x8, x3;                     \
-        adcs    x11, x11, x2;                   \
-        adc     x8, x8, xzr;                    \
-        adds    x10, x10, x9, lsl #32;          \
-        lsr     x3, x9, #32;                    \
-        adcs    x11, x11, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x9, x3;                     \
-        umulh   x9, x9, x3;                     \
-        adcs    x8, x8, x2;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x11, x11, x10, lsl #32;         \
-        lsr     x3, x10, #32;                   \
-        adcs    x8, x8, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x10, x3;                    \
-        umulh   x10, x10, x3;                   \
-        adcs    x9, x9, x2;                     \
-        adc     x10, x10, xzr;                  \
-        adds    x8, x8, x11, lsl #32;           \
-        lsr     x3, x11, #32;                   \
-        adcs    x9, x9, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x11, x3;                    \
-        umulh   x11, x11, x3;                   \
-        adcs    x10, x10, x2;                   \
-        adc     x11, x11, xzr;                  \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        mov     x2, #0xffffffffffffffff;        \
-        csel    x2, xzr, x2, cc;                \
-        mov     x3, #0xffffffff;                \
-        csel    x3, xzr, x3, cc;                \
-        mov     x5, #0xffffffff00000001;        \
-        csel    x5, xzr, x5, cc;                \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, x5;                   \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        adds    x9, x9, x8, lsl #32 __LF           \
+        lsr     x3, x8, #32 __LF                   \
+        adcs    x10, x10, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x8, x3 __LF                    \
+        umulh   x8, x8, x3 __LF                    \
+        adcs    x11, x11, x2 __LF                  \
+        adc     x8, x8, xzr __LF                   \
+        adds    x10, x10, x9, lsl #32 __LF         \
+        lsr     x3, x9, #32 __LF                   \
+        adcs    x11, x11, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x9, x3 __LF                    \
+        umulh   x9, x9, x3 __LF                    \
+        adcs    x8, x8, x2 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x11, x11, x10, lsl #32 __LF        \
+        lsr     x3, x10, #32 __LF                  \
+        adcs    x8, x8, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x10, x3 __LF                   \
+        umulh   x10, x10, x3 __LF                  \
+        adcs    x9, x9, x2 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        adds    x8, x8, x11, lsl #32 __LF          \
+        lsr     x3, x11, #32 __LF                  \
+        adcs    x9, x9, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x11, x3 __LF                   \
+        umulh   x11, x11, x3 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        mov     x2, #0xffffffffffffffff __LF       \
+        csel    x2, xzr, x2, cc __LF               \
+        mov     x3, #0xffffffff __LF               \
+        csel    x3, xzr, x3, cc __LF               \
+        mov     x5, #0xffffffff00000001 __LF       \
+        csel    x5, xzr, x5, cc __LF               \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, x5 __LF                  \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256
 
 #define sub_p256(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, xzr;                    \
-        mov     x4, #0xffffffff00000001;        \
-        and     x4, x4, x3;                     \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x4, #0xffffffff00000001 __LF       \
+        and     x4, x4, x3 __LF                    \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(p256_montjadd_alt):

--- a/arm/p256/p256_montjdouble_alt.S
+++ b/arm/p256/p256_montjdouble_alt.S
@@ -63,284 +63,284 @@
 // Corresponds exactly to bignum_montmul_p256_alt except registers
 
 #define montmul_p256(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x10, #0xffffffff00000001;       \
-        adds    x13, x13, x12, lsl #32;         \
-        lsr     x11, x12, #32;                  \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x12, x10;                  \
-        umulh   x12, x12, x10;                  \
-        adcs    x0, x0, x11;                    \
-        adc     x12, x12, xzr;                  \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        adds    x14, x14, x13, lsl #32;         \
-        lsr     x11, x13, #32;                  \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x13, x10;                  \
-        umulh   x13, x13, x10;                  \
-        adcs    x12, x12, x11;                  \
-        adc     x13, x13, xzr;                  \
-        adds    x0, x0, x14, lsl #32;           \
-        lsr     x11, x14, #32;                  \
-        adcs    x12, x12, x11;                  \
-        mul     x11, x14, x10;                  \
-        umulh   x14, x14, x10;                  \
-        adcs    x13, x13, x11;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x12, x12, x0, lsl #32;          \
-        lsr     x11, x0, #32;                   \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x0, x10;                   \
-        umulh   x0, x0, x10;                    \
-        adcs    x14, x14, x11;                  \
-        adc     x0, x0, xzr;                    \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff;               \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        sbcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x10;                    \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x10, #0xffffffff00000001 __LF      \
+        adds    x13, x13, x12, lsl #32 __LF        \
+        lsr     x11, x12, #32 __LF                 \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x12, x10 __LF                 \
+        umulh   x12, x12, x10 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x12, x12, xzr __LF                 \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        adds    x14, x14, x13, lsl #32 __LF        \
+        lsr     x11, x13, #32 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x13, x10 __LF                 \
+        umulh   x13, x13, x10 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        adds    x0, x0, x14, lsl #32 __LF          \
+        lsr     x11, x14, #32 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        mul     x11, x14, x10 __LF                 \
+        umulh   x14, x14, x10 __LF                 \
+        adcs    x13, x13, x11 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x12, x12, x0, lsl #32 __LF         \
+        lsr     x11, x0, #32 __LF                  \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x0, x10 __LF                  \
+        umulh   x0, x0, x10 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        adc     x0, x0, xzr __LF                   \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff __LF              \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        sbcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x10 __LF                   \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_montsqr_p256_alt
 
 #define montsqr_p256(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, hs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        mov     x5, #-4294967295;               \
-        adds    x9, x9, x8, lsl #32;            \
-        lsr     x3, x8, #32;                    \
-        adcs    x10, x10, x3;                   \
-        mul     x2, x8, x5;                     \
-        umulh   x8, x8, x5;                     \
-        adcs    x11, x11, x2;                   \
-        adc     x8, x8, xzr;                    \
-        adds    x10, x10, x9, lsl #32;          \
-        lsr     x3, x9, #32;                    \
-        adcs    x11, x11, x3;                   \
-        mul     x2, x9, x5;                     \
-        umulh   x9, x9, x5;                     \
-        adcs    x8, x8, x2;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x11, x11, x10, lsl #32;         \
-        lsr     x3, x10, #32;                   \
-        adcs    x8, x8, x3;                     \
-        mul     x2, x10, x5;                    \
-        umulh   x10, x10, x5;                   \
-        adcs    x9, x9, x2;                     \
-        adc     x10, x10, xzr;                  \
-        adds    x8, x8, x11, lsl #32;           \
-        lsr     x3, x11, #32;                   \
-        adcs    x9, x9, x3;                     \
-        mul     x2, x11, x5;                    \
-        umulh   x11, x11, x5;                   \
-        adcs    x10, x10, x2;                   \
-        adc     x11, x11, xzr;                  \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, hs;                         \
-        mov     x3, #4294967295;                \
-        adds    x12, x8, #1;                    \
-        sbcs    x13, x9, x3;                    \
-        sbcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, lo;                \
-        csel    x9, x9, x13, lo;                \
-        csel    x10, x10, x14, lo;              \
-        csel    x11, x11, x7, lo;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, hs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        adds    x9, x9, x8, lsl #32 __LF           \
+        lsr     x3, x8, #32 __LF                   \
+        adcs    x10, x10, x3 __LF                  \
+        mul     x2, x8, x5 __LF                    \
+        umulh   x8, x8, x5 __LF                    \
+        adcs    x11, x11, x2 __LF                  \
+        adc     x8, x8, xzr __LF                   \
+        adds    x10, x10, x9, lsl #32 __LF         \
+        lsr     x3, x9, #32 __LF                   \
+        adcs    x11, x11, x3 __LF                  \
+        mul     x2, x9, x5 __LF                    \
+        umulh   x9, x9, x5 __LF                    \
+        adcs    x8, x8, x2 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x11, x11, x10, lsl #32 __LF        \
+        lsr     x3, x10, #32 __LF                  \
+        adcs    x8, x8, x3 __LF                    \
+        mul     x2, x10, x5 __LF                   \
+        umulh   x10, x10, x5 __LF                  \
+        adcs    x9, x9, x2 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        adds    x8, x8, x11, lsl #32 __LF          \
+        lsr     x3, x11, #32 __LF                  \
+        adcs    x9, x9, x3 __LF                    \
+        mul     x2, x11, x5 __LF                   \
+        umulh   x11, x11, x5 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, hs __LF                        \
+        mov     x3, #4294967295 __LF               \
+        adds    x12, x8, #1 __LF                   \
+        sbcs    x13, x9, x3 __LF                   \
+        sbcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, lo __LF               \
+        csel    x9, x9, x13, lo __LF               \
+        csel    x10, x10, x14, lo __LF             \
+        csel    x11, x11, x7, lo __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256
 
 #define sub_p256(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, lo;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff;            \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, xzr;                    \
-        and     x4, x3, #0xffffffff00000001;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, lo __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff __LF           \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        and     x4, x3, #0xffffffff00000001 __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Corresponds exactly to bignum_add_p256
 
 #define add_p256(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        adc     x3, xzr, xzr;                   \
-        cmn     x5, #1;                         \
-        mov     x4, #4294967295;                \
-        sbcs    xzr, x6, x4;                    \
-        sbcs    xzr, x7, xzr;                   \
-        mov     x4, #-4294967295;               \
-        sbcs    xzr, x8, x4;                    \
-        adcs    x3, x3, xzr;                    \
-        csetm   x3, ne;                         \
-        subs    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff;            \
-        sbcs    x6, x6, x4;                     \
-        sbcs    x7, x7, xzr;                    \
-        and     x4, x3, #0xffffffff00000001;    \
-        sbc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        cmn     x5, #1 __LF                        \
+        mov     x4, #4294967295 __LF               \
+        sbcs    xzr, x6, x4 __LF                   \
+        sbcs    xzr, x7, xzr __LF                  \
+        mov     x4, #-4294967295 __LF              \
+        sbcs    xzr, x8, x4 __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csetm   x3, ne __LF                        \
+        subs    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff __LF           \
+        sbcs    x6, x6, x4 __LF                    \
+        sbcs    x7, x7, xzr __LF                   \
+        and     x4, x3, #0xffffffff00000001 __LF   \
+        sbc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // A weak version of add that only guarantees sum in 4 digits
 
 #define weakadd_p256(P0,P1,P2)                  \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        csetm   x3, cs;                         \
-        subs    x5, x5, x3;                     \
-        and     x1, x3, #4294967295;            \
-        sbcs    x6, x6, x1;                     \
-        sbcs    x7, x7, xzr;                    \
-        and     x2, x3, #-4294967295;           \
-        sbc     x8, x8, x2;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        csetm   x3, cs __LF                        \
+        subs    x5, x5, x3 __LF                    \
+        and     x1, x3, #4294967295 __LF           \
+        sbcs    x6, x6, x1 __LF                    \
+        sbcs    x7, x7, xzr __LF                   \
+        and     x2, x3, #-4294967295 __LF          \
+        sbc     x8, x8, x2 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // P0 = C * P1 - D * P2 computed as D * (p_256 - P2) + C * P1
@@ -348,66 +348,66 @@
 // This also applies to the other functions following.
 
 #define cmsub_p256(P0,C,P1,D,P2)                \
-        mov     x1, D;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x2, #4294967295;                \
-        sbcs    x10, x2, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, xzr, x11;                  \
-        mov     x2, #-4294967295;               \
-        sbc     x12, x2, x12;                   \
-        mul     x3, x1, x9;                     \
-        mul     x4, x1, x10;                    \
-        mul     x5, x1, x11;                    \
-        mul     x6, x1, x12;                    \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        umulh   x11, x1, x11;                   \
-        umulh   x7, x1, x12;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, xzr;                    \
-        mov     x1, C;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x8, x7, #1;                     \
-        lsl     x10, x8, #32;                   \
-        adds    x6, x6, x10;                    \
-        adc     x7, x7, xzr;                    \
-        neg     x9, x8;                         \
-        sub     x10, x10, #1;                   \
-        subs    x3, x3, x9;                     \
-        sbcs    x4, x4, x10;                    \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, x8;                     \
-        sbc     x8, x7, x8;                     \
-        adds    x3, x3, x8;                     \
-        and     x9, x8, #4294967295;            \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        neg     x10, x9;                        \
-        adc     x6, x6, x10;                    \
-        stp     x3, x4, [P0];                   \
+        mov     x1, D __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x2, #4294967295 __LF               \
+        sbcs    x10, x2, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, xzr, x11 __LF                 \
+        mov     x2, #-4294967295 __LF              \
+        sbc     x12, x2, x12 __LF                  \
+        mul     x3, x1, x9 __LF                    \
+        mul     x4, x1, x10 __LF                   \
+        mul     x5, x1, x11 __LF                   \
+        mul     x6, x1, x12 __LF                   \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        umulh   x11, x1, x11 __LF                  \
+        umulh   x7, x1, x12 __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mov     x1, C __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x8, x7, #1 __LF                    \
+        lsl     x10, x8, #32 __LF                  \
+        adds    x6, x6, x10 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        neg     x9, x8 __LF                        \
+        sub     x10, x10, #1 __LF                  \
+        subs    x3, x3, x9 __LF                    \
+        sbcs    x4, x4, x10 __LF                   \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, x8 __LF                    \
+        sbc     x8, x7, x8 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        and     x9, x8, #4294967295 __LF           \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        neg     x10, x9 __LF                       \
+        adc     x6, x6, x10 __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // P0 = 4 * P1 - P2, by direct subtraction of P2; the method
@@ -418,95 +418,95 @@
 // so it works for the q = 0 case.
 
 #define cmsub41_p256(P0,P1,P2)                  \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        lsr     x4, x4, #62;                    \
-        sbc     x4, x4, xzr;                    \
-        add     x5, x4, #1;                     \
-        lsl     x8, x5, #32;                    \
-        subs    x6, xzr, x8;                    \
-        sbcs    x7, xzr, xzr;                   \
-        sbc     x8, x8, x5;                     \
-        adds    x0, x0, x5;                     \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x8;                     \
-        csetm   x5, cc;                         \
-        adds    x0, x0, x5;                     \
-        and     x6, x5, #4294967295;            \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, xzr;                    \
-        neg     x7, x6;                         \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        lsr     x4, x4, #62 __LF                   \
+        sbc     x4, x4, xzr __LF                   \
+        add     x5, x4, #1 __LF                    \
+        lsl     x8, x5, #32 __LF                   \
+        subs    x6, xzr, x8 __LF                   \
+        sbcs    x7, xzr, xzr __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        adds    x0, x0, x5 __LF                    \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        csetm   x5, cc __LF                        \
+        adds    x0, x0, x5 __LF                    \
+        and     x6, x5, #4294967295 __LF           \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        neg     x7, x6 __LF                        \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2, computed as (p_256 - P2) << 3 + 3 * P1
 
 #define cmsub38_p256(P0,P1,P2)                  \
-        mov     x1, 8;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x2, #4294967295;                \
-        sbcs    x10, x2, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, xzr, x11;                  \
-        mov     x2, #-4294967295;               \
-        sbc     x12, x2, x12;                   \
-        lsl     x3, x9, #3;                     \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        extr    x6, x12, x11, #61;              \
-        lsr     x7, x12, #61;                   \
-        mov     x1, 3;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x8, x7, #1;                     \
-        lsl     x10, x8, #32;                   \
-        adds    x6, x6, x10;                    \
-        adc     x7, x7, xzr;                    \
-        neg     x9, x8;                         \
-        sub     x10, x10, #1;                   \
-        subs    x3, x3, x9;                     \
-        sbcs    x4, x4, x10;                    \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, x8;                     \
-        sbc     x8, x7, x8;                     \
-        adds    x3, x3, x8;                     \
-        and     x9, x8, #4294967295;            \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        neg     x10, x9;                        \
-        adc     x6, x6, x10;                    \
-        stp     x3, x4, [P0];                   \
+        mov     x1, 8 __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x2, #4294967295 __LF               \
+        sbcs    x10, x2, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, xzr, x11 __LF                 \
+        mov     x2, #-4294967295 __LF              \
+        sbc     x12, x2, x12 __LF                  \
+        lsl     x3, x9, #3 __LF                    \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        extr    x6, x12, x11, #61 __LF             \
+        lsr     x7, x12, #61 __LF                  \
+        mov     x1, 3 __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x8, x7, #1 __LF                    \
+        lsl     x10, x8, #32 __LF                  \
+        adds    x6, x6, x10 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        neg     x9, x8 __LF                        \
+        sub     x10, x10, #1 __LF                  \
+        subs    x3, x3, x9 __LF                    \
+        sbcs    x4, x4, x10 __LF                   \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, x8 __LF                    \
+        sbc     x8, x7, x8 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        and     x9, x8, #4294967295 __LF           \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        neg     x10, x9 __LF                       \
+        adc     x6, x6, x10 __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(p256_montjdouble_alt):

--- a/arm/p256/p256_montjmixadd.S
+++ b/arm/p256/p256_montjmixadd.S
@@ -74,331 +74,331 @@
 // Corresponds to bignum_montmul_p256 but uses x0 in place of x17
 
 #define montmul_p256(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2];                   \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x3, x4;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        lsl     x0, x11, #32;                   \
-        subs    x1, x11, x0;                    \
-        lsr     x16, x11, #32;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x12, x12, x0;                   \
-        adcs    x13, x13, x16;                  \
-        adcs    x14, x14, x1;                   \
-        adc     x11, x11, xzr;                  \
-        lsl     x0, x12, #32;                   \
-        subs    x1, x12, x0;                    \
-        lsr     x16, x12, #32;                  \
-        sbc     x12, x12, x16;                  \
-        adds    x13, x13, x0;                   \
-        adcs    x14, x14, x16;                  \
-        adcs    x11, x11, x1;                   \
-        adc     x12, x12, xzr;                  \
-        stp     x13, x14, [P0];                 \
-        stp     x11, x12, [P0+16];              \
-        mul     x11, x5, x9;                    \
-        mul     x13, x6, x10;                   \
-        umulh   x12, x5, x9;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x6, x10;                   \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x5, x6;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x10, x9;                    \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        subs    x3, x5, x3;                     \
-        sbcs    x4, x6, x4;                     \
-        ngc     x5, xzr;                        \
-        cmn     x5, #1;                         \
-        eor     x3, x3, x5;                     \
-        adcs    x3, x3, xzr;                    \
-        eor     x4, x4, x5;                     \
-        adcs    x4, x4, xzr;                    \
-        subs    x7, x7, x9;                     \
-        sbcs    x8, x8, x10;                    \
-        ngc     x9, xzr;                        \
-        cmn     x9, #1;                         \
-        eor     x7, x7, x9;                     \
-        adcs    x7, x7, xzr;                    \
-        eor     x8, x8, x9;                     \
-        adcs    x8, x8, xzr;                    \
-        eor     x10, x5, x9;                    \
-        ldp     x15, x1, [P0];                  \
-        adds    x15, x11, x15;                  \
-        adcs    x1, x12, x1;                    \
-        ldp     x5, x9, [P0+16];                \
-        adcs    x5, x13, x5;                    \
-        adcs    x9, x14, x9;                    \
-        adc     x2, xzr, xzr;                   \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x3, x3, x4;                     \
-        cneg    x3, x3, lo;                     \
-        csetm   x4, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x3, x0;                    \
-        umulh   x0, x3, x0;                     \
-        cinv    x4, x4, lo;                     \
-        eor     x16, x16, x4;                   \
-        eor     x0, x0, x4;                     \
-        cmn     x4, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x4;                   \
-        cmn     x10, #1;                        \
-        eor     x11, x11, x10;                  \
-        adcs    x11, x11, x15;                  \
-        eor     x12, x12, x10;                  \
-        adcs    x12, x12, x1;                   \
-        eor     x13, x13, x10;                  \
-        adcs    x13, x13, x5;                   \
-        eor     x14, x14, x10;                  \
-        adcs    x14, x14, x9;                   \
-        adcs    x3, x2, x10;                    \
-        adcs    x4, x10, xzr;                   \
-        adc     x10, x10, xzr;                  \
-        adds    x13, x13, x15;                  \
-        adcs    x14, x14, x1;                   \
-        adcs    x3, x3, x5;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x10, x10, x2;                   \
-        lsl     x0, x11, #32;                   \
-        subs    x1, x11, x0;                    \
-        lsr     x16, x11, #32;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x12, x12, x0;                   \
-        adcs    x13, x13, x16;                  \
-        adcs    x14, x14, x1;                   \
-        adc     x11, x11, xzr;                  \
-        lsl     x0, x12, #32;                   \
-        subs    x1, x12, x0;                    \
-        lsr     x16, x12, #32;                  \
-        sbc     x12, x12, x16;                  \
-        adds    x13, x13, x0;                   \
-        adcs    x14, x14, x16;                  \
-        adcs    x11, x11, x1;                   \
-        adc     x12, x12, xzr;                  \
-        adds    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adc     x10, x10, xzr;                  \
-        add     x2, x10, #1;                    \
-        lsl     x16, x2, #32;                   \
-        adds    x4, x4, x16;                    \
-        adc     x10, x10, xzr;                  \
-        neg     x15, x2;                        \
-        sub     x16, x16, #1;                   \
-        subs    x13, x13, x15;                  \
-        sbcs    x14, x14, x16;                  \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, x2;                     \
-        sbcs    x7, x10, x2;                    \
-        adds    x13, x13, x7;                   \
-        mov     x10, #4294967295;               \
-        and     x10, x10, x7;                   \
-        adcs    x14, x14, x10;                  \
-        adcs    x3, x3, xzr;                    \
-        mov     x10, #-4294967295;              \
-        and     x10, x10, x7;                   \
-        adc     x4, x4, x10;                    \
-        stp     x13, x14, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2] __LF                  \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x3, x4 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        lsl     x0, x11, #32 __LF                  \
+        subs    x1, x11, x0 __LF                   \
+        lsr     x16, x11, #32 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x12, x12, x0 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        lsl     x0, x12, #32 __LF                  \
+        subs    x1, x12, x0 __LF                   \
+        lsr     x16, x12, #32 __LF                 \
+        sbc     x12, x12, x16 __LF                 \
+        adds    x13, x13, x0 __LF                  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x11, x11, x1 __LF                  \
+        adc     x12, x12, xzr __LF                 \
+        stp     x13, x14, [P0] __LF                \
+        stp     x11, x12, [P0+16] __LF             \
+        mul     x11, x5, x9 __LF                   \
+        mul     x13, x6, x10 __LF                  \
+        umulh   x12, x5, x9 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x6, x10 __LF                  \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x5, x6 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x10, x9 __LF                   \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        subs    x3, x5, x3 __LF                    \
+        sbcs    x4, x6, x4 __LF                    \
+        ngc     x5, xzr __LF                       \
+        cmn     x5, #1 __LF                        \
+        eor     x3, x3, x5 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        eor     x4, x4, x5 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        subs    x7, x7, x9 __LF                    \
+        sbcs    x8, x8, x10 __LF                   \
+        ngc     x9, xzr __LF                       \
+        cmn     x9, #1 __LF                        \
+        eor     x7, x7, x9 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        eor     x8, x8, x9 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        eor     x10, x5, x9 __LF                   \
+        ldp     x15, x1, [P0] __LF                 \
+        adds    x15, x11, x15 __LF                 \
+        adcs    x1, x12, x1 __LF                   \
+        ldp     x5, x9, [P0+16] __LF               \
+        adcs    x5, x13, x5 __LF                   \
+        adcs    x9, x14, x9 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x3, x3, x4 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        csetm   x4, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x3, x0 __LF                   \
+        umulh   x0, x3, x0 __LF                    \
+        cinv    x4, x4, lo __LF                    \
+        eor     x16, x16, x4 __LF                  \
+        eor     x0, x0, x4 __LF                    \
+        cmn     x4, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x4 __LF                  \
+        cmn     x10, #1 __LF                       \
+        eor     x11, x11, x10 __LF                 \
+        adcs    x11, x11, x15 __LF                 \
+        eor     x12, x12, x10 __LF                 \
+        adcs    x12, x12, x1 __LF                  \
+        eor     x13, x13, x10 __LF                 \
+        adcs    x13, x13, x5 __LF                  \
+        eor     x14, x14, x10 __LF                 \
+        adcs    x14, x14, x9 __LF                  \
+        adcs    x3, x2, x10 __LF                   \
+        adcs    x4, x10, xzr __LF                  \
+        adc     x10, x10, xzr __LF                 \
+        adds    x13, x13, x15 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adcs    x3, x3, x5 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x10, x10, x2 __LF                  \
+        lsl     x0, x11, #32 __LF                  \
+        subs    x1, x11, x0 __LF                   \
+        lsr     x16, x11, #32 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x12, x12, x0 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        lsl     x0, x12, #32 __LF                  \
+        subs    x1, x12, x0 __LF                   \
+        lsr     x16, x12, #32 __LF                 \
+        sbc     x12, x12, x16 __LF                 \
+        adds    x13, x13, x0 __LF                  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x11, x11, x1 __LF                  \
+        adc     x12, x12, xzr __LF                 \
+        adds    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        add     x2, x10, #1 __LF                   \
+        lsl     x16, x2, #32 __LF                  \
+        adds    x4, x4, x16 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        neg     x15, x2 __LF                       \
+        sub     x16, x16, #1 __LF                  \
+        subs    x13, x13, x15 __LF                 \
+        sbcs    x14, x14, x16 __LF                 \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, x2 __LF                    \
+        sbcs    x7, x10, x2 __LF                   \
+        adds    x13, x13, x7 __LF                  \
+        mov     x10, #4294967295 __LF              \
+        and     x10, x10, x7 __LF                  \
+        adcs    x14, x14, x10 __LF                 \
+        adcs    x3, x3, xzr __LF                   \
+        mov     x10, #-4294967295 __LF             \
+        and     x10, x10, x7 __LF                  \
+        adc     x4, x4, x10 __LF                   \
+        stp     x13, x14, [P0] __LF                \
         stp     x3, x4, [P0+16]
 
 // Corresponds to bignum_montsqr_p256 but uses x0 in place of x17
 
 #define montsqr_p256(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        ldp     x4, x5, [P1+16];                \
-        umull   x15, w2, w2;                    \
-        lsr     x11, x2, #32;                   \
-        umull   x16, w11, w11;                  \
-        umull   x11, w2, w11;                   \
-        adds    x15, x15, x11, lsl #33;         \
-        lsr     x11, x11, #31;                  \
-        adc     x16, x16, x11;                  \
-        umull   x0, w3, w3;                     \
-        lsr     x11, x3, #32;                   \
-        umull   x1, w11, w11;                   \
-        umull   x11, w3, w11;                   \
-        mul     x12, x2, x3;                    \
-        umulh   x13, x2, x3;                    \
-        adds    x0, x0, x11, lsl #33;           \
-        lsr     x11, x11, #31;                  \
-        adc     x1, x1, x11;                    \
-        adds    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x16, x12;                  \
-        adcs    x0, x0, x13;                    \
-        adc     x1, x1, xzr;                    \
-        lsl     x12, x15, #32;                  \
-        subs    x13, x15, x12;                  \
-        lsr     x11, x15, #32;                  \
-        sbc     x15, x15, x11;                  \
-        adds    x16, x16, x12;                  \
-        adcs    x0, x0, x11;                    \
-        adcs    x1, x1, x13;                    \
-        adc     x15, x15, xzr;                  \
-        lsl     x12, x16, #32;                  \
-        subs    x13, x16, x12;                  \
-        lsr     x11, x16, #32;                  \
-        sbc     x16, x16, x11;                  \
-        adds    x0, x0, x12;                    \
-        adcs    x1, x1, x11;                    \
-        adcs    x15, x15, x13;                  \
-        adc     x16, x16, xzr;                  \
-        mul     x6, x2, x4;                     \
-        mul     x14, x3, x5;                    \
-        umulh   x8, x2, x4;                     \
-        subs    x10, x2, x3;                    \
-        cneg    x10, x10, lo;                   \
-        csetm   x13, lo;                        \
-        subs    x12, x5, x4;                    \
-        cneg    x12, x12, lo;                   \
-        mul     x11, x10, x12;                  \
-        umulh   x12, x10, x12;                  \
-        cinv    x13, x13, lo;                   \
-        eor     x11, x11, x13;                  \
-        eor     x12, x12, x13;                  \
-        adds    x7, x6, x8;                     \
-        adc     x8, x8, xzr;                    \
-        umulh   x9, x3, x5;                     \
-        adds    x7, x7, x14;                    \
-        adcs    x8, x8, x9;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x8, x8, x14;                    \
-        adc     x9, x9, xzr;                    \
-        cmn     x13, #1;                        \
-        adcs    x7, x7, x11;                    \
-        adcs    x8, x8, x12;                    \
-        adc     x9, x9, x13;                    \
-        adds    x6, x6, x6;                     \
-        adcs    x7, x7, x7;                     \
-        adcs    x8, x8, x8;                     \
-        adcs    x9, x9, x9;                     \
-        adc     x10, xzr, xzr;                  \
-        adds    x6, x6, x0;                     \
-        adcs    x7, x7, x1;                     \
-        adcs    x8, x8, x15;                    \
-        adcs    x9, x9, x16;                    \
-        adc     x10, x10, xzr;                  \
-        lsl     x12, x6, #32;                   \
-        subs    x13, x6, x12;                   \
-        lsr     x11, x6, #32;                   \
-        sbc     x6, x6, x11;                    \
-        adds    x7, x7, x12;                    \
-        adcs    x8, x8, x11;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x6;                   \
-        adc     x6, xzr, xzr;                   \
-        lsl     x12, x7, #32;                   \
-        subs    x13, x7, x12;                   \
-        lsr     x11, x7, #32;                   \
-        sbc     x7, x7, x11;                    \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x13;                  \
-        adcs    x6, x6, x7;                     \
-        adc     x7, xzr, xzr;                   \
-        mul     x11, x4, x4;                    \
-        adds    x8, x8, x11;                    \
-        mul     x12, x5, x5;                    \
-        umulh   x11, x4, x4;                    \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        umulh   x12, x5, x5;                    \
-        adcs    x6, x6, x12;                    \
-        adc     x7, x7, xzr;                    \
-        mul     x11, x4, x5;                    \
-        umulh   x12, x4, x5;                    \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adc     x13, xzr, xzr;                  \
-        adds    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        adcs    x6, x6, x13;                    \
-        adcs    x7, x7, xzr;                    \
-        mov     x11, #4294967295;               \
-        adds    x5, x8, #1;                     \
-        sbcs    x11, x9, x11;                   \
-        mov     x13, #-4294967295;              \
-        sbcs    x12, x10, xzr;                  \
-        sbcs    x13, x6, x13;                   \
-        sbcs    xzr, x7, xzr;                   \
-        csel    x8, x5, x8, hs;                 \
-        csel    x9, x11, x9, hs;                \
-        csel    x10, x12, x10, hs;              \
-        csel    x6, x13, x6, hs;                \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        ldp     x4, x5, [P1+16] __LF               \
+        umull   x15, w2, w2 __LF                   \
+        lsr     x11, x2, #32 __LF                  \
+        umull   x16, w11, w11 __LF                 \
+        umull   x11, w2, w11 __LF                  \
+        adds    x15, x15, x11, lsl #33 __LF        \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x16, x16, x11 __LF                 \
+        umull   x0, w3, w3 __LF                    \
+        lsr     x11, x3, #32 __LF                  \
+        umull   x1, w11, w11 __LF                  \
+        umull   x11, w3, w11 __LF                  \
+        mul     x12, x2, x3 __LF                   \
+        umulh   x13, x2, x3 __LF                   \
+        adds    x0, x0, x11, lsl #33 __LF          \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x1, x1, x11 __LF                   \
+        adds    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x16, x12 __LF                 \
+        adcs    x0, x0, x13 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        lsl     x12, x15, #32 __LF                 \
+        subs    x13, x15, x12 __LF                 \
+        lsr     x11, x15, #32 __LF                 \
+        sbc     x15, x15, x11 __LF                 \
+        adds    x16, x16, x12 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        adcs    x1, x1, x13 __LF                   \
+        adc     x15, x15, xzr __LF                 \
+        lsl     x12, x16, #32 __LF                 \
+        subs    x13, x16, x12 __LF                 \
+        lsr     x11, x16, #32 __LF                 \
+        sbc     x16, x16, x11 __LF                 \
+        adds    x0, x0, x12 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adcs    x15, x15, x13 __LF                 \
+        adc     x16, x16, xzr __LF                 \
+        mul     x6, x2, x4 __LF                    \
+        mul     x14, x3, x5 __LF                   \
+        umulh   x8, x2, x4 __LF                    \
+        subs    x10, x2, x3 __LF                   \
+        cneg    x10, x10, lo __LF                  \
+        csetm   x13, lo __LF                       \
+        subs    x12, x5, x4 __LF                   \
+        cneg    x12, x12, lo __LF                  \
+        mul     x11, x10, x12 __LF                 \
+        umulh   x12, x10, x12 __LF                 \
+        cinv    x13, x13, lo __LF                  \
+        eor     x11, x11, x13 __LF                 \
+        eor     x12, x12, x13 __LF                 \
+        adds    x7, x6, x8 __LF                    \
+        adc     x8, x8, xzr __LF                   \
+        umulh   x9, x3, x5 __LF                    \
+        adds    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x9 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x8, x8, x14 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        cmn     x13, #1 __LF                       \
+        adcs    x7, x7, x11 __LF                   \
+        adcs    x8, x8, x12 __LF                   \
+        adc     x9, x9, x13 __LF                   \
+        adds    x6, x6, x6 __LF                    \
+        adcs    x7, x7, x7 __LF                    \
+        adcs    x8, x8, x8 __LF                    \
+        adcs    x9, x9, x9 __LF                    \
+        adc     x10, xzr, xzr __LF                 \
+        adds    x6, x6, x0 __LF                    \
+        adcs    x7, x7, x1 __LF                    \
+        adcs    x8, x8, x15 __LF                   \
+        adcs    x9, x9, x16 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        lsl     x12, x6, #32 __LF                  \
+        subs    x13, x6, x12 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        sbc     x6, x6, x11 __LF                   \
+        adds    x7, x7, x12 __LF                   \
+        adcs    x8, x8, x11 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x6 __LF                  \
+        adc     x6, xzr, xzr __LF                  \
+        lsl     x12, x7, #32 __LF                  \
+        subs    x13, x7, x12 __LF                  \
+        lsr     x11, x7, #32 __LF                  \
+        sbc     x7, x7, x11 __LF                   \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x6, x6, x7 __LF                    \
+        adc     x7, xzr, xzr __LF                  \
+        mul     x11, x4, x4 __LF                   \
+        adds    x8, x8, x11 __LF                   \
+        mul     x12, x5, x5 __LF                   \
+        umulh   x11, x4, x4 __LF                   \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        umulh   x12, x5, x5 __LF                   \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        umulh   x12, x4, x5 __LF                   \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adc     x13, xzr, xzr __LF                 \
+        adds    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        adcs    x6, x6, x13 __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x11, #4294967295 __LF              \
+        adds    x5, x8, #1 __LF                    \
+        sbcs    x11, x9, x11 __LF                  \
+        mov     x13, #-4294967295 __LF             \
+        sbcs    x12, x10, xzr __LF                 \
+        sbcs    x13, x6, x13 __LF                  \
+        sbcs    xzr, x7, xzr __LF                  \
+        csel    x8, x5, x8, hs __LF                \
+        csel    x9, x11, x9, hs __LF               \
+        csel    x10, x12, x10, hs __LF             \
+        csel    x6, x13, x6, hs __LF               \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x6, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256
 
 #define sub_p256(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, xzr;                    \
-        mov     x4, #0xffffffff00000001;        \
-        and     x4, x4, x3;                     \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x4, #0xffffffff00000001 __LF       \
+        and     x4, x4, x3 __LF                    \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(p256_montjmixadd):

--- a/arm/p256/p256_montjmixadd_alt.S
+++ b/arm/p256/p256_montjmixadd_alt.S
@@ -74,338 +74,338 @@
 // Corresponds to bignum_montmul_p256_alt except registers
 
 #define montmul_p256(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x10, #0xffffffff00000001;       \
-        adds    x13, x13, x12, lsl #32;         \
-        lsr     x11, x12, #32;                  \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x12, x10;                  \
-        umulh   x12, x12, x10;                  \
-        adcs    x0, x0, x11;                    \
-        adc     x12, x12, xzr;                  \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        adds    x14, x14, x13, lsl #32;         \
-        lsr     x11, x13, #32;                  \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x13, x10;                  \
-        umulh   x13, x13, x10;                  \
-        adcs    x12, x12, x11;                  \
-        adc     x13, x13, xzr;                  \
-        adds    x0, x0, x14, lsl #32;           \
-        lsr     x11, x14, #32;                  \
-        adcs    x12, x12, x11;                  \
-        mul     x11, x14, x10;                  \
-        umulh   x14, x14, x10;                  \
-        adcs    x13, x13, x11;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x12, x12, x0, lsl #32;          \
-        lsr     x11, x0, #32;                   \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x0, x10;                   \
-        umulh   x0, x0, x10;                    \
-        adcs    x14, x14, x11;                  \
-        adc     x0, x0, xzr;                    \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff;               \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        sbcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x10;                    \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x10, #0xffffffff00000001 __LF      \
+        adds    x13, x13, x12, lsl #32 __LF        \
+        lsr     x11, x12, #32 __LF                 \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x12, x10 __LF                 \
+        umulh   x12, x12, x10 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x12, x12, xzr __LF                 \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        adds    x14, x14, x13, lsl #32 __LF        \
+        lsr     x11, x13, #32 __LF                 \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x13, x10 __LF                 \
+        umulh   x13, x13, x10 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        adds    x0, x0, x14, lsl #32 __LF          \
+        lsr     x11, x14, #32 __LF                 \
+        adcs    x12, x12, x11 __LF                 \
+        mul     x11, x14, x10 __LF                 \
+        umulh   x14, x14, x10 __LF                 \
+        adcs    x13, x13, x11 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x12, x12, x0, lsl #32 __LF         \
+        lsr     x11, x0, #32 __LF                  \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x0, x10 __LF                  \
+        umulh   x0, x0, x10 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        adc     x0, x0, xzr __LF                   \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff __LF              \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        sbcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x10 __LF                   \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_montsqr_p256_alt
 
 #define montsqr_p256(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        adds    x9, x9, x8, lsl #32;            \
-        lsr     x3, x8, #32;                    \
-        adcs    x10, x10, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x8, x3;                     \
-        umulh   x8, x8, x3;                     \
-        adcs    x11, x11, x2;                   \
-        adc     x8, x8, xzr;                    \
-        adds    x10, x10, x9, lsl #32;          \
-        lsr     x3, x9, #32;                    \
-        adcs    x11, x11, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x9, x3;                     \
-        umulh   x9, x9, x3;                     \
-        adcs    x8, x8, x2;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x11, x11, x10, lsl #32;         \
-        lsr     x3, x10, #32;                   \
-        adcs    x8, x8, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x10, x3;                    \
-        umulh   x10, x10, x3;                   \
-        adcs    x9, x9, x2;                     \
-        adc     x10, x10, xzr;                  \
-        adds    x8, x8, x11, lsl #32;           \
-        lsr     x3, x11, #32;                   \
-        adcs    x9, x9, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x11, x3;                    \
-        umulh   x11, x11, x3;                   \
-        adcs    x10, x10, x2;                   \
-        adc     x11, x11, xzr;                  \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, cs;                         \
-        mov     x3, #0xffffffff;                \
-        mov     x5, #0xffffffff00000001;        \
-        adds    x12, x8, #0x1;                  \
-        sbcs    x13, x9, x3;                    \
-        sbcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, cc;                \
-        csel    x9, x9, x13, cc;                \
-        csel    x10, x10, x14, cc;              \
-        csel    x11, x11, x7, cc;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        adds    x9, x9, x8, lsl #32 __LF           \
+        lsr     x3, x8, #32 __LF                   \
+        adcs    x10, x10, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x8, x3 __LF                    \
+        umulh   x8, x8, x3 __LF                    \
+        adcs    x11, x11, x2 __LF                  \
+        adc     x8, x8, xzr __LF                   \
+        adds    x10, x10, x9, lsl #32 __LF         \
+        lsr     x3, x9, #32 __LF                   \
+        adcs    x11, x11, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x9, x3 __LF                    \
+        umulh   x9, x9, x3 __LF                    \
+        adcs    x8, x8, x2 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x11, x11, x10, lsl #32 __LF        \
+        lsr     x3, x10, #32 __LF                  \
+        adcs    x8, x8, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x10, x3 __LF                   \
+        umulh   x10, x10, x3 __LF                  \
+        adcs    x9, x9, x2 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        adds    x8, x8, x11, lsl #32 __LF          \
+        lsr     x3, x11, #32 __LF                  \
+        adcs    x9, x9, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x11, x3 __LF                   \
+        umulh   x11, x11, x3 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, cs __LF                        \
+        mov     x3, #0xffffffff __LF               \
+        mov     x5, #0xffffffff00000001 __LF       \
+        adds    x12, x8, #0x1 __LF                 \
+        sbcs    x13, x9, x3 __LF                   \
+        sbcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, cc __LF               \
+        csel    x9, x9, x13, cc __LF               \
+        csel    x10, x10, x14, cc __LF             \
+        csel    x11, x11, x7, cc __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Almost-Montgomery variant which we use when an input to other muls
 // with the other argument fully reduced (which is always safe).
 
 #define amontsqr_p256(P0,P1)                    \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        adds    x9, x9, x8, lsl #32;            \
-        lsr     x3, x8, #32;                    \
-        adcs    x10, x10, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x8, x3;                     \
-        umulh   x8, x8, x3;                     \
-        adcs    x11, x11, x2;                   \
-        adc     x8, x8, xzr;                    \
-        adds    x10, x10, x9, lsl #32;          \
-        lsr     x3, x9, #32;                    \
-        adcs    x11, x11, x3;                   \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x9, x3;                     \
-        umulh   x9, x9, x3;                     \
-        adcs    x8, x8, x2;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x11, x11, x10, lsl #32;         \
-        lsr     x3, x10, #32;                   \
-        adcs    x8, x8, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x10, x3;                    \
-        umulh   x10, x10, x3;                   \
-        adcs    x9, x9, x2;                     \
-        adc     x10, x10, xzr;                  \
-        adds    x8, x8, x11, lsl #32;           \
-        lsr     x3, x11, #32;                   \
-        adcs    x9, x9, x3;                     \
-        mov     x3, #0xffffffff00000001;        \
-        mul     x2, x11, x3;                    \
-        umulh   x11, x11, x3;                   \
-        adcs    x10, x10, x2;                   \
-        adc     x11, x11, xzr;                  \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        mov     x2, #0xffffffffffffffff;        \
-        csel    x2, xzr, x2, cc;                \
-        mov     x3, #0xffffffff;                \
-        csel    x3, xzr, x3, cc;                \
-        mov     x5, #0xffffffff00000001;        \
-        csel    x5, xzr, x5, cc;                \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, x5;                   \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        adds    x9, x9, x8, lsl #32 __LF           \
+        lsr     x3, x8, #32 __LF                   \
+        adcs    x10, x10, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x8, x3 __LF                    \
+        umulh   x8, x8, x3 __LF                    \
+        adcs    x11, x11, x2 __LF                  \
+        adc     x8, x8, xzr __LF                   \
+        adds    x10, x10, x9, lsl #32 __LF         \
+        lsr     x3, x9, #32 __LF                   \
+        adcs    x11, x11, x3 __LF                  \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x9, x3 __LF                    \
+        umulh   x9, x9, x3 __LF                    \
+        adcs    x8, x8, x2 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x11, x11, x10, lsl #32 __LF        \
+        lsr     x3, x10, #32 __LF                  \
+        adcs    x8, x8, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x10, x3 __LF                   \
+        umulh   x10, x10, x3 __LF                  \
+        adcs    x9, x9, x2 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        adds    x8, x8, x11, lsl #32 __LF          \
+        lsr     x3, x11, #32 __LF                  \
+        adcs    x9, x9, x3 __LF                    \
+        mov     x3, #0xffffffff00000001 __LF       \
+        mul     x2, x11, x3 __LF                   \
+        umulh   x11, x11, x3 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        adc     x11, x11, xzr __LF                 \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        mov     x2, #0xffffffffffffffff __LF       \
+        csel    x2, xzr, x2, cc __LF               \
+        mov     x3, #0xffffffff __LF               \
+        csel    x3, xzr, x3, cc __LF               \
+        mov     x5, #0xffffffff00000001 __LF       \
+        csel    x5, xzr, x5, cc __LF               \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, x5 __LF                  \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256
 
 #define sub_p256(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, xzr;                    \
-        mov     x4, #0xffffffff00000001;        \
-        and     x4, x4, x3;                     \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x4, #0xffffffff00000001 __LF       \
+        and     x4, x4, x3 __LF                    \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(p256_montjmixadd_alt):

--- a/arm/p256/p256_montjscalarmul.S
+++ b/arm/p256/p256_montjscalarmul.S
@@ -60,33 +60,33 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                          \
-        cmp     x14, #(1*I);                    \
-        ldp     x12, x13, [x15];                \
-        csel    x0, x12, x0, eq;                \
-        csel    x1, x13, x1, eq;                \
-        ldp     x12, x13, [x15, #16];           \
-        csel    x2, x12, x2, eq;                \
-        csel    x3, x13, x3, eq;                \
-        ldp     x12, x13, [x15, #32];           \
-        csel    x4, x12, x4, eq;                \
-        csel    x5, x13, x5, eq;                \
-        ldp     x12, x13, [x15, #48];           \
-        csel    x6, x12, x6, eq;                \
-        csel    x7, x13, x7, eq;                \
-        ldp     x12, x13, [x15, #64];           \
-        csel    x8, x12, x8, eq;                \
-        csel    x9, x13, x9, eq;                \
-        ldp     x12, x13, [x15, #80];           \
-        csel    x10, x12, x10, eq;              \
-        csel    x11, x13, x11, eq;              \
+        cmp     x14, #(1*I) __LF                   \
+        ldp     x12, x13, [x15] __LF               \
+        csel    x0, x12, x0, eq __LF               \
+        csel    x1, x13, x1, eq __LF               \
+        ldp     x12, x13, [x15, #16] __LF          \
+        csel    x2, x12, x2, eq __LF               \
+        csel    x3, x13, x3, eq __LF               \
+        ldp     x12, x13, [x15, #32] __LF          \
+        csel    x4, x12, x4, eq __LF               \
+        csel    x5, x13, x5, eq __LF               \
+        ldp     x12, x13, [x15, #48] __LF          \
+        csel    x6, x12, x6, eq __LF               \
+        csel    x7, x13, x7, eq __LF               \
+        ldp     x12, x13, [x15, #64] __LF          \
+        csel    x8, x12, x8, eq __LF               \
+        csel    x9, x13, x9, eq __LF               \
+        ldp     x12, x13, [x15, #80] __LF          \
+        csel    x10, x12, x10, eq __LF             \
+        csel    x11, x13, x11, eq __LF             \
         add     x15, x15, #96
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_montjscalarmul):

--- a/arm/p256/p256_montjscalarmul_alt.S
+++ b/arm/p256/p256_montjscalarmul_alt.S
@@ -60,33 +60,33 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                          \
-        cmp     x14, #(1*I);                    \
-        ldp     x12, x13, [x15];                \
-        csel    x0, x12, x0, eq;                \
-        csel    x1, x13, x1, eq;                \
-        ldp     x12, x13, [x15, #16];           \
-        csel    x2, x12, x2, eq;                \
-        csel    x3, x13, x3, eq;                \
-        ldp     x12, x13, [x15, #32];           \
-        csel    x4, x12, x4, eq;                \
-        csel    x5, x13, x5, eq;                \
-        ldp     x12, x13, [x15, #48];           \
-        csel    x6, x12, x6, eq;                \
-        csel    x7, x13, x7, eq;                \
-        ldp     x12, x13, [x15, #64];           \
-        csel    x8, x12, x8, eq;                \
-        csel    x9, x13, x9, eq;                \
-        ldp     x12, x13, [x15, #80];           \
-        csel    x10, x12, x10, eq;              \
-        csel    x11, x13, x11, eq;              \
+        cmp     x14, #(1*I) __LF                   \
+        ldp     x12, x13, [x15] __LF               \
+        csel    x0, x12, x0, eq __LF               \
+        csel    x1, x13, x1, eq __LF               \
+        ldp     x12, x13, [x15, #16] __LF          \
+        csel    x2, x12, x2, eq __LF               \
+        csel    x3, x13, x3, eq __LF               \
+        ldp     x12, x13, [x15, #32] __LF          \
+        csel    x4, x12, x4, eq __LF               \
+        csel    x5, x13, x5, eq __LF               \
+        ldp     x12, x13, [x15, #48] __LF          \
+        csel    x6, x12, x6, eq __LF               \
+        csel    x7, x13, x7, eq __LF               \
+        ldp     x12, x13, [x15, #64] __LF          \
+        csel    x8, x12, x8, eq __LF               \
+        csel    x9, x13, x9, eq __LF               \
+        ldp     x12, x13, [x15, #80] __LF          \
+        csel    x10, x12, x10, eq __LF             \
+        csel    x11, x13, x11, eq __LF             \
         add     x15, x15, #96
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_montjscalarmul_alt):

--- a/arm/p256/p256_scalarmul.S
+++ b/arm/p256/p256_scalarmul.S
@@ -55,9 +55,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_scalarmul):

--- a/arm/p256/p256_scalarmul_alt.S
+++ b/arm/p256/p256_scalarmul_alt.S
@@ -55,9 +55,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_scalarmul_alt):

--- a/arm/p256/p256_scalarmulbase.S
+++ b/arm/p256/p256_scalarmulbase.S
@@ -64,9 +64,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_scalarmulbase):

--- a/arm/p256/p256_scalarmulbase_alt.S
+++ b/arm/p256/p256_scalarmulbase_alt.S
@@ -64,9 +64,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p256_scalarmulbase_alt):

--- a/arm/p256/unopt/bignum_montmul_p256_base.S
+++ b/arm/p256/unopt/bignum_montmul_p256_base.S
@@ -28,15 +28,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -48,17 +48,17 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence [d4;..;d1] := [d3;d2;d1;0] + (2^256 - 2^224 + 2^192 + 2^96) * w */ \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
         adc     d4, d0, xzr
 
 #define a0 x3

--- a/arm/p256/unopt/bignum_montmul_p256_base.S
+++ b/arm/p256/unopt/bignum_montmul_p256_base.S
@@ -48,7 +48,7 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/unopt/bignum_montsqr_p256_base.S
+++ b/arm/p256/unopt/bignum_montsqr_p256_base.S
@@ -27,15 +27,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -46,18 +46,18 @@
 // ---------------------------------------------------------------------------
 
 #define montrede(d5, d4,d3,d2,d1,d0, t2,t1,t0)                              \
-/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence basic [d4;d3;d2;d1] += (2^256 - 2^224 + 2^192 + 2^96) * w  */      \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
-        adcs    d4, d4, d0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
+        adcs    d4, d4, d0 __LF                                        \
         adc     d5, xzr, xzr
 
 // ---------------------------------------------------------------------------
@@ -69,17 +69,17 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
-        lsl     t1, d0, #32;                                        \
-        subs    t0, d0, t1;                                         \
-        lsr     t2, d0, #32;                                        \
-        sbc     d0, d0, t2;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        subs    t0, d0, t1 __LF                                        \
+        lsr     t2, d0, #32 __LF                                       \
+        sbc     d0, d0, t2 __LF                                        \
 /* Hence [d4;..;d1] := [d3;d2;d1;0] + (2^256 - 2^224 + 2^192 + 2^96) * w */ \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, t0;                                         \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, t0 __LF                                        \
         adc     d4, d0, xzr
 
 #define a0 x2

--- a/arm/p256/unopt/bignum_montsqr_p256_base.S
+++ b/arm/p256/unopt/bignum_montsqr_p256_base.S
@@ -46,7 +46,7 @@
 // ---------------------------------------------------------------------------
 
 #define montrede(d5, d4,d3,d2,d1,d0, t2,t1,t0)                              \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled */      \
+/* Let w = d0, the original word we use as offset; d0 gets recycled */      \
 /* First let [t2;t1] = 2^32 * w                                     */      \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)      */      \
         lsl     t1, d0, #32 __LF                                       \
@@ -69,7 +69,7 @@
 // ---------------------------------------------------------------------------
 
 #define montreds(d4,d3,d2,d1,d0, t2,t1,t0)                                  \
-/* Let w = d0, the original word we use as offset __LFd0 gets recycled      */ \
+/* Let w = d0, the original word we use as offset; d0 gets recycled      */ \
 /* First let [t2;t1] = 2^32 * w                                          */ \
 /* then let [d0;t0] = (2^64 - 2^32 + 1) * w (overwrite old d0)           */ \
         lsl     t1, d0, #32 __LF                                       \

--- a/arm/p256/unopt/p256_montjdouble.S
+++ b/arm/p256/unopt/p256_montjdouble.S
@@ -487,22 +487,22 @@
 // A weak version of add that only guarantees sum in 4 digits
 
 #define weakadd_p256(P0,P1,P2)                  \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        csetm   x3, cs;                         \
-        subs    x5, x5, x3;                     \
-        and     x1, x3, #4294967295;            \
-        sbcs    x6, x6, x1;                     \
-        sbcs    x7, x7, xzr;                    \
-        and     x2, x3, #-4294967295;           \
-        sbc     x8, x8, x2;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        csetm   x3, cs __LF                        \
+        subs    x5, x5, x3 __LF                    \
+        and     x1, x3, #4294967295 __LF           \
+        sbcs    x6, x6, x1 __LF                    \
+        sbcs    x7, x7, xzr __LF                   \
+        and     x2, x3, #-4294967295 __LF          \
+        sbc     x8, x8, x2 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // P0 = C * P1 - D * P2 computed as D * (p_256 - P2) + C * P1
@@ -510,66 +510,66 @@
 // This also applies to the other functions following.
 
 #define cmsub_p256(P0,C,P1,D,P2)                \
-        mov     x1, D;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x2, #4294967295;                \
-        sbcs    x10, x2, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, xzr, x11;                  \
-        mov     x2, #-4294967295;               \
-        sbc     x12, x2, x12;                   \
-        mul     x3, x1, x9;                     \
-        mul     x4, x1, x10;                    \
-        mul     x5, x1, x11;                    \
-        mul     x6, x1, x12;                    \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        umulh   x11, x1, x11;                   \
-        umulh   x7, x1, x12;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, xzr;                    \
-        mov     x1, C;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x8, x7, #1;                     \
-        lsl     x10, x8, #32;                   \
-        adds    x6, x6, x10;                    \
-        adc     x7, x7, xzr;                    \
-        neg     x9, x8;                         \
-        sub     x10, x10, #1;                   \
-        subs    x3, x3, x9;                     \
-        sbcs    x4, x4, x10;                    \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, x8;                     \
-        sbc     x8, x7, x8;                     \
-        adds    x3, x3, x8;                     \
-        and     x9, x8, #4294967295;            \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        neg     x10, x9;                        \
-        adc     x6, x6, x10;                    \
-        stp     x3, x4, [P0];                   \
+        mov     x1, D __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x2, #4294967295 __LF               \
+        sbcs    x10, x2, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, xzr, x11 __LF                 \
+        mov     x2, #-4294967295 __LF              \
+        sbc     x12, x2, x12 __LF                  \
+        mul     x3, x1, x9 __LF                    \
+        mul     x4, x1, x10 __LF                   \
+        mul     x5, x1, x11 __LF                   \
+        mul     x6, x1, x12 __LF                   \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        umulh   x11, x1, x11 __LF                  \
+        umulh   x7, x1, x12 __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mov     x1, C __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x8, x7, #1 __LF                    \
+        lsl     x10, x8, #32 __LF                  \
+        adds    x6, x6, x10 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        neg     x9, x8 __LF                        \
+        sub     x10, x10, #1 __LF                  \
+        subs    x3, x3, x9 __LF                    \
+        sbcs    x4, x4, x10 __LF                   \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, x8 __LF                    \
+        sbc     x8, x7, x8 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        and     x9, x8, #4294967295 __LF           \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        neg     x10, x9 __LF                       \
+        adc     x6, x6, x10 __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // P0 = 4 * P1 - P2, by direct subtraction of P2; the method
@@ -580,95 +580,95 @@
 // so it works for the q = 0 case.
 
 #define cmsub41_p256(P0,P1,P2)                  \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        lsr     x4, x4, #62;                    \
-        sbc     x4, x4, xzr;                    \
-        add     x5, x4, #1;                     \
-        lsl     x8, x5, #32;                    \
-        subs    x6, xzr, x8;                    \
-        sbcs    x7, xzr, xzr;                   \
-        sbc     x8, x8, x5;                     \
-        adds    x0, x0, x5;                     \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x8;                     \
-        csetm   x5, cc;                         \
-        adds    x0, x0, x5;                     \
-        and     x6, x5, #4294967295;            \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, xzr;                    \
-        neg     x7, x6;                         \
-        adc     x3, x3, x7;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        lsr     x4, x4, #62 __LF                   \
+        sbc     x4, x4, xzr __LF                   \
+        add     x5, x4, #1 __LF                    \
+        lsl     x8, x5, #32 __LF                   \
+        subs    x6, xzr, x8 __LF                   \
+        sbcs    x7, xzr, xzr __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        adds    x0, x0, x5 __LF                    \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        csetm   x5, cc __LF                        \
+        adds    x0, x0, x5 __LF                    \
+        and     x6, x5, #4294967295 __LF           \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        neg     x7, x6 __LF                        \
+        adc     x3, x3, x7 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2, computed as (p_256 - P2) << 3 + 3 * P1
 
 #define cmsub38_p256(P0,P1,P2)                  \
-        mov     x1, 8;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x2, #4294967295;                \
-        sbcs    x10, x2, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, xzr, x11;                  \
-        mov     x2, #-4294967295;               \
-        sbc     x12, x2, x12;                   \
-        lsl     x3, x9, #3;                     \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        extr    x6, x12, x11, #61;              \
-        lsr     x7, x12, #61;                   \
-        mov     x1, 3;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x8, x7, #1;                     \
-        lsl     x10, x8, #32;                   \
-        adds    x6, x6, x10;                    \
-        adc     x7, x7, xzr;                    \
-        neg     x9, x8;                         \
-        sub     x10, x10, #1;                   \
-        subs    x3, x3, x9;                     \
-        sbcs    x4, x4, x10;                    \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, x8;                     \
-        sbc     x8, x7, x8;                     \
-        adds    x3, x3, x8;                     \
-        and     x9, x8, #4294967295;            \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        neg     x10, x9;                        \
-        adc     x6, x6, x10;                    \
-        stp     x3, x4, [P0];                   \
+        mov     x1, 8 __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x2, #4294967295 __LF               \
+        sbcs    x10, x2, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, xzr, x11 __LF                 \
+        mov     x2, #-4294967295 __LF              \
+        sbc     x12, x2, x12 __LF                  \
+        lsl     x3, x9, #3 __LF                    \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        extr    x6, x12, x11, #61 __LF             \
+        lsr     x7, x12, #61 __LF                  \
+        mov     x1, 3 __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x8, x7, #1 __LF                    \
+        lsl     x10, x8, #32 __LF                  \
+        adds    x6, x6, x10 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        neg     x9, x8 __LF                        \
+        sub     x10, x10, #1 __LF                  \
+        subs    x3, x3, x9 __LF                    \
+        sbcs    x4, x4, x10 __LF                   \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, x8 __LF                    \
+        sbc     x8, x7, x8 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        and     x9, x8, #4294967295 __LF           \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        neg     x10, x9 __LF                       \
+        adc     x6, x6, x10 __LF                   \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(p256_montjdouble):

--- a/arm/p384/bignum_deamont_p384.S
+++ b/arm/p384/bignum_deamont_p384.S
@@ -39,7 +39,7 @@
         add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
+/* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
         lsr     t1, d0, #32 __LF                                       \
         subs    t1, t1, d0 __LF                                        \

--- a/arm/p384/bignum_deamont_p384.S
+++ b/arm/p384/bignum_deamont_p384.S
@@ -35,27 +35,27 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-        lsl     t1, d0, #32;                                        \
-        add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway; we only need the w_hi    */  \
+/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-        lsr     t1, d0, #32;                                        \
-        subs    t1, t1, d0;                                         \
-        sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32 __LF                                       \
+        subs    t1, t1, d0 __LF                                        \
+        sbc     t2, d0, xzr __LF                                       \
 /* Now select in t1 the field to subtract from d1                       */  \
-        extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32 __LF                                   \
 /* And now get the terms to subtract from d2 and d3                     */  \
-        lsr     t2, t2, #32;                                        \
-        adds    t2, t2, d0;                                         \
-        adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32 __LF                                       \
+        adds    t2, t2, d0 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Do the subtraction of that portion                                   */  \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
         sbc     d6, d0, xzr
 

--- a/arm/p384/bignum_demont_p384.S
+++ b/arm/p384/bignum_demont_p384.S
@@ -39,7 +39,7 @@
         add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
+/* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
         lsr     t1, d0, #32 __LF                                       \
         subs    t1, t1, d0 __LF                                        \

--- a/arm/p384/bignum_demont_p384.S
+++ b/arm/p384/bignum_demont_p384.S
@@ -35,27 +35,27 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-        lsl     t1, d0, #32;                                        \
-        add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway; we only need the w_hi    */  \
+/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-        lsr     t1, d0, #32;                                        \
-        subs    t1, t1, d0;                                         \
-        sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32 __LF                                       \
+        subs    t1, t1, d0 __LF                                        \
+        sbc     t2, d0, xzr __LF                                       \
 /* Now select in t1 the field to subtract from d1                       */  \
-        extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32 __LF                                   \
 /* And now get the terms to subtract from d2 and d3                     */  \
-        lsr     t2, t2, #32;                                        \
-        adds    t2, t2, d0;                                         \
-        adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32 __LF                                       \
+        adds    t2, t2, d0 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Do the subtraction of that portion                                   */  \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
         sbc     d6, d0, xzr
 

--- a/arm/p384/bignum_inv_p384.S
+++ b/arm/p384/bignum_inv_p384.S
@@ -89,52 +89,52 @@
 #define amontred(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* We only know the input is -2^444 < x < 2^444. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_384.     */      \
-        mov     t1, #0xe000000000000000;                            \
-        adds    d0, d0, t1;                                         \
-        mov     t2, #0x000000001fffffff;                            \
-        adcs    d1, d1, t2;                                         \
-        mov     t3, #0xffffffffe0000000;                            \
-        bic     t3, t3, #0x2000000000000000;                        \
-        adcs    d2, d2, t3;                                         \
-        sbcs    d3, d3, xzr;                                        \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
-        mov     t1, #0x1fffffffffffffff;                            \
-        adc     d6, d6, t1;                                         \
+        mov     t1, #0xe000000000000000 __LF                           \
+        adds    d0, d0, t1 __LF                                        \
+        mov     t2, #0x000000001fffffff __LF                           \
+        adcs    d1, d1, t2 __LF                                        \
+        mov     t3, #0xffffffffe0000000 __LF                           \
+        bic     t3, t3, #0x2000000000000000 __LF                       \
+        adcs    d2, d2, t3 __LF                                        \
+        sbcs    d3, d3, xzr __LF                                       \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
+        mov     t1, #0x1fffffffffffffff __LF                           \
+        adc     d6, d6, t1 __LF                                        \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64  */    \
 /* Store it back into d0 since we no longer need that digit.  */    \
-        add     d0, d0, d0, lsl #32;                                \
+        add     d0, d0, d0, lsl #32 __LF                               \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                 */    \
 /* We know the lowest word will cancel d0 so we don't need it */    \
-        mov     t1, #0xffffffff00000001;                            \
-        umulh   t1, t1, d0;                                         \
-        mov     t2, #0x00000000ffffffff;                            \
-        mul     t3, t2, d0;                                         \
-        umulh   t2, t2, d0;                                         \
-        adds    t1, t1, t3;                                         \
-        adcs    t2, t2, d0;                                         \
-        cset    t3, cs;                                             \
+        mov     t1, #0xffffffff00000001 __LF                           \
+        umulh   t1, t1, d0 __LF                                        \
+        mov     t2, #0x00000000ffffffff __LF                           \
+        mul     t3, t2, d0 __LF                                        \
+        umulh   t2, t2, d0 __LF                                        \
+        adds    t1, t1, t3 __LF                                        \
+        adcs    t2, t2, d0 __LF                                        \
+        cset    t3, cs __LF                                            \
 /* Now x + p_384 * w = (x + 2^384 * w) - (2^384 - p_384) * w */     \
 /* We catch the net top carry from add-subtract in the digit d0 */  \
-        adds    d6, d6, d0;                                         \
-        cset    d0, cs;                                             \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
-        sbcs    d6, d6, xzr;                                        \
-        sbcs    d0, d0, xzr;                                        \
+        adds    d6, d6, d0 __LF                                        \
+        cset    d0, cs __LF                                            \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
+        sbcs    d6, d6, xzr __LF                                       \
+        sbcs    d0, d0, xzr __LF                                       \
 /* Now if d0 is nonzero we subtract p_384 (almost-Montgomery) */    \
-        neg     d0, d0;                                             \
-        and     t1, d0, #0x00000000ffffffff;                        \
-        and     t2, d0, #0xffffffff00000000;                        \
-        and     t3, d0, #0xfffffffffffffffe;                        \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, d0;                                         \
-        sbcs    d5, d5, d0;                                         \
+        neg     d0, d0 __LF                                            \
+        and     t1, d0, #0x00000000ffffffff __LF                       \
+        and     t2, d0, #0xffffffff00000000 __LF                       \
+        and     t3, d0, #0xfffffffffffffffe __LF                       \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, d0 __LF                                        \
+        sbcs    d5, d5, d0 __LF                                        \
         sbc     d6, d6, d0
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -145,610 +145,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_inv_p384):

--- a/arm/p384/bignum_mod_n384.S
+++ b/arm/p384/bignum_mod_n384.S
@@ -59,9 +59,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n384):

--- a/arm/p384/bignum_mod_n384_6.S
+++ b/arm/p384/bignum_mod_n384_6.S
@@ -37,9 +37,9 @@
 #define d5 x13
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n384_6):

--- a/arm/p384/bignum_montinv_p384.S
+++ b/arm/p384/bignum_montinv_p384.S
@@ -94,52 +94,52 @@
 #define amontred(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* We only know the input is -2^444 < x < 2^444. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_384.     */      \
-        mov     t1, #0xe000000000000000;                            \
-        adds    d0, d0, t1;                                         \
-        mov     t2, #0x000000001fffffff;                            \
-        adcs    d1, d1, t2;                                         \
-        mov     t3, #0xffffffffe0000000;                            \
-        bic     t3, t3, #0x2000000000000000;                        \
-        adcs    d2, d2, t3;                                         \
-        sbcs    d3, d3, xzr;                                        \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
-        mov     t1, #0x1fffffffffffffff;                            \
-        adc     d6, d6, t1;                                         \
+        mov     t1, #0xe000000000000000 __LF                           \
+        adds    d0, d0, t1 __LF                                        \
+        mov     t2, #0x000000001fffffff __LF                           \
+        adcs    d1, d1, t2 __LF                                        \
+        mov     t3, #0xffffffffe0000000 __LF                           \
+        bic     t3, t3, #0x2000000000000000 __LF                       \
+        adcs    d2, d2, t3 __LF                                        \
+        sbcs    d3, d3, xzr __LF                                       \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
+        mov     t1, #0x1fffffffffffffff __LF                           \
+        adc     d6, d6, t1 __LF                                        \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64  */    \
 /* Store it back into d0 since we no longer need that digit.  */    \
-        add     d0, d0, d0, lsl #32;                                \
+        add     d0, d0, d0, lsl #32 __LF                               \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                 */    \
 /* We know the lowest word will cancel d0 so we don't need it */    \
-        mov     t1, #0xffffffff00000001;                            \
-        umulh   t1, t1, d0;                                         \
-        mov     t2, #0x00000000ffffffff;                            \
-        mul     t3, t2, d0;                                         \
-        umulh   t2, t2, d0;                                         \
-        adds    t1, t1, t3;                                         \
-        adcs    t2, t2, d0;                                         \
-        cset    t3, cs;                                             \
+        mov     t1, #0xffffffff00000001 __LF                           \
+        umulh   t1, t1, d0 __LF                                        \
+        mov     t2, #0x00000000ffffffff __LF                           \
+        mul     t3, t2, d0 __LF                                        \
+        umulh   t2, t2, d0 __LF                                        \
+        adds    t1, t1, t3 __LF                                        \
+        adcs    t2, t2, d0 __LF                                        \
+        cset    t3, cs __LF                                            \
 /* Now x + p_384 * w = (x + 2^384 * w) - (2^384 - p_384) * w */     \
 /* We catch the net top carry from add-subtract in the digit d0 */  \
-        adds    d6, d6, d0;                                         \
-        cset    d0, cs;                                             \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
-        sbcs    d6, d6, xzr;                                        \
-        sbcs    d0, d0, xzr;                                        \
+        adds    d6, d6, d0 __LF                                        \
+        cset    d0, cs __LF                                            \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
+        sbcs    d6, d6, xzr __LF                                       \
+        sbcs    d0, d0, xzr __LF                                       \
 /* Now if d0 is nonzero we subtract p_384 (almost-Montgomery) */    \
-        neg     d0, d0;                                             \
-        and     t1, d0, #0x00000000ffffffff;                        \
-        and     t2, d0, #0xffffffff00000000;                        \
-        and     t3, d0, #0xfffffffffffffffe;                        \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, d0;                                         \
-        sbcs    d5, d5, d0;                                         \
+        neg     d0, d0 __LF                                            \
+        and     t1, d0, #0x00000000ffffffff __LF                       \
+        and     t2, d0, #0xffffffff00000000 __LF                       \
+        and     t3, d0, #0xfffffffffffffffe __LF                       \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, d0 __LF                                        \
+        sbcs    d5, d5, d0 __LF                                        \
         sbc     d6, d6, d0
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -150,610 +150,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_montinv_p384):

--- a/arm/p384/bignum_montmul_p384_alt.S
+++ b/arm/p384/bignum_montmul_p384_alt.S
@@ -34,24 +34,24 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Store it in d6 to make the 2^384 * w contribution already            */  \
-        lsl     t1, d0, #32;                                        \
-        add     d6, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d6, t1, d0 __LF                                        \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
 /* We know the lowest word will cancel d0 so we don't need it    */         \
-        mov     t1, #0xffffffff00000001;                            \
-        umulh   t1, t1, d6;                                         \
-        mov     t2, #0x00000000ffffffff;                            \
-        mul     t3, t2, d6;                                         \
-        umulh   t2, t2, d6;                                         \
-        adds    t1, t1, t3;                                         \
-        adcs    t2, t2, d6;                                         \
-        adc     t3, xzr, xzr;                                       \
+        mov     t1, #0xffffffff00000001 __LF                           \
+        umulh   t1, t1, d6 __LF                                        \
+        mov     t2, #0x00000000ffffffff __LF                           \
+        mul     t3, t2, d6 __LF                                        \
+        umulh   t2, t2, d6 __LF                                        \
+        adds    t1, t1, t3 __LF                                        \
+        adcs    t2, t2, d6 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Now add it, by subtracting from 2^384 * w + x */                         \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
         sbc     d6, d6, xzr
 
 

--- a/arm/p384/bignum_montsqr_p384_alt.S
+++ b/arm/p384/bignum_montsqr_p384_alt.S
@@ -33,24 +33,24 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Store it in d6 to make the 2^384 * w contribution already            */  \
-        lsl     t1, d0, #32;                                        \
-        add     d6, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d6, t1, d0 __LF                                        \
 /* Now let [t3;t2;t1;-] = (2^384 - p_384) * w                    */         \
 /* We know the lowest word will cancel d0 so we don't need it    */         \
-        mov     t1, #0xffffffff00000001;                            \
-        umulh   t1, t1, d6;                                         \
-        mov     t2, #0x00000000ffffffff;                            \
-        mul     t3, t2, d6;                                         \
-        umulh   t2, t2, d6;                                         \
-        adds    t1, t1, t3;                                         \
-        adcs    t2, t2, d6;                                         \
-        adc     t3, xzr, xzr;                                       \
+        mov     t1, #0xffffffff00000001 __LF                           \
+        umulh   t1, t1, d6 __LF                                        \
+        mov     t2, #0x00000000ffffffff __LF                           \
+        mul     t3, t2, d6 __LF                                        \
+        umulh   t2, t2, d6 __LF                                        \
+        adds    t1, t1, t3 __LF                                        \
+        adcs    t2, t2, d6 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Now add it, by subtracting from 2^384 * w + x */                         \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
         sbc     d6, d6, xzr
 
 #define z x0

--- a/arm/p384/bignum_tomont_p384.S
+++ b/arm/p384/bignum_tomont_p384.S
@@ -27,38 +27,38 @@
 
 #define modstep_p384(d6,d5,d4,d3,d2,d1,d0, t1,t2,t3)                        \
 /* Initial quotient approximation q = min (h + 1) (2^64 - 1) */             \
-        adds    d6, d6, #1;                                         \
-        csetm   t3, cs;                                             \
-        add     d6, d6, t3;                                         \
-        orn     t3, xzr, t3;                                        \
-        sub     t2, d6, #1;                                         \
-        sub     t1, xzr, d6;                                        \
+        adds    d6, d6, #1 __LF                                        \
+        csetm   t3, cs __LF                                            \
+        add     d6, d6, t3 __LF                                        \
+        orn     t3, xzr, t3 __LF                                       \
+        sub     t2, d6, #1 __LF                                        \
+        sub     t1, xzr, d6 __LF                                       \
 /* Correction term [d6;t2;t1;d0] = q * (2^384 - p_384) */                   \
-        lsl     d0, t1, #32;                                        \
-        extr    t1, t2, t1, #32;                                    \
-        lsr     t2, t2, #32;                                        \
-        adds    d0, d0, d6;                                         \
-        adcs    t1, t1, xzr;                                        \
-        adcs    t2, t2, d6;                                         \
-        adc     d6, xzr, xzr;                                       \
+        lsl     d0, t1, #32 __LF                                       \
+        extr    t1, t2, t1, #32 __LF                                   \
+        lsr     t2, t2, #32 __LF                                       \
+        adds    d0, d0, d6 __LF                                        \
+        adcs    t1, t1, xzr __LF                                       \
+        adcs    t2, t2, d6 __LF                                        \
+        adc     d6, xzr, xzr __LF                                      \
 /* Addition to the initial value */                                         \
-        adds    d1, d1, t1;                                         \
-        adcs    d2, d2, t2;                                         \
-        adcs    d3, d3, d6;                                         \
-        adcs    d4, d4, xzr;                                        \
-        adcs    d5, d5, xzr;                                        \
-        adc     t3, t3, xzr;                                        \
+        adds    d1, d1, t1 __LF                                        \
+        adcs    d2, d2, t2 __LF                                        \
+        adcs    d3, d3, d6 __LF                                        \
+        adcs    d4, d4, xzr __LF                                       \
+        adcs    d5, d5, xzr __LF                                       \
+        adc     t3, t3, xzr __LF                                       \
 /* Use net top of the 7-word answer in t3 for masked correction */          \
-        mov     t1, #0x00000000ffffffff;                            \
-        and     t1, t1, t3;                                         \
-        adds    d0, d0, t1;                                         \
-        eor     t1, t1, t3;                                         \
-        adcs    d1, d1, t1;                                         \
-        mov     t1, #0xfffffffffffffffe;                            \
-        and     t1, t1, t3;                                         \
-        adcs    d2, d2, t1;                                         \
-        adcs    d3, d3, t3;                                         \
-        adcs    d4, d4, t3;                                         \
+        mov     t1, #0x00000000ffffffff __LF                           \
+        and     t1, t1, t3 __LF                                        \
+        adds    d0, d0, t1 __LF                                        \
+        eor     t1, t1, t3 __LF                                        \
+        adcs    d1, d1, t1 __LF                                        \
+        mov     t1, #0xfffffffffffffffe __LF                           \
+        and     t1, t1, t3 __LF                                        \
+        adcs    d2, d2, t1 __LF                                        \
+        adcs    d3, d3, t3 __LF                                        \
+        adcs    d4, d4, t3 __LF                                        \
         adc     d5, d5, t3
 
 S2N_BN_SYMBOL(bignum_tomont_p384):

--- a/arm/p384/p384_montjadd_alt.S
+++ b/arm/p384/p384_montjadd_alt.S
@@ -76,495 +76,495 @@
 // Corresponds exactly to bignum_montmul_p384_alt
 
 #define montmul_p384(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x12, x3, x5;                    \
-        umulh   x13, x3, x5;                    \
-        mul     x11, x3, x6;                    \
-        umulh   x14, x3, x6;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x11, x3, x7;                    \
-        umulh   x15, x3, x7;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x8;                    \
-        umulh   x16, x3, x8;                    \
-        adcs    x15, x15, x11;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x11, x3, x9;                    \
-        umulh   x17, x3, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x19, x3, x10;                   \
-        adcs    x17, x17, x11;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x11, x4, x5;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x19, x19, x11;                  \
-        cset    x20, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x20, x20, x11;                  \
-        ldp     x3, x4, [P1+16];                \
-        mul     x11, x3, x5;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x20, x20, x11;                  \
-        cset    x21, cs;                        \
-        umulh   x11, x3, x5;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x21, x21, x11;                  \
-        mul     x11, x4, x5;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x21, x21, x11;                  \
-        cset    x22, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x22, x22, x11;                  \
-        ldp     x3, x4, [P1+32];                \
-        mul     x11, x3, x5;                    \
-        adds    x16, x16, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x22, x22, x11;                  \
-        cset    x2, cs;                         \
-        umulh   x11, x3, x5;                    \
-        adds    x17, x17, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x2, x2, x11;                    \
-        mul     x11, x4, x5;                    \
-        adds    x17, x17, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x22, x22, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x2, x2, x11;                    \
-        cset    x1, cs;                         \
-        umulh   x11, x4, x5;                    \
-        adds    x19, x19, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x2, x2, x11;                    \
-        umulh   x11, x4, x10;                   \
-        adc     x1, x1, x11;                    \
-        lsl     x7, x12, #32;                   \
-        add     x12, x7, x12;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x12;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x12;                    \
-        umulh   x6, x6, x12;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x12;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x13, x13, x7;                   \
-        sbcs    x14, x14, x6;                   \
-        sbcs    x15, x15, x5;                   \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x7, x13, #32;                   \
-        add     x13, x7, x13;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x13;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x13;                    \
-        umulh   x6, x6, x13;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x13;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x14, x14, x7;                   \
-        sbcs    x15, x15, x6;                   \
-        sbcs    x16, x16, x5;                   \
-        sbcs    x17, x17, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        lsl     x7, x14, #32;                   \
-        add     x14, x7, x14;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x14;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x14;                    \
-        umulh   x6, x6, x14;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x14;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x15, x15, x7;                   \
-        sbcs    x16, x16, x6;                   \
-        sbcs    x17, x17, x5;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x14, x14, xzr;                  \
-        lsl     x7, x15, #32;                   \
-        add     x15, x7, x15;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x15;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x15;                    \
-        umulh   x6, x6, x15;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x15;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x16, x16, x7;                   \
-        sbcs    x17, x17, x6;                   \
-        sbcs    x12, x12, x5;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        lsl     x7, x16, #32;                   \
-        add     x16, x7, x16;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x16;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x16;                    \
-        umulh   x6, x6, x16;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x16;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x17, x17, x7;                   \
-        sbcs    x12, x12, x6;                   \
-        sbcs    x13, x13, x5;                   \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbc     x16, x16, xzr;                  \
-        lsl     x7, x17, #32;                   \
-        add     x17, x7, x17;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x17;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x17;                    \
-        umulh   x6, x6, x17;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x17;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, x6;                   \
-        sbcs    x14, x14, x5;                   \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbc     x17, x17, xzr;                  \
-        adds    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adcs    x14, x14, x21;                  \
-        adcs    x15, x15, x22;                  \
-        adcs    x16, x16, x2;                   \
-        adcs    x17, x17, x1;                   \
-        adc     x10, xzr, xzr;                  \
-        mov     x11, #0xffffffff00000001;       \
-        adds    x19, x12, x11;                  \
-        mov     x11, #0xffffffff;               \
-        adcs    x20, x13, x11;                  \
-        mov     x11, #0x1;                      \
-        adcs    x21, x14, x11;                  \
-        adcs    x22, x15, xzr;                  \
-        adcs    x2, x16, xzr;                   \
-        adcs    x1, x17, xzr;                   \
-        adcs    x10, x10, xzr;                  \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        csel    x14, x14, x21, eq;              \
-        csel    x15, x15, x22, eq;              \
-        csel    x16, x16, x2, eq;               \
-        csel    x17, x17, x1, eq;               \
-        stp     x12, x13, [P0];                 \
-        stp     x14, x15, [P0+16];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x12, x3, x5 __LF                   \
+        umulh   x13, x3, x5 __LF                   \
+        mul     x11, x3, x6 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x11, x3, x7 __LF                   \
+        umulh   x15, x3, x7 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x16, x3, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x17, x3, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x19, x3, x10 __LF                  \
+        adcs    x17, x17, x11 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x19, x19, x11 __LF                 \
+        cset    x20, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x20, x20, x11 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x20, x20, x11 __LF                 \
+        cset    x21, cs __LF                       \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x21, x21, x11 __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x21, x21, x11 __LF                 \
+        cset    x22, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x22, x22, x11 __LF                 \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x22, x22, x11 __LF                 \
+        cset    x2, cs __LF                        \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x2, x2, x11 __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x2, x2, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x2, x2, x11 __LF                   \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x1, x1, x11 __LF                   \
+        lsl     x7, x12, #32 __LF                  \
+        add     x12, x7, x12 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x12 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x12 __LF                   \
+        umulh   x6, x6, x12 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x6 __LF                  \
+        sbcs    x15, x15, x5 __LF                  \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x7, x13, #32 __LF                  \
+        add     x13, x7, x13 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x13 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x13 __LF                   \
+        umulh   x6, x6, x13 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x13 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x14, x14, x7 __LF                  \
+        sbcs    x15, x15, x6 __LF                  \
+        sbcs    x16, x16, x5 __LF                  \
+        sbcs    x17, x17, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        lsl     x7, x14, #32 __LF                  \
+        add     x14, x7, x14 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x14 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x14 __LF                   \
+        umulh   x6, x6, x14 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x14 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x15, x15, x7 __LF                  \
+        sbcs    x16, x16, x6 __LF                  \
+        sbcs    x17, x17, x5 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x14, x14, xzr __LF                 \
+        lsl     x7, x15, #32 __LF                  \
+        add     x15, x7, x15 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x15 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x15 __LF                   \
+        umulh   x6, x6, x15 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x15 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x16, x16, x7 __LF                  \
+        sbcs    x17, x17, x6 __LF                  \
+        sbcs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        lsl     x7, x16, #32 __LF                  \
+        add     x16, x7, x16 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x16 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x16 __LF                   \
+        umulh   x6, x6, x16 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x16 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x17, x17, x7 __LF                  \
+        sbcs    x12, x12, x6 __LF                  \
+        sbcs    x13, x13, x5 __LF                  \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbc     x16, x16, xzr __LF                 \
+        lsl     x7, x17, #32 __LF                  \
+        add     x17, x7, x17 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x17 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x17 __LF                   \
+        umulh   x6, x6, x17 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x17 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x6 __LF                  \
+        sbcs    x14, x14, x5 __LF                  \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbc     x17, x17, xzr __LF                 \
+        adds    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adcs    x14, x14, x21 __LF                 \
+        adcs    x15, x15, x22 __LF                 \
+        adcs    x16, x16, x2 __LF                  \
+        adcs    x17, x17, x1 __LF                  \
+        adc     x10, xzr, xzr __LF                 \
+        mov     x11, #0xffffffff00000001 __LF      \
+        adds    x19, x12, x11 __LF                 \
+        mov     x11, #0xffffffff __LF              \
+        adcs    x20, x13, x11 __LF                 \
+        mov     x11, #0x1 __LF                     \
+        adcs    x21, x14, x11 __LF                 \
+        adcs    x22, x15, xzr __LF                 \
+        adcs    x2, x16, xzr __LF                  \
+        adcs    x1, x17, xzr __LF                  \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        csel    x14, x14, x21, eq __LF             \
+        csel    x15, x15, x22, eq __LF             \
+        csel    x16, x16, x2, eq __LF              \
+        csel    x17, x17, x1, eq __LF              \
+        stp     x12, x13, [P0] __LF                \
+        stp     x14, x15, [P0+16] __LF             \
         stp     x16, x17, [P0+32]
 
 // Corresponds exactly to bignum_montsqr_p384_alt
 
 #define montsqr_p384(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x8, x2, x4;                     \
-        adds    x10, x10, x8;                   \
-        mul     x11, x2, x5;                    \
-        mul     x8, x3, x4;                     \
-        adcs    x11, x11, x8;                   \
-        umulh   x12, x2, x5;                    \
-        mul     x8, x3, x5;                     \
-        adcs    x12, x12, x8;                   \
-        ldp     x6, x7, [P1+32];                \
-        mul     x13, x2, x7;                    \
-        mul     x8, x3, x6;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x14, x2, x7;                    \
-        mul     x8, x3, x7;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x15, x5, x6;                    \
-        adcs    x15, x15, xzr;                  \
-        umulh   x16, x5, x6;                    \
-        adc     x16, x16, xzr;                  \
-        umulh   x8, x2, x4;                     \
-        adds    x11, x11, x8;                   \
-        umulh   x8, x3, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x3, x5;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x8, x3, x6;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x3, x7;                     \
-        adcs    x15, x15, x8;                   \
-        adc     x16, x16, xzr;                  \
-        mul     x8, x2, x6;                     \
-        adds    x12, x12, x8;                   \
-        mul     x8, x4, x5;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x4, x6;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x8, x4, x7;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x5, x7;                     \
-        adcs    x16, x16, x8;                   \
-        mul     x17, x6, x7;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x19, x6, x7;                    \
-        adc     x19, x19, xzr;                  \
-        umulh   x8, x2, x6;                     \
-        adds    x13, x13, x8;                   \
-        umulh   x8, x4, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x4, x6;                     \
-        adcs    x15, x15, x8;                   \
-        umulh   x8, x4, x7;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x5, x7;                     \
-        adcs    x17, x17, x8;                   \
-        adc     x19, x19, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        cset    x20, hs;                        \
-        umulh   x8, x2, x2;                     \
-        mul     x2, x2, x2;                     \
-        adds    x9, x9, x8;                     \
-        mul     x8, x3, x3;                     \
-        adcs    x10, x10, x8;                   \
-        umulh   x8, x3, x3;                     \
-        adcs    x11, x11, x8;                   \
-        mul     x8, x4, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x4, x4;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x5, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x5, x5;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x6, x6;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x6, x6;                     \
-        adcs    x17, x17, x8;                   \
-        mul     x8, x7, x7;                     \
-        adcs    x19, x19, x8;                   \
-        umulh   x8, x7, x7;                     \
-        adc     x20, x20, x8;                   \
-        lsl     x5, x2, #32;                    \
-        add     x2, x5, x2;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x2;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x2;                     \
-        umulh   x4, x4, x2;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x2;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x9, x9, x5;                     \
-        sbcs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x2, x2, xzr;                    \
-        lsl     x5, x9, #32;                    \
-        add     x9, x5, x9;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x9;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x9;                     \
-        umulh   x4, x4, x9;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x10, x10, x5;                   \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x5, x10, #32;                   \
-        add     x10, x5, x10;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x10;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x10;                    \
-        umulh   x4, x4, x10;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x10;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x11, x11, x5;                   \
-        sbcs    x12, x12, x4;                   \
-        sbcs    x13, x13, x3;                   \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        lsl     x5, x11, #32;                   \
-        add     x11, x5, x11;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x11;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x11;                    \
-        umulh   x4, x4, x11;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x12, x12, x5;                   \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x2, x2, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        lsl     x5, x12, #32;                   \
-        add     x12, x5, x12;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x12;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x12;                    \
-        umulh   x4, x4, x12;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x12;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x13, x13, x5;                   \
-        sbcs    x2, x2, x4;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x5, x13, #32;                   \
-        add     x13, x5, x13;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x13;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x13;                    \
-        umulh   x4, x4, x13;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x13;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x2, x2, x5;                     \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adcs    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adc     x6, xzr, xzr;                   \
-        mov     x8, #-4294967295;               \
-        adds    x14, x2, x8;                    \
-        mov     x8, #4294967295;                \
-        adcs    x15, x9, x8;                    \
-        mov     x8, #1;                         \
-        adcs    x16, x10, x8;                   \
-        adcs    x17, x11, xzr;                  \
-        adcs    x19, x12, xzr;                  \
-        adcs    x20, x13, xzr;                  \
-        adcs    x6, x6, xzr;                    \
-        csel    x2, x2, x14, eq;                \
-        csel    x9, x9, x15, eq;                \
-        csel    x10, x10, x16, eq;              \
-        csel    x11, x11, x17, eq;              \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        stp     x2, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x8, x2, x4 __LF                    \
+        adds    x10, x10, x8 __LF                  \
+        mul     x11, x2, x5 __LF                   \
+        mul     x8, x3, x4 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x8, x3, x5 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x13, x2, x7 __LF                   \
+        mul     x8, x3, x6 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x14, x2, x7 __LF                   \
+        mul     x8, x3, x7 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x15, x5, x6 __LF                   \
+        adcs    x15, x15, xzr __LF                 \
+        umulh   x16, x5, x6 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        umulh   x8, x2, x4 __LF                    \
+        adds    x11, x11, x8 __LF                  \
+        umulh   x8, x3, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x3, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x8, x3, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x3, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        adc     x16, x16, xzr __LF                 \
+        mul     x8, x2, x6 __LF                    \
+        adds    x12, x12, x8 __LF                  \
+        mul     x8, x4, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x4, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x8, x4, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x5, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        mul     x17, x6, x7 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x19, x6, x7 __LF                   \
+        adc     x19, x19, xzr __LF                 \
+        umulh   x8, x2, x6 __LF                    \
+        adds    x13, x13, x8 __LF                  \
+        umulh   x8, x4, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x4, x6 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        umulh   x8, x4, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x5, x7 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        adc     x19, x19, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x8, x2, x2 __LF                    \
+        mul     x2, x2, x2 __LF                    \
+        adds    x9, x9, x8 __LF                    \
+        mul     x8, x3, x3 __LF                    \
+        adcs    x10, x10, x8 __LF                  \
+        umulh   x8, x3, x3 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        mul     x8, x4, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x4, x4 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x5, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x5, x5 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x6, x6 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x6, x6 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        mul     x8, x7, x7 __LF                    \
+        adcs    x19, x19, x8 __LF                  \
+        umulh   x8, x7, x7 __LF                    \
+        adc     x20, x20, x8 __LF                  \
+        lsl     x5, x2, #32 __LF                   \
+        add     x2, x5, x2 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x2 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x2 __LF                    \
+        umulh   x4, x4, x2 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x2 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x9, x9, x5 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x2, x2, xzr __LF                   \
+        lsl     x5, x9, #32 __LF                   \
+        add     x9, x5, x9 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x9 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x9 __LF                    \
+        umulh   x4, x4, x9 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x10, x10, x5 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x5, x10, #32 __LF                  \
+        add     x10, x5, x10 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x10 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x10 __LF                   \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x10 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x11, x11, x5 __LF                  \
+        sbcs    x12, x12, x4 __LF                  \
+        sbcs    x13, x13, x3 __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        lsl     x5, x11, #32 __LF                  \
+        add     x11, x5, x11 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x11 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x11 __LF                   \
+        umulh   x4, x4, x11 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x2, x2, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        lsl     x5, x12, #32 __LF                  \
+        add     x12, x5, x12 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x12 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x12 __LF                   \
+        umulh   x4, x4, x12 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x13, x13, x5 __LF                  \
+        sbcs    x2, x2, x4 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x5, x13, #32 __LF                  \
+        add     x13, x5, x13 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x13 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x13 __LF                   \
+        umulh   x4, x4, x13 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x13 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x2, x2, x5 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adcs    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        mov     x8, #-4294967295 __LF              \
+        adds    x14, x2, x8 __LF                   \
+        mov     x8, #4294967295 __LF               \
+        adcs    x15, x9, x8 __LF                   \
+        mov     x8, #1 __LF                        \
+        adcs    x16, x10, x8 __LF                  \
+        adcs    x17, x11, xzr __LF                 \
+        adcs    x19, x12, xzr __LF                 \
+        adcs    x20, x13, xzr __LF                 \
+        adcs    x6, x6, xzr __LF                   \
+        csel    x2, x2, x14, eq __LF               \
+        csel    x9, x9, x15, eq __LF               \
+        csel    x10, x10, x16, eq __LF             \
+        csel    x11, x11, x17, eq __LF             \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        stp     x2, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         stp     x12, x13, [P0+32]
 
 // Almost-Montgomery variant which we use when an input to other muls
@@ -573,245 +573,245 @@
 // *need* the restriction that the other argument is reduced.
 
 #define amontsqr_p384(P0,P1)                    \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x8, x2, x4;                     \
-        adds    x10, x10, x8;                   \
-        mul     x11, x2, x5;                    \
-        mul     x8, x3, x4;                     \
-        adcs    x11, x11, x8;                   \
-        umulh   x12, x2, x5;                    \
-        mul     x8, x3, x5;                     \
-        adcs    x12, x12, x8;                   \
-        ldp     x6, x7, [P1+32];                \
-        mul     x13, x2, x7;                    \
-        mul     x8, x3, x6;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x14, x2, x7;                    \
-        mul     x8, x3, x7;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x15, x5, x6;                    \
-        adcs    x15, x15, xzr;                  \
-        umulh   x16, x5, x6;                    \
-        adc     x16, x16, xzr;                  \
-        umulh   x8, x2, x4;                     \
-        adds    x11, x11, x8;                   \
-        umulh   x8, x3, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x3, x5;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x8, x3, x6;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x3, x7;                     \
-        adcs    x15, x15, x8;                   \
-        adc     x16, x16, xzr;                  \
-        mul     x8, x2, x6;                     \
-        adds    x12, x12, x8;                   \
-        mul     x8, x4, x5;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x4, x6;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x8, x4, x7;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x5, x7;                     \
-        adcs    x16, x16, x8;                   \
-        mul     x17, x6, x7;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x19, x6, x7;                    \
-        adc     x19, x19, xzr;                  \
-        umulh   x8, x2, x6;                     \
-        adds    x13, x13, x8;                   \
-        umulh   x8, x4, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x4, x6;                     \
-        adcs    x15, x15, x8;                   \
-        umulh   x8, x4, x7;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x5, x7;                     \
-        adcs    x17, x17, x8;                   \
-        adc     x19, x19, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        cset    x20, hs;                        \
-        umulh   x8, x2, x2;                     \
-        mul     x2, x2, x2;                     \
-        adds    x9, x9, x8;                     \
-        mul     x8, x3, x3;                     \
-        adcs    x10, x10, x8;                   \
-        umulh   x8, x3, x3;                     \
-        adcs    x11, x11, x8;                   \
-        mul     x8, x4, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x4, x4;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x5, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x5, x5;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x6, x6;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x6, x6;                     \
-        adcs    x17, x17, x8;                   \
-        mul     x8, x7, x7;                     \
-        adcs    x19, x19, x8;                   \
-        umulh   x8, x7, x7;                     \
-        adc     x20, x20, x8;                   \
-        lsl     x5, x2, #32;                    \
-        add     x2, x5, x2;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x2;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x2;                     \
-        umulh   x4, x4, x2;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x2;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x9, x9, x5;                     \
-        sbcs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x2, x2, xzr;                    \
-        lsl     x5, x9, #32;                    \
-        add     x9, x5, x9;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x9;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x9;                     \
-        umulh   x4, x4, x9;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x10, x10, x5;                   \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x5, x10, #32;                   \
-        add     x10, x5, x10;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x10;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x10;                    \
-        umulh   x4, x4, x10;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x10;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x11, x11, x5;                   \
-        sbcs    x12, x12, x4;                   \
-        sbcs    x13, x13, x3;                   \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        lsl     x5, x11, #32;                   \
-        add     x11, x5, x11;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x11;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x11;                    \
-        umulh   x4, x4, x11;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x12, x12, x5;                   \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x2, x2, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        lsl     x5, x12, #32;                   \
-        add     x12, x5, x12;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x12;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x12;                    \
-        umulh   x4, x4, x12;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x12;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x13, x13, x5;                   \
-        sbcs    x2, x2, x4;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x5, x13, #32;                   \
-        add     x13, x5, x13;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x13;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x13;                    \
-        umulh   x4, x4, x13;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x13;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x2, x2, x5;                     \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adcs    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        mov     x14, #-4294967295;              \
-        mov     x15, #4294967295;               \
-        csel    x14, x14, xzr, cs;              \
-        csel    x15, x15, xzr, cs;              \
-        cset    x16, cs;                        \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, xzr;                  \
-        adcs    x12, x12, xzr;                  \
-        adc     x13, x13, xzr;                  \
-        stp     x2, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x8, x2, x4 __LF                    \
+        adds    x10, x10, x8 __LF                  \
+        mul     x11, x2, x5 __LF                   \
+        mul     x8, x3, x4 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x8, x3, x5 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x13, x2, x7 __LF                   \
+        mul     x8, x3, x6 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x14, x2, x7 __LF                   \
+        mul     x8, x3, x7 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x15, x5, x6 __LF                   \
+        adcs    x15, x15, xzr __LF                 \
+        umulh   x16, x5, x6 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        umulh   x8, x2, x4 __LF                    \
+        adds    x11, x11, x8 __LF                  \
+        umulh   x8, x3, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x3, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x8, x3, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x3, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        adc     x16, x16, xzr __LF                 \
+        mul     x8, x2, x6 __LF                    \
+        adds    x12, x12, x8 __LF                  \
+        mul     x8, x4, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x4, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x8, x4, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x5, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        mul     x17, x6, x7 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x19, x6, x7 __LF                   \
+        adc     x19, x19, xzr __LF                 \
+        umulh   x8, x2, x6 __LF                    \
+        adds    x13, x13, x8 __LF                  \
+        umulh   x8, x4, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x4, x6 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        umulh   x8, x4, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x5, x7 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        adc     x19, x19, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x8, x2, x2 __LF                    \
+        mul     x2, x2, x2 __LF                    \
+        adds    x9, x9, x8 __LF                    \
+        mul     x8, x3, x3 __LF                    \
+        adcs    x10, x10, x8 __LF                  \
+        umulh   x8, x3, x3 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        mul     x8, x4, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x4, x4 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x5, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x5, x5 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x6, x6 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x6, x6 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        mul     x8, x7, x7 __LF                    \
+        adcs    x19, x19, x8 __LF                  \
+        umulh   x8, x7, x7 __LF                    \
+        adc     x20, x20, x8 __LF                  \
+        lsl     x5, x2, #32 __LF                   \
+        add     x2, x5, x2 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x2 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x2 __LF                    \
+        umulh   x4, x4, x2 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x2 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x9, x9, x5 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x2, x2, xzr __LF                   \
+        lsl     x5, x9, #32 __LF                   \
+        add     x9, x5, x9 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x9 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x9 __LF                    \
+        umulh   x4, x4, x9 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x10, x10, x5 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x5, x10, #32 __LF                  \
+        add     x10, x5, x10 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x10 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x10 __LF                   \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x10 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x11, x11, x5 __LF                  \
+        sbcs    x12, x12, x4 __LF                  \
+        sbcs    x13, x13, x3 __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        lsl     x5, x11, #32 __LF                  \
+        add     x11, x5, x11 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x11 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x11 __LF                   \
+        umulh   x4, x4, x11 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x2, x2, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        lsl     x5, x12, #32 __LF                  \
+        add     x12, x5, x12 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x12 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x12 __LF                   \
+        umulh   x4, x4, x12 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x13, x13, x5 __LF                  \
+        sbcs    x2, x2, x4 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x5, x13, #32 __LF                  \
+        add     x13, x5, x13 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x13 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x13 __LF                   \
+        umulh   x4, x4, x13 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x13 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x2, x2, x5 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adcs    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        mov     x14, #-4294967295 __LF             \
+        mov     x15, #4294967295 __LF              \
+        csel    x14, x14, xzr, cs __LF             \
+        csel    x15, x15, xzr, cs __LF             \
+        cset    x16, cs __LF                       \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        adcs    x12, x12, xzr __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        stp     x2, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         stp     x12, x13, [P0+32]
 
 // Corresponds exactly to bignum_sub_p384
 
 #define sub_p384(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        csetm   x3, lo;                         \
-        mov     x4, #4294967295;                \
-        and     x4, x4, x3;                     \
-        adds    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        mov     x4, #-2;                        \
-        and     x4, x4, x3;                     \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        adcs    x9, x9, x3;                     \
-        adc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        csetm   x3, lo __LF                        \
+        mov     x4, #4294967295 __LF               \
+        and     x4, x4, x3 __LF                    \
+        adds    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        mov     x4, #-2 __LF                       \
+        and     x4, x4, x3 __LF                    \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        adcs    x9, x9, x3 __LF                    \
+        adc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 S2N_BN_SYMBOL(p384_montjadd_alt):

--- a/arm/p384/p384_montjdouble_alt.S
+++ b/arm/p384/p384_montjdouble_alt.S
@@ -61,815 +61,815 @@
 // Corresponds exactly to bignum_montmul_p384_alt
 
 #define montmul_p384(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x12, x3, x5;                    \
-        umulh   x13, x3, x5;                    \
-        mul     x11, x3, x6;                    \
-        umulh   x14, x3, x6;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x11, x3, x7;                    \
-        umulh   x15, x3, x7;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x8;                    \
-        umulh   x16, x3, x8;                    \
-        adcs    x15, x15, x11;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x11, x3, x9;                    \
-        umulh   x17, x3, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x19, x3, x10;                   \
-        adcs    x17, x17, x11;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x11, x4, x5;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x19, x19, x11;                  \
-        cset    x20, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x20, x20, x11;                  \
-        ldp     x3, x4, [P1+16];                \
-        mul     x11, x3, x5;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x20, x20, x11;                  \
-        cset    x21, cs;                        \
-        umulh   x11, x3, x5;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x21, x21, x11;                  \
-        mul     x11, x4, x5;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x21, x21, x11;                  \
-        cset    x22, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x22, x22, x11;                  \
-        ldp     x3, x4, [P1+32];                \
-        mul     x11, x3, x5;                    \
-        adds    x16, x16, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x22, x22, x11;                  \
-        cset    x2, cs;                         \
-        umulh   x11, x3, x5;                    \
-        adds    x17, x17, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x2, x2, x11;                    \
-        mul     x11, x4, x5;                    \
-        adds    x17, x17, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x22, x22, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x2, x2, x11;                    \
-        cset    x1, cs;                         \
-        umulh   x11, x4, x5;                    \
-        adds    x19, x19, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x2, x2, x11;                    \
-        umulh   x11, x4, x10;                   \
-        adc     x1, x1, x11;                    \
-        lsl     x7, x12, #32;                   \
-        add     x12, x7, x12;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x12;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x12;                    \
-        umulh   x6, x6, x12;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x12;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x13, x13, x7;                   \
-        sbcs    x14, x14, x6;                   \
-        sbcs    x15, x15, x5;                   \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x7, x13, #32;                   \
-        add     x13, x7, x13;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x13;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x13;                    \
-        umulh   x6, x6, x13;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x13;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x14, x14, x7;                   \
-        sbcs    x15, x15, x6;                   \
-        sbcs    x16, x16, x5;                   \
-        sbcs    x17, x17, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        lsl     x7, x14, #32;                   \
-        add     x14, x7, x14;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x14;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x14;                    \
-        umulh   x6, x6, x14;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x14;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x15, x15, x7;                   \
-        sbcs    x16, x16, x6;                   \
-        sbcs    x17, x17, x5;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x14, x14, xzr;                  \
-        lsl     x7, x15, #32;                   \
-        add     x15, x7, x15;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x15;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x15;                    \
-        umulh   x6, x6, x15;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x15;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x16, x16, x7;                   \
-        sbcs    x17, x17, x6;                   \
-        sbcs    x12, x12, x5;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        lsl     x7, x16, #32;                   \
-        add     x16, x7, x16;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x16;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x16;                    \
-        umulh   x6, x6, x16;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x16;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x17, x17, x7;                   \
-        sbcs    x12, x12, x6;                   \
-        sbcs    x13, x13, x5;                   \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbc     x16, x16, xzr;                  \
-        lsl     x7, x17, #32;                   \
-        add     x17, x7, x17;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x17;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x17;                    \
-        umulh   x6, x6, x17;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x17;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, x6;                   \
-        sbcs    x14, x14, x5;                   \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbc     x17, x17, xzr;                  \
-        adds    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adcs    x14, x14, x21;                  \
-        adcs    x15, x15, x22;                  \
-        adcs    x16, x16, x2;                   \
-        adcs    x17, x17, x1;                   \
-        adc     x10, xzr, xzr;                  \
-        mov     x11, #0xffffffff00000001;       \
-        adds    x19, x12, x11;                  \
-        mov     x11, #0xffffffff;               \
-        adcs    x20, x13, x11;                  \
-        mov     x11, #0x1;                      \
-        adcs    x21, x14, x11;                  \
-        adcs    x22, x15, xzr;                  \
-        adcs    x2, x16, xzr;                   \
-        adcs    x1, x17, xzr;                   \
-        adcs    x10, x10, xzr;                  \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        csel    x14, x14, x21, eq;              \
-        csel    x15, x15, x22, eq;              \
-        csel    x16, x16, x2, eq;               \
-        csel    x17, x17, x1, eq;               \
-        stp     x12, x13, [P0];                 \
-        stp     x14, x15, [P0+16];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x12, x3, x5 __LF                   \
+        umulh   x13, x3, x5 __LF                   \
+        mul     x11, x3, x6 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x11, x3, x7 __LF                   \
+        umulh   x15, x3, x7 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x16, x3, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x17, x3, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x19, x3, x10 __LF                  \
+        adcs    x17, x17, x11 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x19, x19, x11 __LF                 \
+        cset    x20, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x20, x20, x11 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x20, x20, x11 __LF                 \
+        cset    x21, cs __LF                       \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x21, x21, x11 __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x21, x21, x11 __LF                 \
+        cset    x22, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x22, x22, x11 __LF                 \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x22, x22, x11 __LF                 \
+        cset    x2, cs __LF                        \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x2, x2, x11 __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x2, x2, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x2, x2, x11 __LF                   \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x1, x1, x11 __LF                   \
+        lsl     x7, x12, #32 __LF                  \
+        add     x12, x7, x12 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x12 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x12 __LF                   \
+        umulh   x6, x6, x12 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x6 __LF                  \
+        sbcs    x15, x15, x5 __LF                  \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x7, x13, #32 __LF                  \
+        add     x13, x7, x13 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x13 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x13 __LF                   \
+        umulh   x6, x6, x13 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x13 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x14, x14, x7 __LF                  \
+        sbcs    x15, x15, x6 __LF                  \
+        sbcs    x16, x16, x5 __LF                  \
+        sbcs    x17, x17, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        lsl     x7, x14, #32 __LF                  \
+        add     x14, x7, x14 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x14 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x14 __LF                   \
+        umulh   x6, x6, x14 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x14 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x15, x15, x7 __LF                  \
+        sbcs    x16, x16, x6 __LF                  \
+        sbcs    x17, x17, x5 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x14, x14, xzr __LF                 \
+        lsl     x7, x15, #32 __LF                  \
+        add     x15, x7, x15 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x15 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x15 __LF                   \
+        umulh   x6, x6, x15 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x15 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x16, x16, x7 __LF                  \
+        sbcs    x17, x17, x6 __LF                  \
+        sbcs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        lsl     x7, x16, #32 __LF                  \
+        add     x16, x7, x16 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x16 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x16 __LF                   \
+        umulh   x6, x6, x16 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x16 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x17, x17, x7 __LF                  \
+        sbcs    x12, x12, x6 __LF                  \
+        sbcs    x13, x13, x5 __LF                  \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbc     x16, x16, xzr __LF                 \
+        lsl     x7, x17, #32 __LF                  \
+        add     x17, x7, x17 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x17 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x17 __LF                   \
+        umulh   x6, x6, x17 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x17 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x6 __LF                  \
+        sbcs    x14, x14, x5 __LF                  \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbc     x17, x17, xzr __LF                 \
+        adds    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adcs    x14, x14, x21 __LF                 \
+        adcs    x15, x15, x22 __LF                 \
+        adcs    x16, x16, x2 __LF                  \
+        adcs    x17, x17, x1 __LF                  \
+        adc     x10, xzr, xzr __LF                 \
+        mov     x11, #0xffffffff00000001 __LF      \
+        adds    x19, x12, x11 __LF                 \
+        mov     x11, #0xffffffff __LF              \
+        adcs    x20, x13, x11 __LF                 \
+        mov     x11, #0x1 __LF                     \
+        adcs    x21, x14, x11 __LF                 \
+        adcs    x22, x15, xzr __LF                 \
+        adcs    x2, x16, xzr __LF                  \
+        adcs    x1, x17, xzr __LF                  \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        csel    x14, x14, x21, eq __LF             \
+        csel    x15, x15, x22, eq __LF             \
+        csel    x16, x16, x2, eq __LF              \
+        csel    x17, x17, x1, eq __LF              \
+        stp     x12, x13, [P0] __LF                \
+        stp     x14, x15, [P0+16] __LF             \
         stp     x16, x17, [P0+32]
 
 // Corresponds exactly to bignum_montsqr_p384_alt
 
 #define montsqr_p384(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x8, x2, x4;                     \
-        adds    x10, x10, x8;                   \
-        mul     x11, x2, x5;                    \
-        mul     x8, x3, x4;                     \
-        adcs    x11, x11, x8;                   \
-        umulh   x12, x2, x5;                    \
-        mul     x8, x3, x5;                     \
-        adcs    x12, x12, x8;                   \
-        ldp     x6, x7, [P1+32];                \
-        mul     x13, x2, x7;                    \
-        mul     x8, x3, x6;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x14, x2, x7;                    \
-        mul     x8, x3, x7;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x15, x5, x6;                    \
-        adcs    x15, x15, xzr;                  \
-        umulh   x16, x5, x6;                    \
-        adc     x16, x16, xzr;                  \
-        umulh   x8, x2, x4;                     \
-        adds    x11, x11, x8;                   \
-        umulh   x8, x3, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x3, x5;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x8, x3, x6;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x3, x7;                     \
-        adcs    x15, x15, x8;                   \
-        adc     x16, x16, xzr;                  \
-        mul     x8, x2, x6;                     \
-        adds    x12, x12, x8;                   \
-        mul     x8, x4, x5;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x4, x6;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x8, x4, x7;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x5, x7;                     \
-        adcs    x16, x16, x8;                   \
-        mul     x17, x6, x7;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x19, x6, x7;                    \
-        adc     x19, x19, xzr;                  \
-        umulh   x8, x2, x6;                     \
-        adds    x13, x13, x8;                   \
-        umulh   x8, x4, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x4, x6;                     \
-        adcs    x15, x15, x8;                   \
-        umulh   x8, x4, x7;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x5, x7;                     \
-        adcs    x17, x17, x8;                   \
-        adc     x19, x19, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        cset    x20, hs;                        \
-        umulh   x8, x2, x2;                     \
-        mul     x2, x2, x2;                     \
-        adds    x9, x9, x8;                     \
-        mul     x8, x3, x3;                     \
-        adcs    x10, x10, x8;                   \
-        umulh   x8, x3, x3;                     \
-        adcs    x11, x11, x8;                   \
-        mul     x8, x4, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x4, x4;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x5, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x5, x5;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x6, x6;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x6, x6;                     \
-        adcs    x17, x17, x8;                   \
-        mul     x8, x7, x7;                     \
-        adcs    x19, x19, x8;                   \
-        umulh   x8, x7, x7;                     \
-        adc     x20, x20, x8;                   \
-        lsl     x5, x2, #32;                    \
-        add     x2, x5, x2;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x2;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x2;                     \
-        umulh   x4, x4, x2;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x2;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x9, x9, x5;                     \
-        sbcs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x2, x2, xzr;                    \
-        lsl     x5, x9, #32;                    \
-        add     x9, x5, x9;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x9;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x9;                     \
-        umulh   x4, x4, x9;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x10, x10, x5;                   \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x5, x10, #32;                   \
-        add     x10, x5, x10;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x10;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x10;                    \
-        umulh   x4, x4, x10;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x10;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x11, x11, x5;                   \
-        sbcs    x12, x12, x4;                   \
-        sbcs    x13, x13, x3;                   \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        lsl     x5, x11, #32;                   \
-        add     x11, x5, x11;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x11;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x11;                    \
-        umulh   x4, x4, x11;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x12, x12, x5;                   \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x2, x2, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        lsl     x5, x12, #32;                   \
-        add     x12, x5, x12;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x12;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x12;                    \
-        umulh   x4, x4, x12;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x12;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x13, x13, x5;                   \
-        sbcs    x2, x2, x4;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x5, x13, #32;                   \
-        add     x13, x5, x13;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x13;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x13;                    \
-        umulh   x4, x4, x13;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x13;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x2, x2, x5;                     \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adcs    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adc     x6, xzr, xzr;                   \
-        mov     x8, #-4294967295;               \
-        adds    x14, x2, x8;                    \
-        mov     x8, #4294967295;                \
-        adcs    x15, x9, x8;                    \
-        mov     x8, #1;                         \
-        adcs    x16, x10, x8;                   \
-        adcs    x17, x11, xzr;                  \
-        adcs    x19, x12, xzr;                  \
-        adcs    x20, x13, xzr;                  \
-        adcs    x6, x6, xzr;                    \
-        csel    x2, x2, x14, eq;                \
-        csel    x9, x9, x15, eq;                \
-        csel    x10, x10, x16, eq;              \
-        csel    x11, x11, x17, eq;              \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        stp     x2, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x8, x2, x4 __LF                    \
+        adds    x10, x10, x8 __LF                  \
+        mul     x11, x2, x5 __LF                   \
+        mul     x8, x3, x4 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x8, x3, x5 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x13, x2, x7 __LF                   \
+        mul     x8, x3, x6 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x14, x2, x7 __LF                   \
+        mul     x8, x3, x7 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x15, x5, x6 __LF                   \
+        adcs    x15, x15, xzr __LF                 \
+        umulh   x16, x5, x6 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        umulh   x8, x2, x4 __LF                    \
+        adds    x11, x11, x8 __LF                  \
+        umulh   x8, x3, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x3, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x8, x3, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x3, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        adc     x16, x16, xzr __LF                 \
+        mul     x8, x2, x6 __LF                    \
+        adds    x12, x12, x8 __LF                  \
+        mul     x8, x4, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x4, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x8, x4, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x5, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        mul     x17, x6, x7 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x19, x6, x7 __LF                   \
+        adc     x19, x19, xzr __LF                 \
+        umulh   x8, x2, x6 __LF                    \
+        adds    x13, x13, x8 __LF                  \
+        umulh   x8, x4, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x4, x6 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        umulh   x8, x4, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x5, x7 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        adc     x19, x19, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x8, x2, x2 __LF                    \
+        mul     x2, x2, x2 __LF                    \
+        adds    x9, x9, x8 __LF                    \
+        mul     x8, x3, x3 __LF                    \
+        adcs    x10, x10, x8 __LF                  \
+        umulh   x8, x3, x3 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        mul     x8, x4, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x4, x4 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x5, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x5, x5 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x6, x6 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x6, x6 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        mul     x8, x7, x7 __LF                    \
+        adcs    x19, x19, x8 __LF                  \
+        umulh   x8, x7, x7 __LF                    \
+        adc     x20, x20, x8 __LF                  \
+        lsl     x5, x2, #32 __LF                   \
+        add     x2, x5, x2 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x2 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x2 __LF                    \
+        umulh   x4, x4, x2 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x2 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x9, x9, x5 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x2, x2, xzr __LF                   \
+        lsl     x5, x9, #32 __LF                   \
+        add     x9, x5, x9 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x9 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x9 __LF                    \
+        umulh   x4, x4, x9 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x10, x10, x5 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x5, x10, #32 __LF                  \
+        add     x10, x5, x10 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x10 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x10 __LF                   \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x10 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x11, x11, x5 __LF                  \
+        sbcs    x12, x12, x4 __LF                  \
+        sbcs    x13, x13, x3 __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        lsl     x5, x11, #32 __LF                  \
+        add     x11, x5, x11 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x11 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x11 __LF                   \
+        umulh   x4, x4, x11 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x2, x2, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        lsl     x5, x12, #32 __LF                  \
+        add     x12, x5, x12 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x12 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x12 __LF                   \
+        umulh   x4, x4, x12 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x13, x13, x5 __LF                  \
+        sbcs    x2, x2, x4 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x5, x13, #32 __LF                  \
+        add     x13, x5, x13 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x13 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x13 __LF                   \
+        umulh   x4, x4, x13 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x13 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x2, x2, x5 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adcs    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        mov     x8, #-4294967295 __LF              \
+        adds    x14, x2, x8 __LF                   \
+        mov     x8, #4294967295 __LF               \
+        adcs    x15, x9, x8 __LF                   \
+        mov     x8, #1 __LF                        \
+        adcs    x16, x10, x8 __LF                  \
+        adcs    x17, x11, xzr __LF                 \
+        adcs    x19, x12, xzr __LF                 \
+        adcs    x20, x13, xzr __LF                 \
+        adcs    x6, x6, xzr __LF                   \
+        csel    x2, x2, x14, eq __LF               \
+        csel    x9, x9, x15, eq __LF               \
+        csel    x10, x10, x16, eq __LF             \
+        csel    x11, x11, x17, eq __LF             \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        stp     x2, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         stp     x12, x13, [P0+32]
 
 // Corresponds exactly to bignum_sub_p384
 
 #define sub_p384(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        csetm   x3, lo;                         \
-        mov     x4, #4294967295;                \
-        and     x4, x4, x3;                     \
-        adds    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        mov     x4, #-2;                        \
-        and     x4, x4, x3;                     \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        adcs    x9, x9, x3;                     \
-        adc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        csetm   x3, lo __LF                        \
+        mov     x4, #4294967295 __LF               \
+        and     x4, x4, x3 __LF                    \
+        adds    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        mov     x4, #-2 __LF                       \
+        and     x4, x4, x3 __LF                    \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        adcs    x9, x9, x3 __LF                    \
+        adc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 // Corresponds exactly to bignum_add_p384
 
 #define add_p384(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x3;                   \
-        adc     x3, xzr, xzr;                   \
-        mov     x4, #0xffffffff;                \
-        cmp     x5, x4;                         \
-        mov     x4, #0xffffffff00000000;        \
-        sbcs    xzr, x6, x4;                    \
-        mov     x4, #0xfffffffffffffffe;        \
-        sbcs    xzr, x7, x4;                    \
-        adcs    xzr, x8, xzr;                   \
-        adcs    xzr, x9, xzr;                   \
-        adcs    xzr, x10, xzr;                  \
-        adcs    x3, x3, xzr;                    \
-        csetm   x3, ne;                         \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        subs    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        sbcs    x6, x6, x4;                     \
-        mov     x4, #0xfffffffffffffffe;        \
-        and     x4, x4, x3;                     \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x3;                     \
-        sbc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x3 __LF                  \
+        adc     x3, xzr, xzr __LF                  \
+        mov     x4, #0xffffffff __LF               \
+        cmp     x5, x4 __LF                        \
+        mov     x4, #0xffffffff00000000 __LF       \
+        sbcs    xzr, x6, x4 __LF                   \
+        mov     x4, #0xfffffffffffffffe __LF       \
+        sbcs    xzr, x7, x4 __LF                   \
+        adcs    xzr, x8, xzr __LF                  \
+        adcs    xzr, x9, xzr __LF                  \
+        adcs    xzr, x10, xzr __LF                 \
+        adcs    x3, x3, xzr __LF                   \
+        csetm   x3, ne __LF                        \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        subs    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        sbcs    x6, x6, x4 __LF                    \
+        mov     x4, #0xfffffffffffffffe __LF       \
+        and     x4, x4, x3 __LF                    \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 // P0 = 4 * P1 - P2
 
 #define cmsub41_p384(P0,P1,P2)                  \
-        ldp     x1, x2, [P1];                   \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P1+32];                \
-        lsl     x0, x1, #2;                     \
-        ldp     x7, x8, [P2];                   \
-        subs    x0, x0, x7;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x8;                     \
-        ldp     x7, x8, [P2+16];                \
-        extr    x2, x3, x2, #62;                \
-        sbcs    x2, x2, x7;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x8;                     \
-        extr    x4, x5, x4, #62;                \
-        ldp     x7, x8, [P2+32];                \
-        sbcs    x4, x4, x7;                     \
-        extr    x5, x6, x5, #62;                \
-        sbcs    x5, x5, x8;                     \
-        lsr     x6, x6, #62;                    \
-        adc     x6, x6, xzr;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x8, cc;                         \
-        mov     x9, #0xffffffff;                \
-        and     x9, x9, x8;                     \
-        adds    x0, x0, x9;                     \
-        eor     x9, x9, x8;                     \
-        adcs    x1, x1, x9;                     \
-        mov     x9, #0xfffffffffffffffe;        \
-        and     x9, x9, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x8;                     \
-        adcs    x4, x4, x8;                     \
-        adc     x5, x5, x8;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x1, x2, [P1] __LF                  \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P1+32] __LF               \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x7, x8, [P2] __LF                  \
+        subs    x0, x0, x7 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x8 __LF                    \
+        ldp     x7, x8, [P2+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        sbcs    x2, x2, x7 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x8 __LF                    \
+        extr    x4, x5, x4, #62 __LF               \
+        ldp     x7, x8, [P2+32] __LF               \
+        sbcs    x4, x4, x7 __LF                    \
+        extr    x5, x6, x5, #62 __LF               \
+        sbcs    x5, x5, x8 __LF                    \
+        lsr     x6, x6, #62 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x8, cc __LF                        \
+        mov     x9, #0xffffffff __LF               \
+        and     x9, x9, x8 __LF                    \
+        adds    x0, x0, x9 __LF                    \
+        eor     x9, x9, x8 __LF                    \
+        adcs    x1, x1, x9 __LF                    \
+        mov     x9, #0xfffffffffffffffe __LF       \
+        and     x9, x9, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        adc     x5, x5, x8 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 // P0 = C * P1 - D * P2
 
 #define cmsub_p384(P0,C,P1,D,P2)                \
-        ldp     x0, x1, [P2];                   \
-        mov     x6, #0x00000000ffffffff;        \
-        subs    x6, x6, x0;                     \
-        mov     x7, #0xffffffff00000000;        \
-        sbcs    x7, x7, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        mov     x8, #0xfffffffffffffffe;        \
-        sbcs    x8, x8, x0;                     \
-        mov     x13, #0xffffffffffffffff;       \
-        sbcs    x9, x13, x1;                    \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x10, x13, x0;                   \
-        sbc     x11, x13, x1;                   \
-        mov     x12, D;                         \
-        mul     x0, x12, x6;                    \
-        mul     x1, x12, x7;                    \
-        mul     x2, x12, x8;                    \
-        mul     x3, x12, x9;                    \
-        mul     x4, x12, x10;                   \
-        mul     x5, x12, x11;                   \
-        umulh   x6, x12, x6;                    \
-        umulh   x7, x12, x7;                    \
-        umulh   x8, x12, x8;                    \
-        umulh   x9, x12, x9;                    \
-        umulh   x10, x12, x10;                  \
-        umulh   x12, x12, x11;                  \
-        adds    x1, x1, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x8;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        mov     x6, #1;                         \
-        adc     x6, x12, x6;                    \
-        ldp     x8, x9, [P1];                   \
-        ldp     x10, x11, [P1+16];              \
-        ldp     x12, x13, [P1+32];              \
-        mov     x14, C;                         \
-        mul     x15, x14, x8;                   \
-        umulh   x8, x14, x8;                    \
-        adds    x0, x0, x15;                    \
-        mul     x15, x14, x9;                   \
-        umulh   x9, x14, x9;                    \
-        adcs    x1, x1, x15;                    \
-        mul     x15, x14, x10;                  \
-        umulh   x10, x14, x10;                  \
-        adcs    x2, x2, x15;                    \
-        mul     x15, x14, x11;                  \
-        umulh   x11, x14, x11;                  \
-        adcs    x3, x3, x15;                    \
-        mul     x15, x14, x12;                  \
-        umulh   x12, x14, x12;                  \
-        adcs    x4, x4, x15;                    \
-        mul     x15, x14, x13;                  \
-        umulh   x13, x14, x13;                  \
-        adcs    x5, x5, x15;                    \
-        adc     x6, x6, xzr;                    \
-        adds    x1, x1, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x10;                    \
-        adcs    x4, x4, x11;                    \
-        adcs    x5, x5, x12;                    \
-        adcs    x6, x6, x13;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x6, cc;                         \
-        mov     x7, #0xffffffff;                \
-        and     x7, x7, x6;                     \
-        adds    x0, x0, x7;                     \
-        eor     x7, x7, x6;                     \
-        adcs    x1, x1, x7;                     \
-        mov     x7, #0xfffffffffffffffe;        \
-        and     x7, x7, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x6;                     \
-        adcs    x4, x4, x6;                     \
-        adc     x5, x5, x6;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x0, x1, [P2] __LF                  \
+        mov     x6, #0x00000000ffffffff __LF       \
+        subs    x6, x6, x0 __LF                    \
+        mov     x7, #0xffffffff00000000 __LF       \
+        sbcs    x7, x7, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        mov     x8, #0xfffffffffffffffe __LF       \
+        sbcs    x8, x8, x0 __LF                    \
+        mov     x13, #0xffffffffffffffff __LF      \
+        sbcs    x9, x13, x1 __LF                   \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x10, x13, x0 __LF                  \
+        sbc     x11, x13, x1 __LF                  \
+        mov     x12, D __LF                        \
+        mul     x0, x12, x6 __LF                   \
+        mul     x1, x12, x7 __LF                   \
+        mul     x2, x12, x8 __LF                   \
+        mul     x3, x12, x9 __LF                   \
+        mul     x4, x12, x10 __LF                  \
+        mul     x5, x12, x11 __LF                  \
+        umulh   x6, x12, x6 __LF                   \
+        umulh   x7, x12, x7 __LF                   \
+        umulh   x8, x12, x8 __LF                   \
+        umulh   x9, x12, x9 __LF                   \
+        umulh   x10, x12, x10 __LF                 \
+        umulh   x12, x12, x11 __LF                 \
+        adds    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        mov     x6, #1 __LF                        \
+        adc     x6, x12, x6 __LF                   \
+        ldp     x8, x9, [P1] __LF                  \
+        ldp     x10, x11, [P1+16] __LF             \
+        ldp     x12, x13, [P1+32] __LF             \
+        mov     x14, C __LF                        \
+        mul     x15, x14, x8 __LF                  \
+        umulh   x8, x14, x8 __LF                   \
+        adds    x0, x0, x15 __LF                   \
+        mul     x15, x14, x9 __LF                  \
+        umulh   x9, x14, x9 __LF                   \
+        adcs    x1, x1, x15 __LF                   \
+        mul     x15, x14, x10 __LF                 \
+        umulh   x10, x14, x10 __LF                 \
+        adcs    x2, x2, x15 __LF                   \
+        mul     x15, x14, x11 __LF                 \
+        umulh   x11, x14, x11 __LF                 \
+        adcs    x3, x3, x15 __LF                   \
+        mul     x15, x14, x12 __LF                 \
+        umulh   x12, x14, x12 __LF                 \
+        adcs    x4, x4, x15 __LF                   \
+        mul     x15, x14, x13 __LF                 \
+        umulh   x13, x14, x13 __LF                 \
+        adcs    x5, x5, x15 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        adds    x1, x1, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x10 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adcs    x5, x5, x12 __LF                   \
+        adcs    x6, x6, x13 __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x6, cc __LF                        \
+        mov     x7, #0xffffffff __LF               \
+        and     x7, x7, x6 __LF                    \
+        adds    x0, x0, x7 __LF                    \
+        eor     x7, x7, x6 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        mov     x7, #0xfffffffffffffffe __LF       \
+        and     x7, x7, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x6 __LF                    \
+        adcs    x4, x4, x6 __LF                    \
+        adc     x5, x5, x6 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 // A weak version of add that only guarantees sum in 6 digits
 
 #define weakadd_p384(P0,P1,P2)                  \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x3;                   \
-        csetm   x3, cs;                         \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        subs    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        sbcs    x6, x6, x4;                     \
-        mov     x4, #0xfffffffffffffffe;        \
-        and     x4, x4, x3;                     \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x3;                     \
-        sbc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x3 __LF                  \
+        csetm   x3, cs __LF                        \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        subs    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        sbcs    x6, x6, x4 __LF                    \
+        mov     x4, #0xfffffffffffffffe __LF       \
+        and     x4, x4, x3 __LF                    \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 // P0 = 3 * P1 - 8 * P2
 
 #define cmsub38_p384(P0,P1,P2)                  \
-        ldp     x0, x1, [P2];                   \
-        mov     x6, #0x00000000ffffffff;        \
-        subs    x6, x6, x0;                     \
-        mov     x7, #0xffffffff00000000;        \
-        sbcs    x7, x7, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        mov     x8, #0xfffffffffffffffe;        \
-        sbcs    x8, x8, x0;                     \
-        mov     x13, #0xffffffffffffffff;       \
-        sbcs    x9, x13, x1;                    \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x10, x13, x0;                   \
-        sbc     x11, x13, x1;                   \
-        lsl     x0, x6, #3;                     \
-        extr    x1, x7, x6, #61;                \
-        extr    x2, x8, x7, #61;                \
-        extr    x3, x9, x8, #61;                \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        lsr     x6, x11, #61;                   \
-        add     x6, x6, #1;                     \
-        ldp     x8, x9, [P1];                   \
-        ldp     x10, x11, [P1+16];              \
-        ldp     x12, x13, [P1+32];              \
-        mov     x14, 3;                         \
-        mul     x15, x14, x8;                   \
-        umulh   x8, x14, x8;                    \
-        adds    x0, x0, x15;                    \
-        mul     x15, x14, x9;                   \
-        umulh   x9, x14, x9;                    \
-        adcs    x1, x1, x15;                    \
-        mul     x15, x14, x10;                  \
-        umulh   x10, x14, x10;                  \
-        adcs    x2, x2, x15;                    \
-        mul     x15, x14, x11;                  \
-        umulh   x11, x14, x11;                  \
-        adcs    x3, x3, x15;                    \
-        mul     x15, x14, x12;                  \
-        umulh   x12, x14, x12;                  \
-        adcs    x4, x4, x15;                    \
-        mul     x15, x14, x13;                  \
-        umulh   x13, x14, x13;                  \
-        adcs    x5, x5, x15;                    \
-        adc     x6, x6, xzr;                    \
-        adds    x1, x1, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x10;                    \
-        adcs    x4, x4, x11;                    \
-        adcs    x5, x5, x12;                    \
-        adcs    x6, x6, x13;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x6, cc;                         \
-        mov     x7, #0xffffffff;                \
-        and     x7, x7, x6;                     \
-        adds    x0, x0, x7;                     \
-        eor     x7, x7, x6;                     \
-        adcs    x1, x1, x7;                     \
-        mov     x7, #0xfffffffffffffffe;        \
-        and     x7, x7, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x6;                     \
-        adcs    x4, x4, x6;                     \
-        adc     x5, x5, x6;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x0, x1, [P2] __LF                  \
+        mov     x6, #0x00000000ffffffff __LF       \
+        subs    x6, x6, x0 __LF                    \
+        mov     x7, #0xffffffff00000000 __LF       \
+        sbcs    x7, x7, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        mov     x8, #0xfffffffffffffffe __LF       \
+        sbcs    x8, x8, x0 __LF                    \
+        mov     x13, #0xffffffffffffffff __LF      \
+        sbcs    x9, x13, x1 __LF                   \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x10, x13, x0 __LF                  \
+        sbc     x11, x13, x1 __LF                  \
+        lsl     x0, x6, #3 __LF                    \
+        extr    x1, x7, x6, #61 __LF               \
+        extr    x2, x8, x7, #61 __LF               \
+        extr    x3, x9, x8, #61 __LF               \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        lsr     x6, x11, #61 __LF                  \
+        add     x6, x6, #1 __LF                    \
+        ldp     x8, x9, [P1] __LF                  \
+        ldp     x10, x11, [P1+16] __LF             \
+        ldp     x12, x13, [P1+32] __LF             \
+        mov     x14, 3 __LF                        \
+        mul     x15, x14, x8 __LF                  \
+        umulh   x8, x14, x8 __LF                   \
+        adds    x0, x0, x15 __LF                   \
+        mul     x15, x14, x9 __LF                  \
+        umulh   x9, x14, x9 __LF                   \
+        adcs    x1, x1, x15 __LF                   \
+        mul     x15, x14, x10 __LF                 \
+        umulh   x10, x14, x10 __LF                 \
+        adcs    x2, x2, x15 __LF                   \
+        mul     x15, x14, x11 __LF                 \
+        umulh   x11, x14, x11 __LF                 \
+        adcs    x3, x3, x15 __LF                   \
+        mul     x15, x14, x12 __LF                 \
+        umulh   x12, x14, x12 __LF                 \
+        adcs    x4, x4, x15 __LF                   \
+        mul     x15, x14, x13 __LF                 \
+        umulh   x13, x14, x13 __LF                 \
+        adcs    x5, x5, x15 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        adds    x1, x1, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x10 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adcs    x5, x5, x12 __LF                   \
+        adcs    x6, x6, x13 __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x6, cc __LF                        \
+        mov     x7, #0xffffffff __LF               \
+        and     x7, x7, x6 __LF                    \
+        adds    x0, x0, x7 __LF                    \
+        eor     x7, x7, x6 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        mov     x7, #0xfffffffffffffffe __LF       \
+        and     x7, x7, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x6 __LF                    \
+        adcs    x4, x4, x6 __LF                    \
+        adc     x5, x5, x6 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 S2N_BN_SYMBOL(p384_montjdouble_alt):

--- a/arm/p384/p384_montjmixadd.S
+++ b/arm/p384/p384_montjmixadd.S
@@ -73,677 +73,677 @@
 // Corresponds to bignum_montmul_p384 except x24 -> x0
 
 #define montmul_p384(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P1+32];                \
-        ldp     x9, x10, [P2];                  \
-        ldp     x11, x12, [P2+16];              \
-        ldp     x13, x14, [P2+32];              \
-        mul     x15, x3, x9;                    \
-        mul     x21, x4, x10;                   \
-        mul     x22, x5, x11;                   \
-        umulh   x23, x3, x9;                    \
-        umulh   x0, x4, x10;                    \
-        umulh   x1, x5, x11;                    \
-        adds    x23, x23, x21;                  \
-        adcs    x0, x0, x22;                    \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x23, x15;                  \
-        adcs    x17, x0, x23;                   \
-        adcs    x19, x1, x0;                    \
-        adc     x20, x1, xzr;                   \
-        adds    x17, x17, x15;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x0, x3, x4;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x10, x9;                   \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x16, x16, x21;                  \
-        adcs    x17, x17, x22;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x3, x5;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x11, x9;                   \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x17, x17, x21;                  \
-        adcs    x19, x19, x22;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x4, x5;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x11, x10;                  \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x19, x19, x21;                  \
-        adcs    x20, x20, x22;                  \
-        adc     x1, x1, x23;                    \
-        lsl     x23, x15, #32;                  \
-        add     x15, x23, x15;                  \
-        lsr     x23, x15, #32;                  \
-        subs    x23, x23, x15;                  \
-        sbc     x22, x15, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x15;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x16, x16, x23;                  \
-        sbcs    x17, x17, x22;                  \
-        sbcs    x19, x19, x21;                  \
-        sbcs    x20, x20, xzr;                  \
-        sbcs    x1, x1, xzr;                    \
-        sbc     x15, x15, xzr;                  \
-        lsl     x23, x16, #32;                  \
-        add     x16, x23, x16;                  \
-        lsr     x23, x16, #32;                  \
-        subs    x23, x23, x16;                  \
-        sbc     x22, x16, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x16;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x17, x17, x23;                  \
-        sbcs    x19, x19, x22;                  \
-        sbcs    x20, x20, x21;                  \
-        sbcs    x1, x1, xzr;                    \
-        sbcs    x15, x15, xzr;                  \
-        sbc     x16, x16, xzr;                  \
-        lsl     x23, x17, #32;                  \
-        add     x17, x23, x17;                  \
-        lsr     x23, x17, #32;                  \
-        subs    x23, x23, x17;                  \
-        sbc     x22, x17, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x17;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x19, x19, x23;                  \
-        sbcs    x20, x20, x22;                  \
-        sbcs    x1, x1, x21;                    \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbc     x17, x17, xzr;                  \
-        stp     x19, x20, [P0];                 \
-        stp     x1, x15, [P0+16];               \
-        stp     x16, x17, [P0+32];              \
-        mul     x15, x6, x12;                   \
-        mul     x21, x7, x13;                   \
-        mul     x22, x8, x14;                   \
-        umulh   x23, x6, x12;                   \
-        umulh   x0, x7, x13;                    \
-        umulh   x1, x8, x14;                    \
-        adds    x23, x23, x21;                  \
-        adcs    x0, x0, x22;                    \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x23, x15;                  \
-        adcs    x17, x0, x23;                   \
-        adcs    x19, x1, x0;                    \
-        adc     x20, x1, xzr;                   \
-        adds    x17, x17, x15;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x0, x6, x7;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x13, x12;                  \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x16, x16, x21;                  \
-        adcs    x17, x17, x22;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x6, x8;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x14, x12;                  \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x17, x17, x21;                  \
-        adcs    x19, x19, x22;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x7, x8;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x14, x13;                  \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x19, x19, x21;                  \
-        adcs    x20, x20, x22;                  \
-        adc     x1, x1, x23;                    \
-        subs    x6, x6, x3;                     \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x5;                     \
-        ngc     x3, xzr;                        \
-        cmn     x3, #1;                         \
-        eor     x6, x6, x3;                     \
-        adcs    x6, x6, xzr;                    \
-        eor     x7, x7, x3;                     \
-        adcs    x7, x7, xzr;                    \
-        eor     x8, x8, x3;                     \
-        adc     x8, x8, xzr;                    \
-        subs    x9, x9, x12;                    \
-        sbcs    x10, x10, x13;                  \
-        sbcs    x11, x11, x14;                  \
-        ngc     x14, xzr;                       \
-        cmn     x14, #1;                        \
-        eor     x9, x9, x14;                    \
-        adcs    x9, x9, xzr;                    \
-        eor     x10, x10, x14;                  \
-        adcs    x10, x10, xzr;                  \
-        eor     x11, x11, x14;                  \
-        adc     x11, x11, xzr;                  \
-        eor     x14, x3, x14;                   \
-        ldp     x21, x22, [P0];                 \
-        adds    x15, x15, x21;                  \
-        adcs    x16, x16, x22;                  \
-        ldp     x21, x22, [P0+16];              \
-        adcs    x17, x17, x21;                  \
-        adcs    x19, x19, x22;                  \
-        ldp     x21, x22, [P0+32];              \
-        adcs    x20, x20, x21;                  \
-        adcs    x1, x1, x22;                    \
-        adc     x2, xzr, xzr;                   \
-        stp     x15, x16, [P0];                 \
-        stp     x17, x19, [P0+16];              \
-        stp     x20, x1, [P0+32];               \
-        mul     x15, x6, x9;                    \
-        mul     x21, x7, x10;                   \
-        mul     x22, x8, x11;                   \
-        umulh   x23, x6, x9;                    \
-        umulh   x0, x7, x10;                    \
-        umulh   x1, x8, x11;                    \
-        adds    x23, x23, x21;                  \
-        adcs    x0, x0, x22;                    \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x23, x15;                  \
-        adcs    x17, x0, x23;                   \
-        adcs    x19, x1, x0;                    \
-        adc     x20, x1, xzr;                   \
-        adds    x17, x17, x15;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x0, x6, x7;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x10, x9;                   \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x16, x16, x21;                  \
-        adcs    x17, x17, x22;                  \
-        adcs    x19, x19, x23;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x6, x8;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x11, x9;                   \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x17, x17, x21;                  \
-        adcs    x19, x19, x22;                  \
-        adcs    x20, x20, x23;                  \
-        adc     x1, x1, x23;                    \
-        subs    x0, x7, x8;                     \
-        cneg    x0, x0, lo;                     \
-        csetm   x23, lo;                        \
-        subs    x22, x11, x10;                  \
-        cneg    x22, x22, lo;                   \
-        mul     x21, x0, x22;                   \
-        umulh   x22, x0, x22;                   \
-        cinv    x23, x23, lo;                   \
-        eor     x21, x21, x23;                  \
-        eor     x22, x22, x23;                  \
-        cmn     x23, #1;                        \
-        adcs    x19, x19, x21;                  \
-        adcs    x20, x20, x22;                  \
-        adc     x1, x1, x23;                    \
-        ldp     x3, x4, [P0];                   \
-        ldp     x5, x6, [P0+16];                \
-        ldp     x7, x8, [P0+32];                \
-        cmn     x14, #1;                        \
-        eor     x15, x15, x14;                  \
-        adcs    x15, x15, x3;                   \
-        eor     x16, x16, x14;                  \
-        adcs    x16, x16, x4;                   \
-        eor     x17, x17, x14;                  \
-        adcs    x17, x17, x5;                   \
-        eor     x19, x19, x14;                  \
-        adcs    x19, x19, x6;                   \
-        eor     x20, x20, x14;                  \
-        adcs    x20, x20, x7;                   \
-        eor     x1, x1, x14;                    \
-        adcs    x1, x1, x8;                     \
-        adcs    x9, x14, x2;                    \
-        adcs    x10, x14, xzr;                  \
-        adcs    x11, x14, xzr;                  \
-        adc     x12, x14, xzr;                  \
-        adds    x19, x19, x3;                   \
-        adcs    x20, x20, x4;                   \
-        adcs    x1, x1, x5;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, x7;                   \
-        adcs    x11, x11, x8;                   \
-        adc     x12, x12, x2;                   \
-        lsl     x23, x15, #32;                  \
-        add     x15, x23, x15;                  \
-        lsr     x23, x15, #32;                  \
-        subs    x23, x23, x15;                  \
-        sbc     x22, x15, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x15;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x16, x16, x23;                  \
-        sbcs    x17, x17, x22;                  \
-        sbcs    x19, x19, x21;                  \
-        sbcs    x20, x20, xzr;                  \
-        sbcs    x1, x1, xzr;                    \
-        sbc     x15, x15, xzr;                  \
-        lsl     x23, x16, #32;                  \
-        add     x16, x23, x16;                  \
-        lsr     x23, x16, #32;                  \
-        subs    x23, x23, x16;                  \
-        sbc     x22, x16, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x16;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x17, x17, x23;                  \
-        sbcs    x19, x19, x22;                  \
-        sbcs    x20, x20, x21;                  \
-        sbcs    x1, x1, xzr;                    \
-        sbcs    x15, x15, xzr;                  \
-        sbc     x16, x16, xzr;                  \
-        lsl     x23, x17, #32;                  \
-        add     x17, x23, x17;                  \
-        lsr     x23, x17, #32;                  \
-        subs    x23, x23, x17;                  \
-        sbc     x22, x17, xzr;                  \
-        extr    x23, x22, x23, #32;             \
-        lsr     x22, x22, #32;                  \
-        adds    x22, x22, x17;                  \
-        adc     x21, xzr, xzr;                  \
-        subs    x19, x19, x23;                  \
-        sbcs    x20, x20, x22;                  \
-        sbcs    x1, x1, x21;                    \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbc     x17, x17, xzr;                  \
-        adds    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adc     x12, x12, xzr;                  \
-        add     x22, x12, #1;                   \
-        lsl     x21, x22, #32;                  \
-        subs    x0, x22, x21;                   \
-        sbc     x21, x21, xzr;                  \
-        adds    x19, x19, x0;                   \
-        adcs    x20, x20, x21;                  \
-        adcs    x1, x1, x22;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adcs    x11, x11, xzr;                  \
-        csetm   x22, lo;                        \
-        mov     x23, #4294967295;               \
-        and     x23, x23, x22;                  \
-        adds    x19, x19, x23;                  \
-        eor     x23, x23, x22;                  \
-        adcs    x20, x20, x23;                  \
-        mov     x23, #-2;                       \
-        and     x23, x23, x22;                  \
-        adcs    x1, x1, x23;                    \
-        adcs    x9, x9, x22;                    \
-        adcs    x10, x10, x22;                  \
-        adc     x11, x11, x22;                  \
-        stp     x19, x20, [P0];                 \
-        stp     x1, x9, [P0+16];                \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P1+32] __LF               \
+        ldp     x9, x10, [P2] __LF                 \
+        ldp     x11, x12, [P2+16] __LF             \
+        ldp     x13, x14, [P2+32] __LF             \
+        mul     x15, x3, x9 __LF                   \
+        mul     x21, x4, x10 __LF                  \
+        mul     x22, x5, x11 __LF                  \
+        umulh   x23, x3, x9 __LF                   \
+        umulh   x0, x4, x10 __LF                   \
+        umulh   x1, x5, x11 __LF                   \
+        adds    x23, x23, x21 __LF                 \
+        adcs    x0, x0, x22 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x23, x15 __LF                 \
+        adcs    x17, x0, x23 __LF                  \
+        adcs    x19, x1, x0 __LF                   \
+        adc     x20, x1, xzr __LF                  \
+        adds    x17, x17, x15 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x0, x3, x4 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x10, x9 __LF                  \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x16, x16, x21 __LF                 \
+        adcs    x17, x17, x22 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x3, x5 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x11, x9 __LF                  \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x17, x17, x21 __LF                 \
+        adcs    x19, x19, x22 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x4, x5 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x11, x10 __LF                 \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x19, x19, x21 __LF                 \
+        adcs    x20, x20, x22 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        lsl     x23, x15, #32 __LF                 \
+        add     x15, x23, x15 __LF                 \
+        lsr     x23, x15, #32 __LF                 \
+        subs    x23, x23, x15 __LF                 \
+        sbc     x22, x15, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x15 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x16, x16, x23 __LF                 \
+        sbcs    x17, x17, x22 __LF                 \
+        sbcs    x19, x19, x21 __LF                 \
+        sbcs    x20, x20, xzr __LF                 \
+        sbcs    x1, x1, xzr __LF                   \
+        sbc     x15, x15, xzr __LF                 \
+        lsl     x23, x16, #32 __LF                 \
+        add     x16, x23, x16 __LF                 \
+        lsr     x23, x16, #32 __LF                 \
+        subs    x23, x23, x16 __LF                 \
+        sbc     x22, x16, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x16 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x17, x17, x23 __LF                 \
+        sbcs    x19, x19, x22 __LF                 \
+        sbcs    x20, x20, x21 __LF                 \
+        sbcs    x1, x1, xzr __LF                   \
+        sbcs    x15, x15, xzr __LF                 \
+        sbc     x16, x16, xzr __LF                 \
+        lsl     x23, x17, #32 __LF                 \
+        add     x17, x23, x17 __LF                 \
+        lsr     x23, x17, #32 __LF                 \
+        subs    x23, x23, x17 __LF                 \
+        sbc     x22, x17, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x17 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x19, x19, x23 __LF                 \
+        sbcs    x20, x20, x22 __LF                 \
+        sbcs    x1, x1, x21 __LF                   \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbc     x17, x17, xzr __LF                 \
+        stp     x19, x20, [P0] __LF                \
+        stp     x1, x15, [P0+16] __LF              \
+        stp     x16, x17, [P0+32] __LF             \
+        mul     x15, x6, x12 __LF                  \
+        mul     x21, x7, x13 __LF                  \
+        mul     x22, x8, x14 __LF                  \
+        umulh   x23, x6, x12 __LF                  \
+        umulh   x0, x7, x13 __LF                   \
+        umulh   x1, x8, x14 __LF                   \
+        adds    x23, x23, x21 __LF                 \
+        adcs    x0, x0, x22 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x23, x15 __LF                 \
+        adcs    x17, x0, x23 __LF                  \
+        adcs    x19, x1, x0 __LF                   \
+        adc     x20, x1, xzr __LF                  \
+        adds    x17, x17, x15 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x0, x6, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x13, x12 __LF                 \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x16, x16, x21 __LF                 \
+        adcs    x17, x17, x22 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x6, x8 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x14, x12 __LF                 \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x17, x17, x21 __LF                 \
+        adcs    x19, x19, x22 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x7, x8 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x14, x13 __LF                 \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x19, x19, x21 __LF                 \
+        adcs    x20, x20, x22 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x6, x6, x3 __LF                    \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x5 __LF                    \
+        ngc     x3, xzr __LF                       \
+        cmn     x3, #1 __LF                        \
+        eor     x6, x6, x3 __LF                    \
+        adcs    x6, x6, xzr __LF                   \
+        eor     x7, x7, x3 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        eor     x8, x8, x3 __LF                    \
+        adc     x8, x8, xzr __LF                   \
+        subs    x9, x9, x12 __LF                   \
+        sbcs    x10, x10, x13 __LF                 \
+        sbcs    x11, x11, x14 __LF                 \
+        ngc     x14, xzr __LF                      \
+        cmn     x14, #1 __LF                       \
+        eor     x9, x9, x14 __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        eor     x10, x10, x14 __LF                 \
+        adcs    x10, x10, xzr __LF                 \
+        eor     x11, x11, x14 __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        eor     x14, x3, x14 __LF                  \
+        ldp     x21, x22, [P0] __LF                \
+        adds    x15, x15, x21 __LF                 \
+        adcs    x16, x16, x22 __LF                 \
+        ldp     x21, x22, [P0+16] __LF             \
+        adcs    x17, x17, x21 __LF                 \
+        adcs    x19, x19, x22 __LF                 \
+        ldp     x21, x22, [P0+32] __LF             \
+        adcs    x20, x20, x21 __LF                 \
+        adcs    x1, x1, x22 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        stp     x15, x16, [P0] __LF                \
+        stp     x17, x19, [P0+16] __LF             \
+        stp     x20, x1, [P0+32] __LF              \
+        mul     x15, x6, x9 __LF                   \
+        mul     x21, x7, x10 __LF                  \
+        mul     x22, x8, x11 __LF                  \
+        umulh   x23, x6, x9 __LF                   \
+        umulh   x0, x7, x10 __LF                   \
+        umulh   x1, x8, x11 __LF                   \
+        adds    x23, x23, x21 __LF                 \
+        adcs    x0, x0, x22 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x23, x15 __LF                 \
+        adcs    x17, x0, x23 __LF                  \
+        adcs    x19, x1, x0 __LF                   \
+        adc     x20, x1, xzr __LF                  \
+        adds    x17, x17, x15 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x0, x6, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x10, x9 __LF                  \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x16, x16, x21 __LF                 \
+        adcs    x17, x17, x22 __LF                 \
+        adcs    x19, x19, x23 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x6, x8 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x11, x9 __LF                  \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x17, x17, x21 __LF                 \
+        adcs    x19, x19, x22 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        subs    x0, x7, x8 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        csetm   x23, lo __LF                       \
+        subs    x22, x11, x10 __LF                 \
+        cneg    x22, x22, lo __LF                  \
+        mul     x21, x0, x22 __LF                  \
+        umulh   x22, x0, x22 __LF                  \
+        cinv    x23, x23, lo __LF                  \
+        eor     x21, x21, x23 __LF                 \
+        eor     x22, x22, x23 __LF                 \
+        cmn     x23, #1 __LF                       \
+        adcs    x19, x19, x21 __LF                 \
+        adcs    x20, x20, x22 __LF                 \
+        adc     x1, x1, x23 __LF                   \
+        ldp     x3, x4, [P0] __LF                  \
+        ldp     x5, x6, [P0+16] __LF               \
+        ldp     x7, x8, [P0+32] __LF               \
+        cmn     x14, #1 __LF                       \
+        eor     x15, x15, x14 __LF                 \
+        adcs    x15, x15, x3 __LF                  \
+        eor     x16, x16, x14 __LF                 \
+        adcs    x16, x16, x4 __LF                  \
+        eor     x17, x17, x14 __LF                 \
+        adcs    x17, x17, x5 __LF                  \
+        eor     x19, x19, x14 __LF                 \
+        adcs    x19, x19, x6 __LF                  \
+        eor     x20, x20, x14 __LF                 \
+        adcs    x20, x20, x7 __LF                  \
+        eor     x1, x1, x14 __LF                   \
+        adcs    x1, x1, x8 __LF                    \
+        adcs    x9, x14, x2 __LF                   \
+        adcs    x10, x14, xzr __LF                 \
+        adcs    x11, x14, xzr __LF                 \
+        adc     x12, x14, xzr __LF                 \
+        adds    x19, x19, x3 __LF                  \
+        adcs    x20, x20, x4 __LF                  \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x8 __LF                  \
+        adc     x12, x12, x2 __LF                  \
+        lsl     x23, x15, #32 __LF                 \
+        add     x15, x23, x15 __LF                 \
+        lsr     x23, x15, #32 __LF                 \
+        subs    x23, x23, x15 __LF                 \
+        sbc     x22, x15, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x15 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x16, x16, x23 __LF                 \
+        sbcs    x17, x17, x22 __LF                 \
+        sbcs    x19, x19, x21 __LF                 \
+        sbcs    x20, x20, xzr __LF                 \
+        sbcs    x1, x1, xzr __LF                   \
+        sbc     x15, x15, xzr __LF                 \
+        lsl     x23, x16, #32 __LF                 \
+        add     x16, x23, x16 __LF                 \
+        lsr     x23, x16, #32 __LF                 \
+        subs    x23, x23, x16 __LF                 \
+        sbc     x22, x16, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x16 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x17, x17, x23 __LF                 \
+        sbcs    x19, x19, x22 __LF                 \
+        sbcs    x20, x20, x21 __LF                 \
+        sbcs    x1, x1, xzr __LF                   \
+        sbcs    x15, x15, xzr __LF                 \
+        sbc     x16, x16, xzr __LF                 \
+        lsl     x23, x17, #32 __LF                 \
+        add     x17, x23, x17 __LF                 \
+        lsr     x23, x17, #32 __LF                 \
+        subs    x23, x23, x17 __LF                 \
+        sbc     x22, x17, xzr __LF                 \
+        extr    x23, x22, x23, #32 __LF            \
+        lsr     x22, x22, #32 __LF                 \
+        adds    x22, x22, x17 __LF                 \
+        adc     x21, xzr, xzr __LF                 \
+        subs    x19, x19, x23 __LF                 \
+        sbcs    x20, x20, x22 __LF                 \
+        sbcs    x1, x1, x21 __LF                   \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbc     x17, x17, xzr __LF                 \
+        adds    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adc     x12, x12, xzr __LF                 \
+        add     x22, x12, #1 __LF                  \
+        lsl     x21, x22, #32 __LF                 \
+        subs    x0, x22, x21 __LF                  \
+        sbc     x21, x21, xzr __LF                 \
+        adds    x19, x19, x0 __LF                  \
+        adcs    x20, x20, x21 __LF                 \
+        adcs    x1, x1, x22 __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csetm   x22, lo __LF                       \
+        mov     x23, #4294967295 __LF              \
+        and     x23, x23, x22 __LF                 \
+        adds    x19, x19, x23 __LF                 \
+        eor     x23, x23, x22 __LF                 \
+        adcs    x20, x20, x23 __LF                 \
+        mov     x23, #-2 __LF                      \
+        and     x23, x23, x22 __LF                 \
+        adcs    x1, x1, x23 __LF                   \
+        adcs    x9, x9, x22 __LF                   \
+        adcs    x10, x10, x22 __LF                 \
+        adc     x11, x11, x22 __LF                 \
+        stp     x19, x20, [P0] __LF                \
+        stp     x1, x9, [P0+16] __LF               \
         stp     x10, x11, [P0+32]
 
 // Corresponds exactly to bignum_montsqr_p384
 
 #define montsqr_p384(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        ldp     x4, x5, [P1+16];                \
-        ldp     x6, x7, [P1+32];                \
-        mul     x14, x2, x3;                    \
-        mul     x15, x2, x4;                    \
-        mul     x16, x3, x4;                    \
-        mul     x8, x2, x2;                     \
-        mul     x10, x3, x3;                    \
-        mul     x12, x4, x4;                    \
-        umulh   x17, x2, x3;                    \
-        adds    x15, x15, x17;                  \
-        umulh   x17, x2, x4;                    \
-        adcs    x16, x16, x17;                  \
-        umulh   x17, x3, x4;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x9, x2, x2;                     \
-        umulh   x11, x3, x3;                    \
-        umulh   x13, x4, x4;                    \
-        adds    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adc     x13, x13, xzr;                  \
-        adds    x9, x9, x14;                    \
-        adcs    x10, x10, x15;                  \
-        adcs    x11, x11, x16;                  \
-        adcs    x12, x12, x17;                  \
-        adc     x13, x13, xzr;                  \
-        lsl     x16, x8, #32;                   \
-        add     x8, x16, x8;                    \
-        lsr     x16, x8, #32;                   \
-        subs    x16, x16, x8;                   \
-        sbc     x15, x8, xzr;                   \
-        extr    x16, x15, x16, #32;             \
-        lsr     x15, x15, #32;                  \
-        adds    x15, x15, x8;                   \
-        adc     x14, xzr, xzr;                  \
-        subs    x9, x9, x16;                    \
-        sbcs    x10, x10, x15;                  \
-        sbcs    x11, x11, x14;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x8, x8, xzr;                    \
-        lsl     x16, x9, #32;                   \
-        add     x9, x16, x9;                    \
-        lsr     x16, x9, #32;                   \
-        subs    x16, x16, x9;                   \
-        sbc     x15, x9, xzr;                   \
-        extr    x16, x15, x16, #32;             \
-        lsr     x15, x15, #32;                  \
-        adds    x15, x15, x9;                   \
-        adc     x14, xzr, xzr;                  \
-        subs    x10, x10, x16;                  \
-        sbcs    x11, x11, x15;                  \
-        sbcs    x12, x12, x14;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x8, x8, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x16, x10, #32;                  \
-        add     x10, x16, x10;                  \
-        lsr     x16, x10, #32;                  \
-        subs    x16, x16, x10;                  \
-        sbc     x15, x10, xzr;                  \
-        extr    x16, x15, x16, #32;             \
-        lsr     x15, x15, #32;                  \
-        adds    x15, x15, x10;                  \
-        adc     x14, xzr, xzr;                  \
-        subs    x11, x11, x16;                  \
-        sbcs    x12, x12, x15;                  \
-        sbcs    x13, x13, x14;                  \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        stp     x11, x12, [P0];                 \
-        stp     x13, x8, [P0+16];               \
-        stp     x9, x10, [P0+32];               \
-        mul     x8, x2, x5;                     \
-        mul     x14, x3, x6;                    \
-        mul     x15, x4, x7;                    \
-        umulh   x16, x2, x5;                    \
-        umulh   x17, x3, x6;                    \
-        umulh   x1, x4, x7;                     \
-        adds    x16, x16, x14;                  \
-        adcs    x17, x17, x15;                  \
-        adc     x1, x1, xzr;                    \
-        adds    x9, x16, x8;                    \
-        adcs    x10, x17, x16;                  \
-        adcs    x11, x1, x17;                   \
-        adc     x12, x1, xzr;                   \
-        adds    x10, x10, x8;                   \
-        adcs    x11, x11, x16;                  \
-        adcs    x12, x12, x17;                  \
-        adc     x13, x1, xzr;                   \
-        subs    x17, x2, x3;                    \
-        cneg    x17, x17, lo;                   \
-        csetm   x14, lo;                        \
-        subs    x15, x6, x5;                    \
-        cneg    x15, x15, lo;                   \
-        mul     x16, x17, x15;                  \
-        umulh   x15, x17, x15;                  \
-        cinv    x14, x14, lo;                   \
-        eor     x16, x16, x14;                  \
-        eor     x15, x15, x14;                  \
-        cmn     x14, #1;                        \
-        adcs    x9, x9, x16;                    \
-        adcs    x10, x10, x15;                  \
-        adcs    x11, x11, x14;                  \
-        adcs    x12, x12, x14;                  \
-        adc     x13, x13, x14;                  \
-        subs    x17, x2, x4;                    \
-        cneg    x17, x17, lo;                   \
-        csetm   x14, lo;                        \
-        subs    x15, x7, x5;                    \
-        cneg    x15, x15, lo;                   \
-        mul     x16, x17, x15;                  \
-        umulh   x15, x17, x15;                  \
-        cinv    x14, x14, lo;                   \
-        eor     x16, x16, x14;                  \
-        eor     x15, x15, x14;                  \
-        cmn     x14, #1;                        \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x15;                  \
-        adcs    x12, x12, x14;                  \
-        adc     x13, x13, x14;                  \
-        subs    x17, x3, x4;                    \
-        cneg    x17, x17, lo;                   \
-        csetm   x14, lo;                        \
-        subs    x15, x7, x6;                    \
-        cneg    x15, x15, lo;                   \
-        mul     x16, x17, x15;                  \
-        umulh   x15, x17, x15;                  \
-        cinv    x14, x14, lo;                   \
-        eor     x16, x16, x14;                  \
-        eor     x15, x15, x14;                  \
-        cmn     x14, #1;                        \
-        adcs    x11, x11, x16;                  \
-        adcs    x12, x12, x15;                  \
-        adc     x13, x13, x14;                  \
-        adds    x8, x8, x8;                     \
-        adcs    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adc     x17, xzr, xzr;                  \
-        ldp     x2, x3, [P0];                   \
-        adds    x8, x8, x2;                     \
-        adcs    x9, x9, x3;                     \
-        ldp     x2, x3, [P0+16];                \
-        adcs    x10, x10, x2;                   \
-        adcs    x11, x11, x3;                   \
-        ldp     x2, x3, [P0+32];                \
-        adcs    x12, x12, x2;                   \
-        adcs    x13, x13, x3;                   \
-        adc     x17, x17, xzr;                  \
-        lsl     x4, x8, #32;                    \
-        add     x8, x4, x8;                     \
-        lsr     x4, x8, #32;                    \
-        subs    x4, x4, x8;                     \
-        sbc     x3, x8, xzr;                    \
-        extr    x4, x3, x4, #32;                \
-        lsr     x3, x3, #32;                    \
-        adds    x3, x3, x8;                     \
-        adc     x2, xzr, xzr;                   \
-        subs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x2;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x8, x8, xzr;                    \
-        lsl     x4, x9, #32;                    \
-        add     x9, x4, x9;                     \
-        lsr     x4, x9, #32;                    \
-        subs    x4, x4, x9;                     \
-        sbc     x3, x9, xzr;                    \
-        extr    x4, x3, x4, #32;                \
-        lsr     x3, x3, #32;                    \
-        adds    x3, x3, x9;                     \
-        adc     x2, xzr, xzr;                   \
-        subs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, x2;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x8, x8, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x4, x10, #32;                   \
-        add     x10, x4, x10;                   \
-        lsr     x4, x10, #32;                   \
-        subs    x4, x4, x10;                    \
-        sbc     x3, x10, xzr;                   \
-        extr    x4, x3, x4, #32;                \
-        lsr     x3, x3, #32;                    \
-        adds    x3, x3, x10;                    \
-        adc     x2, xzr, xzr;                   \
-        subs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, x2;                   \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        adds    x17, x17, x8;                   \
-        adcs    x8, x9, xzr;                    \
-        adcs    x9, x10, xzr;                   \
-        adcs    x10, xzr, xzr;                  \
-        mul     x1, x5, x5;                     \
-        adds    x11, x11, x1;                   \
-        mul     x14, x6, x6;                    \
-        mul     x15, x7, x7;                    \
-        umulh   x1, x5, x5;                     \
-        adcs    x12, x12, x1;                   \
-        umulh   x1, x6, x6;                     \
-        adcs    x13, x13, x14;                  \
-        adcs    x17, x17, x1;                   \
-        umulh   x1, x7, x7;                     \
-        adcs    x8, x8, x15;                    \
-        adcs    x9, x9, x1;                     \
-        adc     x10, x10, xzr;                  \
-        mul     x1, x5, x6;                     \
-        mul     x14, x5, x7;                    \
-        mul     x15, x6, x7;                    \
-        umulh   x16, x5, x6;                    \
-        adds    x14, x14, x16;                  \
-        umulh   x16, x5, x7;                    \
-        adcs    x15, x15, x16;                  \
-        umulh   x16, x6, x7;                    \
-        adc     x16, x16, xzr;                  \
-        adds    x1, x1, x1;                     \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, xzr, xzr;                   \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x14;                  \
-        adcs    x17, x17, x15;                  \
-        adcs    x8, x8, x16;                    \
-        adcs    x9, x9, x5;                     \
-        adc     x10, x10, xzr;                  \
-        mov     x1, #-4294967295;               \
-        mov     x14, #4294967295;               \
-        mov     x15, #1;                        \
-        cmn     x11, x1;                        \
-        adcs    xzr, x12, x14;                  \
-        adcs    xzr, x13, x15;                  \
-        adcs    xzr, x17, xzr;                  \
-        adcs    xzr, x8, xzr;                   \
-        adcs    xzr, x9, xzr;                   \
-        adc     x10, x10, xzr;                  \
-        neg     x10, x10;                       \
-        and     x1, x1, x10;                    \
-        adds    x11, x11, x1;                   \
-        and     x14, x14, x10;                  \
-        adcs    x12, x12, x14;                  \
-        and     x15, x15, x10;                  \
-        adcs    x13, x13, x15;                  \
-        adcs    x17, x17, xzr;                  \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        stp     x11, x12, [P0];                 \
-        stp     x13, x17, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        ldp     x4, x5, [P1+16] __LF               \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x14, x2, x3 __LF                   \
+        mul     x15, x2, x4 __LF                   \
+        mul     x16, x3, x4 __LF                   \
+        mul     x8, x2, x2 __LF                    \
+        mul     x10, x3, x3 __LF                   \
+        mul     x12, x4, x4 __LF                   \
+        umulh   x17, x2, x3 __LF                   \
+        adds    x15, x15, x17 __LF                 \
+        umulh   x17, x2, x4 __LF                   \
+        adcs    x16, x16, x17 __LF                 \
+        umulh   x17, x3, x4 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x9, x2, x2 __LF                    \
+        umulh   x11, x3, x3 __LF                   \
+        umulh   x13, x4, x4 __LF                   \
+        adds    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        adds    x9, x9, x14 __LF                   \
+        adcs    x10, x10, x15 __LF                 \
+        adcs    x11, x11, x16 __LF                 \
+        adcs    x12, x12, x17 __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        lsl     x16, x8, #32 __LF                  \
+        add     x8, x16, x8 __LF                   \
+        lsr     x16, x8, #32 __LF                  \
+        subs    x16, x16, x8 __LF                  \
+        sbc     x15, x8, xzr __LF                  \
+        extr    x16, x15, x16, #32 __LF            \
+        lsr     x15, x15, #32 __LF                 \
+        adds    x15, x15, x8 __LF                  \
+        adc     x14, xzr, xzr __LF                 \
+        subs    x9, x9, x16 __LF                   \
+        sbcs    x10, x10, x15 __LF                 \
+        sbcs    x11, x11, x14 __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x8, x8, xzr __LF                   \
+        lsl     x16, x9, #32 __LF                  \
+        add     x9, x16, x9 __LF                   \
+        lsr     x16, x9, #32 __LF                  \
+        subs    x16, x16, x9 __LF                  \
+        sbc     x15, x9, xzr __LF                  \
+        extr    x16, x15, x16, #32 __LF            \
+        lsr     x15, x15, #32 __LF                 \
+        adds    x15, x15, x9 __LF                  \
+        adc     x14, xzr, xzr __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        sbcs    x11, x11, x15 __LF                 \
+        sbcs    x12, x12, x14 __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x8, x8, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x16, x10, #32 __LF                 \
+        add     x10, x16, x10 __LF                 \
+        lsr     x16, x10, #32 __LF                 \
+        subs    x16, x16, x10 __LF                 \
+        sbc     x15, x10, xzr __LF                 \
+        extr    x16, x15, x16, #32 __LF            \
+        lsr     x15, x15, #32 __LF                 \
+        adds    x15, x15, x10 __LF                 \
+        adc     x14, xzr, xzr __LF                 \
+        subs    x11, x11, x16 __LF                 \
+        sbcs    x12, x12, x15 __LF                 \
+        sbcs    x13, x13, x14 __LF                 \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        stp     x11, x12, [P0] __LF                \
+        stp     x13, x8, [P0+16] __LF              \
+        stp     x9, x10, [P0+32] __LF              \
+        mul     x8, x2, x5 __LF                    \
+        mul     x14, x3, x6 __LF                   \
+        mul     x15, x4, x7 __LF                   \
+        umulh   x16, x2, x5 __LF                   \
+        umulh   x17, x3, x6 __LF                   \
+        umulh   x1, x4, x7 __LF                    \
+        adds    x16, x16, x14 __LF                 \
+        adcs    x17, x17, x15 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        adds    x9, x16, x8 __LF                   \
+        adcs    x10, x17, x16 __LF                 \
+        adcs    x11, x1, x17 __LF                  \
+        adc     x12, x1, xzr __LF                  \
+        adds    x10, x10, x8 __LF                  \
+        adcs    x11, x11, x16 __LF                 \
+        adcs    x12, x12, x17 __LF                 \
+        adc     x13, x1, xzr __LF                  \
+        subs    x17, x2, x3 __LF                   \
+        cneg    x17, x17, lo __LF                  \
+        csetm   x14, lo __LF                       \
+        subs    x15, x6, x5 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        mul     x16, x17, x15 __LF                 \
+        umulh   x15, x17, x15 __LF                 \
+        cinv    x14, x14, lo __LF                  \
+        eor     x16, x16, x14 __LF                 \
+        eor     x15, x15, x14 __LF                 \
+        cmn     x14, #1 __LF                       \
+        adcs    x9, x9, x16 __LF                   \
+        adcs    x10, x10, x15 __LF                 \
+        adcs    x11, x11, x14 __LF                 \
+        adcs    x12, x12, x14 __LF                 \
+        adc     x13, x13, x14 __LF                 \
+        subs    x17, x2, x4 __LF                   \
+        cneg    x17, x17, lo __LF                  \
+        csetm   x14, lo __LF                       \
+        subs    x15, x7, x5 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        mul     x16, x17, x15 __LF                 \
+        umulh   x15, x17, x15 __LF                 \
+        cinv    x14, x14, lo __LF                  \
+        eor     x16, x16, x14 __LF                 \
+        eor     x15, x15, x14 __LF                 \
+        cmn     x14, #1 __LF                       \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x15 __LF                 \
+        adcs    x12, x12, x14 __LF                 \
+        adc     x13, x13, x14 __LF                 \
+        subs    x17, x3, x4 __LF                   \
+        cneg    x17, x17, lo __LF                  \
+        csetm   x14, lo __LF                       \
+        subs    x15, x7, x6 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        mul     x16, x17, x15 __LF                 \
+        umulh   x15, x17, x15 __LF                 \
+        cinv    x14, x14, lo __LF                  \
+        eor     x16, x16, x14 __LF                 \
+        eor     x15, x15, x14 __LF                 \
+        cmn     x14, #1 __LF                       \
+        adcs    x11, x11, x16 __LF                 \
+        adcs    x12, x12, x15 __LF                 \
+        adc     x13, x13, x14 __LF                 \
+        adds    x8, x8, x8 __LF                    \
+        adcs    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adc     x17, xzr, xzr __LF                 \
+        ldp     x2, x3, [P0] __LF                  \
+        adds    x8, x8, x2 __LF                    \
+        adcs    x9, x9, x3 __LF                    \
+        ldp     x2, x3, [P0+16] __LF               \
+        adcs    x10, x10, x2 __LF                  \
+        adcs    x11, x11, x3 __LF                  \
+        ldp     x2, x3, [P0+32] __LF               \
+        adcs    x12, x12, x2 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adc     x17, x17, xzr __LF                 \
+        lsl     x4, x8, #32 __LF                   \
+        add     x8, x4, x8 __LF                    \
+        lsr     x4, x8, #32 __LF                   \
+        subs    x4, x4, x8 __LF                    \
+        sbc     x3, x8, xzr __LF                   \
+        extr    x4, x3, x4, #32 __LF               \
+        lsr     x3, x3, #32 __LF                   \
+        adds    x3, x3, x8 __LF                    \
+        adc     x2, xzr, xzr __LF                  \
+        subs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x2 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x8, x8, xzr __LF                   \
+        lsl     x4, x9, #32 __LF                   \
+        add     x9, x4, x9 __LF                    \
+        lsr     x4, x9, #32 __LF                   \
+        subs    x4, x4, x9 __LF                    \
+        sbc     x3, x9, xzr __LF                   \
+        extr    x4, x3, x4, #32 __LF               \
+        lsr     x3, x3, #32 __LF                   \
+        adds    x3, x3, x9 __LF                    \
+        adc     x2, xzr, xzr __LF                  \
+        subs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, x2 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x8, x8, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x4, x10, #32 __LF                  \
+        add     x10, x4, x10 __LF                  \
+        lsr     x4, x10, #32 __LF                  \
+        subs    x4, x4, x10 __LF                   \
+        sbc     x3, x10, xzr __LF                  \
+        extr    x4, x3, x4, #32 __LF               \
+        lsr     x3, x3, #32 __LF                   \
+        adds    x3, x3, x10 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        subs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, x2 __LF                  \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        adds    x17, x17, x8 __LF                  \
+        adcs    x8, x9, xzr __LF                   \
+        adcs    x9, x10, xzr __LF                  \
+        adcs    x10, xzr, xzr __LF                 \
+        mul     x1, x5, x5 __LF                    \
+        adds    x11, x11, x1 __LF                  \
+        mul     x14, x6, x6 __LF                   \
+        mul     x15, x7, x7 __LF                   \
+        umulh   x1, x5, x5 __LF                    \
+        adcs    x12, x12, x1 __LF                  \
+        umulh   x1, x6, x6 __LF                    \
+        adcs    x13, x13, x14 __LF                 \
+        adcs    x17, x17, x1 __LF                  \
+        umulh   x1, x7, x7 __LF                    \
+        adcs    x8, x8, x15 __LF                   \
+        adcs    x9, x9, x1 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        mul     x1, x5, x6 __LF                    \
+        mul     x14, x5, x7 __LF                   \
+        mul     x15, x6, x7 __LF                   \
+        umulh   x16, x5, x6 __LF                   \
+        adds    x14, x14, x16 __LF                 \
+        umulh   x16, x5, x7 __LF                   \
+        adcs    x15, x15, x16 __LF                 \
+        umulh   x16, x6, x7 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        adds    x1, x1, x1 __LF                    \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, xzr, xzr __LF                  \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x14 __LF                 \
+        adcs    x17, x17, x15 __LF                 \
+        adcs    x8, x8, x16 __LF                   \
+        adcs    x9, x9, x5 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        mov     x1, #-4294967295 __LF              \
+        mov     x14, #4294967295 __LF              \
+        mov     x15, #1 __LF                       \
+        cmn     x11, x1 __LF                       \
+        adcs    xzr, x12, x14 __LF                 \
+        adcs    xzr, x13, x15 __LF                 \
+        adcs    xzr, x17, xzr __LF                 \
+        adcs    xzr, x8, xzr __LF                  \
+        adcs    xzr, x9, xzr __LF                  \
+        adc     x10, x10, xzr __LF                 \
+        neg     x10, x10 __LF                      \
+        and     x1, x1, x10 __LF                   \
+        adds    x11, x11, x1 __LF                  \
+        and     x14, x14, x10 __LF                 \
+        adcs    x12, x12, x14 __LF                 \
+        and     x15, x15, x10 __LF                 \
+        adcs    x13, x13, x15 __LF                 \
+        adcs    x17, x17, xzr __LF                 \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        stp     x11, x12, [P0] __LF                \
+        stp     x13, x17, [P0+16] __LF             \
         stp     x8, x9, [P0+32]
 
 // Corresponds exactly to bignum_sub_p384
 
 #define sub_p384(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        csetm   x3, lo;                         \
-        mov     x4, #4294967295;                \
-        and     x4, x4, x3;                     \
-        adds    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        mov     x4, #-2;                        \
-        and     x4, x4, x3;                     \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        adcs    x9, x9, x3;                     \
-        adc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        csetm   x3, lo __LF                        \
+        mov     x4, #4294967295 __LF               \
+        and     x4, x4, x3 __LF                    \
+        adds    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        mov     x4, #-2 __LF                       \
+        and     x4, x4, x3 __LF                    \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        adcs    x9, x9, x3 __LF                    \
+        adc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 S2N_BN_SYMBOL(p384_montjmixadd):

--- a/arm/p384/p384_montjmixadd_alt.S
+++ b/arm/p384/p384_montjmixadd_alt.S
@@ -73,495 +73,495 @@
 // Corresponds exactly to bignum_montmul_p384_alt
 
 #define montmul_p384(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x12, x3, x5;                    \
-        umulh   x13, x3, x5;                    \
-        mul     x11, x3, x6;                    \
-        umulh   x14, x3, x6;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x11, x3, x7;                    \
-        umulh   x15, x3, x7;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x8;                    \
-        umulh   x16, x3, x8;                    \
-        adcs    x15, x15, x11;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x11, x3, x9;                    \
-        umulh   x17, x3, x9;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x19, x3, x10;                   \
-        adcs    x17, x17, x11;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x11, x4, x5;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x19, x19, x11;                  \
-        cset    x20, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x15, x15, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x20, x20, x11;                  \
-        ldp     x3, x4, [P1+16];                \
-        mul     x11, x3, x5;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x15, x15, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x20, x20, x11;                  \
-        cset    x21, cs;                        \
-        umulh   x11, x3, x5;                    \
-        adds    x15, x15, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x16, x16, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x21, x21, x11;                  \
-        mul     x11, x4, x5;                    \
-        adds    x15, x15, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x16, x16, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x21, x21, x11;                  \
-        cset    x22, cs;                        \
-        umulh   x11, x4, x5;                    \
-        adds    x16, x16, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x17, x17, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x10;                   \
-        adc     x22, x22, x11;                  \
-        ldp     x3, x4, [P1+32];                \
-        mul     x11, x3, x5;                    \
-        adds    x16, x16, x11;                  \
-        mul     x11, x3, x6;                    \
-        adcs    x17, x17, x11;                  \
-        mul     x11, x3, x7;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x3, x8;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x3, x9;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x3, x10;                   \
-        adcs    x22, x22, x11;                  \
-        cset    x2, cs;                         \
-        umulh   x11, x3, x5;                    \
-        adds    x17, x17, x11;                  \
-        umulh   x11, x3, x6;                    \
-        adcs    x19, x19, x11;                  \
-        umulh   x11, x3, x7;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x3, x8;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x3, x9;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x3, x10;                   \
-        adc     x2, x2, x11;                    \
-        mul     x11, x4, x5;                    \
-        adds    x17, x17, x11;                  \
-        mul     x11, x4, x6;                    \
-        adcs    x19, x19, x11;                  \
-        mul     x11, x4, x7;                    \
-        adcs    x20, x20, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x21, x21, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x22, x22, x11;                  \
-        mul     x11, x4, x10;                   \
-        adcs    x2, x2, x11;                    \
-        cset    x1, cs;                         \
-        umulh   x11, x4, x5;                    \
-        adds    x19, x19, x11;                  \
-        umulh   x11, x4, x6;                    \
-        adcs    x20, x20, x11;                  \
-        umulh   x11, x4, x7;                    \
-        adcs    x21, x21, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x22, x22, x11;                  \
-        umulh   x11, x4, x9;                    \
-        adcs    x2, x2, x11;                    \
-        umulh   x11, x4, x10;                   \
-        adc     x1, x1, x11;                    \
-        lsl     x7, x12, #32;                   \
-        add     x12, x7, x12;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x12;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x12;                    \
-        umulh   x6, x6, x12;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x12;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x13, x13, x7;                   \
-        sbcs    x14, x14, x6;                   \
-        sbcs    x15, x15, x5;                   \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x7, x13, #32;                   \
-        add     x13, x7, x13;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x13;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x13;                    \
-        umulh   x6, x6, x13;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x13;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x14, x14, x7;                   \
-        sbcs    x15, x15, x6;                   \
-        sbcs    x16, x16, x5;                   \
-        sbcs    x17, x17, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        lsl     x7, x14, #32;                   \
-        add     x14, x7, x14;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x14;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x14;                    \
-        umulh   x6, x6, x14;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x14;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x15, x15, x7;                   \
-        sbcs    x16, x16, x6;                   \
-        sbcs    x17, x17, x5;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x14, x14, xzr;                  \
-        lsl     x7, x15, #32;                   \
-        add     x15, x7, x15;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x15;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x15;                    \
-        umulh   x6, x6, x15;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x15;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x16, x16, x7;                   \
-        sbcs    x17, x17, x6;                   \
-        sbcs    x12, x12, x5;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x15, x15, xzr;                  \
-        lsl     x7, x16, #32;                   \
-        add     x16, x7, x16;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x16;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x16;                    \
-        umulh   x6, x6, x16;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x16;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x17, x17, x7;                   \
-        sbcs    x12, x12, x6;                   \
-        sbcs    x13, x13, x5;                   \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbc     x16, x16, xzr;                  \
-        lsl     x7, x17, #32;                   \
-        add     x17, x7, x17;                   \
-        mov     x7, #0xffffffff00000001;        \
-        umulh   x7, x7, x17;                    \
-        mov     x6, #0xffffffff;                \
-        mul     x5, x6, x17;                    \
-        umulh   x6, x6, x17;                    \
-        adds    x7, x7, x5;                     \
-        adcs    x6, x6, x17;                    \
-        adc     x5, xzr, xzr;                   \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, x6;                   \
-        sbcs    x14, x14, x5;                   \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbc     x17, x17, xzr;                  \
-        adds    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adcs    x14, x14, x21;                  \
-        adcs    x15, x15, x22;                  \
-        adcs    x16, x16, x2;                   \
-        adcs    x17, x17, x1;                   \
-        adc     x10, xzr, xzr;                  \
-        mov     x11, #0xffffffff00000001;       \
-        adds    x19, x12, x11;                  \
-        mov     x11, #0xffffffff;               \
-        adcs    x20, x13, x11;                  \
-        mov     x11, #0x1;                      \
-        adcs    x21, x14, x11;                  \
-        adcs    x22, x15, xzr;                  \
-        adcs    x2, x16, xzr;                   \
-        adcs    x1, x17, xzr;                   \
-        adcs    x10, x10, xzr;                  \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        csel    x14, x14, x21, eq;              \
-        csel    x15, x15, x22, eq;              \
-        csel    x16, x16, x2, eq;               \
-        csel    x17, x17, x1, eq;               \
-        stp     x12, x13, [P0];                 \
-        stp     x14, x15, [P0+16];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x12, x3, x5 __LF                   \
+        umulh   x13, x3, x5 __LF                   \
+        mul     x11, x3, x6 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x11, x3, x7 __LF                   \
+        umulh   x15, x3, x7 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x16, x3, x8 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x17, x3, x9 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x19, x3, x10 __LF                  \
+        adcs    x17, x17, x11 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x19, x19, x11 __LF                 \
+        cset    x20, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x20, x20, x11 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x15, x15, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x20, x20, x11 __LF                 \
+        cset    x21, cs __LF                       \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x21, x21, x11 __LF                 \
+        mul     x11, x4, x5 __LF                   \
+        adds    x15, x15, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x16, x16, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x21, x21, x11 __LF                 \
+        cset    x22, cs __LF                       \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x22, x22, x11 __LF                 \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        adds    x16, x16, x11 __LF                 \
+        mul     x11, x3, x6 __LF                   \
+        adcs    x17, x17, x11 __LF                 \
+        mul     x11, x3, x7 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x3, x8 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x3, x9 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        adcs    x22, x22, x11 __LF                 \
+        cset    x2, cs __LF                        \
+        umulh   x11, x3, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        umulh   x11, x3, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        umulh   x11, x3, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x3, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x3, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x3, x10 __LF                  \
+        adc     x2, x2, x11 __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        adds    x17, x17, x11 __LF                 \
+        mul     x11, x4, x6 __LF                   \
+        adcs    x19, x19, x11 __LF                 \
+        mul     x11, x4, x7 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x2, x2, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        umulh   x11, x4, x5 __LF                   \
+        adds    x19, x19, x11 __LF                 \
+        umulh   x11, x4, x6 __LF                   \
+        adcs    x20, x20, x11 __LF                 \
+        umulh   x11, x4, x7 __LF                   \
+        adcs    x21, x21, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x22, x22, x11 __LF                 \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x2, x2, x11 __LF                   \
+        umulh   x11, x4, x10 __LF                  \
+        adc     x1, x1, x11 __LF                   \
+        lsl     x7, x12, #32 __LF                  \
+        add     x12, x7, x12 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x12 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x12 __LF                   \
+        umulh   x6, x6, x12 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x6 __LF                  \
+        sbcs    x15, x15, x5 __LF                  \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x7, x13, #32 __LF                  \
+        add     x13, x7, x13 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x13 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x13 __LF                   \
+        umulh   x6, x6, x13 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x13 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x14, x14, x7 __LF                  \
+        sbcs    x15, x15, x6 __LF                  \
+        sbcs    x16, x16, x5 __LF                  \
+        sbcs    x17, x17, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        lsl     x7, x14, #32 __LF                  \
+        add     x14, x7, x14 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x14 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x14 __LF                   \
+        umulh   x6, x6, x14 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x14 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x15, x15, x7 __LF                  \
+        sbcs    x16, x16, x6 __LF                  \
+        sbcs    x17, x17, x5 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x14, x14, xzr __LF                 \
+        lsl     x7, x15, #32 __LF                  \
+        add     x15, x7, x15 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x15 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x15 __LF                   \
+        umulh   x6, x6, x15 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x15 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x16, x16, x7 __LF                  \
+        sbcs    x17, x17, x6 __LF                  \
+        sbcs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x15, x15, xzr __LF                 \
+        lsl     x7, x16, #32 __LF                  \
+        add     x16, x7, x16 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x16 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x16 __LF                   \
+        umulh   x6, x6, x16 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x16 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x17, x17, x7 __LF                  \
+        sbcs    x12, x12, x6 __LF                  \
+        sbcs    x13, x13, x5 __LF                  \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbc     x16, x16, xzr __LF                 \
+        lsl     x7, x17, #32 __LF                  \
+        add     x17, x7, x17 __LF                  \
+        mov     x7, #0xffffffff00000001 __LF       \
+        umulh   x7, x7, x17 __LF                   \
+        mov     x6, #0xffffffff __LF               \
+        mul     x5, x6, x17 __LF                   \
+        umulh   x6, x6, x17 __LF                   \
+        adds    x7, x7, x5 __LF                    \
+        adcs    x6, x6, x17 __LF                   \
+        adc     x5, xzr, xzr __LF                  \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x6 __LF                  \
+        sbcs    x14, x14, x5 __LF                  \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbc     x17, x17, xzr __LF                 \
+        adds    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adcs    x14, x14, x21 __LF                 \
+        adcs    x15, x15, x22 __LF                 \
+        adcs    x16, x16, x2 __LF                  \
+        adcs    x17, x17, x1 __LF                  \
+        adc     x10, xzr, xzr __LF                 \
+        mov     x11, #0xffffffff00000001 __LF      \
+        adds    x19, x12, x11 __LF                 \
+        mov     x11, #0xffffffff __LF              \
+        adcs    x20, x13, x11 __LF                 \
+        mov     x11, #0x1 __LF                     \
+        adcs    x21, x14, x11 __LF                 \
+        adcs    x22, x15, xzr __LF                 \
+        adcs    x2, x16, xzr __LF                  \
+        adcs    x1, x17, xzr __LF                  \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        csel    x14, x14, x21, eq __LF             \
+        csel    x15, x15, x22, eq __LF             \
+        csel    x16, x16, x2, eq __LF              \
+        csel    x17, x17, x1, eq __LF              \
+        stp     x12, x13, [P0] __LF                \
+        stp     x14, x15, [P0+16] __LF             \
         stp     x16, x17, [P0+32]
 
 // Corresponds exactly to bignum_montsqr_p384_alt
 
 #define montsqr_p384(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x8, x2, x4;                     \
-        adds    x10, x10, x8;                   \
-        mul     x11, x2, x5;                    \
-        mul     x8, x3, x4;                     \
-        adcs    x11, x11, x8;                   \
-        umulh   x12, x2, x5;                    \
-        mul     x8, x3, x5;                     \
-        adcs    x12, x12, x8;                   \
-        ldp     x6, x7, [P1+32];                \
-        mul     x13, x2, x7;                    \
-        mul     x8, x3, x6;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x14, x2, x7;                    \
-        mul     x8, x3, x7;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x15, x5, x6;                    \
-        adcs    x15, x15, xzr;                  \
-        umulh   x16, x5, x6;                    \
-        adc     x16, x16, xzr;                  \
-        umulh   x8, x2, x4;                     \
-        adds    x11, x11, x8;                   \
-        umulh   x8, x3, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x3, x5;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x8, x3, x6;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x3, x7;                     \
-        adcs    x15, x15, x8;                   \
-        adc     x16, x16, xzr;                  \
-        mul     x8, x2, x6;                     \
-        adds    x12, x12, x8;                   \
-        mul     x8, x4, x5;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x4, x6;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x8, x4, x7;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x5, x7;                     \
-        adcs    x16, x16, x8;                   \
-        mul     x17, x6, x7;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x19, x6, x7;                    \
-        adc     x19, x19, xzr;                  \
-        umulh   x8, x2, x6;                     \
-        adds    x13, x13, x8;                   \
-        umulh   x8, x4, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x4, x6;                     \
-        adcs    x15, x15, x8;                   \
-        umulh   x8, x4, x7;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x5, x7;                     \
-        adcs    x17, x17, x8;                   \
-        adc     x19, x19, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        cset    x20, hs;                        \
-        umulh   x8, x2, x2;                     \
-        mul     x2, x2, x2;                     \
-        adds    x9, x9, x8;                     \
-        mul     x8, x3, x3;                     \
-        adcs    x10, x10, x8;                   \
-        umulh   x8, x3, x3;                     \
-        adcs    x11, x11, x8;                   \
-        mul     x8, x4, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x4, x4;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x5, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x5, x5;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x6, x6;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x6, x6;                     \
-        adcs    x17, x17, x8;                   \
-        mul     x8, x7, x7;                     \
-        adcs    x19, x19, x8;                   \
-        umulh   x8, x7, x7;                     \
-        adc     x20, x20, x8;                   \
-        lsl     x5, x2, #32;                    \
-        add     x2, x5, x2;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x2;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x2;                     \
-        umulh   x4, x4, x2;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x2;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x9, x9, x5;                     \
-        sbcs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x2, x2, xzr;                    \
-        lsl     x5, x9, #32;                    \
-        add     x9, x5, x9;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x9;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x9;                     \
-        umulh   x4, x4, x9;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x10, x10, x5;                   \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x5, x10, #32;                   \
-        add     x10, x5, x10;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x10;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x10;                    \
-        umulh   x4, x4, x10;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x10;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x11, x11, x5;                   \
-        sbcs    x12, x12, x4;                   \
-        sbcs    x13, x13, x3;                   \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        lsl     x5, x11, #32;                   \
-        add     x11, x5, x11;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x11;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x11;                    \
-        umulh   x4, x4, x11;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x12, x12, x5;                   \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x2, x2, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        lsl     x5, x12, #32;                   \
-        add     x12, x5, x12;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x12;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x12;                    \
-        umulh   x4, x4, x12;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x12;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x13, x13, x5;                   \
-        sbcs    x2, x2, x4;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x5, x13, #32;                   \
-        add     x13, x5, x13;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x13;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x13;                    \
-        umulh   x4, x4, x13;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x13;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x2, x2, x5;                     \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adcs    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        adc     x6, xzr, xzr;                   \
-        mov     x8, #-4294967295;               \
-        adds    x14, x2, x8;                    \
-        mov     x8, #4294967295;                \
-        adcs    x15, x9, x8;                    \
-        mov     x8, #1;                         \
-        adcs    x16, x10, x8;                   \
-        adcs    x17, x11, xzr;                  \
-        adcs    x19, x12, xzr;                  \
-        adcs    x20, x13, xzr;                  \
-        adcs    x6, x6, xzr;                    \
-        csel    x2, x2, x14, eq;                \
-        csel    x9, x9, x15, eq;                \
-        csel    x10, x10, x16, eq;              \
-        csel    x11, x11, x17, eq;              \
-        csel    x12, x12, x19, eq;              \
-        csel    x13, x13, x20, eq;              \
-        stp     x2, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x8, x2, x4 __LF                    \
+        adds    x10, x10, x8 __LF                  \
+        mul     x11, x2, x5 __LF                   \
+        mul     x8, x3, x4 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x8, x3, x5 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x13, x2, x7 __LF                   \
+        mul     x8, x3, x6 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x14, x2, x7 __LF                   \
+        mul     x8, x3, x7 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x15, x5, x6 __LF                   \
+        adcs    x15, x15, xzr __LF                 \
+        umulh   x16, x5, x6 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        umulh   x8, x2, x4 __LF                    \
+        adds    x11, x11, x8 __LF                  \
+        umulh   x8, x3, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x3, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x8, x3, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x3, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        adc     x16, x16, xzr __LF                 \
+        mul     x8, x2, x6 __LF                    \
+        adds    x12, x12, x8 __LF                  \
+        mul     x8, x4, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x4, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x8, x4, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x5, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        mul     x17, x6, x7 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x19, x6, x7 __LF                   \
+        adc     x19, x19, xzr __LF                 \
+        umulh   x8, x2, x6 __LF                    \
+        adds    x13, x13, x8 __LF                  \
+        umulh   x8, x4, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x4, x6 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        umulh   x8, x4, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x5, x7 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        adc     x19, x19, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x8, x2, x2 __LF                    \
+        mul     x2, x2, x2 __LF                    \
+        adds    x9, x9, x8 __LF                    \
+        mul     x8, x3, x3 __LF                    \
+        adcs    x10, x10, x8 __LF                  \
+        umulh   x8, x3, x3 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        mul     x8, x4, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x4, x4 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x5, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x5, x5 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x6, x6 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x6, x6 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        mul     x8, x7, x7 __LF                    \
+        adcs    x19, x19, x8 __LF                  \
+        umulh   x8, x7, x7 __LF                    \
+        adc     x20, x20, x8 __LF                  \
+        lsl     x5, x2, #32 __LF                   \
+        add     x2, x5, x2 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x2 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x2 __LF                    \
+        umulh   x4, x4, x2 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x2 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x9, x9, x5 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x2, x2, xzr __LF                   \
+        lsl     x5, x9, #32 __LF                   \
+        add     x9, x5, x9 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x9 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x9 __LF                    \
+        umulh   x4, x4, x9 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x10, x10, x5 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x5, x10, #32 __LF                  \
+        add     x10, x5, x10 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x10 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x10 __LF                   \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x10 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x11, x11, x5 __LF                  \
+        sbcs    x12, x12, x4 __LF                  \
+        sbcs    x13, x13, x3 __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        lsl     x5, x11, #32 __LF                  \
+        add     x11, x5, x11 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x11 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x11 __LF                   \
+        umulh   x4, x4, x11 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x2, x2, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        lsl     x5, x12, #32 __LF                  \
+        add     x12, x5, x12 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x12 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x12 __LF                   \
+        umulh   x4, x4, x12 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x13, x13, x5 __LF                  \
+        sbcs    x2, x2, x4 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x5, x13, #32 __LF                  \
+        add     x13, x5, x13 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x13 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x13 __LF                   \
+        umulh   x4, x4, x13 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x13 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x2, x2, x5 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adcs    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        mov     x8, #-4294967295 __LF              \
+        adds    x14, x2, x8 __LF                   \
+        mov     x8, #4294967295 __LF               \
+        adcs    x15, x9, x8 __LF                   \
+        mov     x8, #1 __LF                        \
+        adcs    x16, x10, x8 __LF                  \
+        adcs    x17, x11, xzr __LF                 \
+        adcs    x19, x12, xzr __LF                 \
+        adcs    x20, x13, xzr __LF                 \
+        adcs    x6, x6, xzr __LF                   \
+        csel    x2, x2, x14, eq __LF               \
+        csel    x9, x9, x15, eq __LF               \
+        csel    x10, x10, x16, eq __LF             \
+        csel    x11, x11, x17, eq __LF             \
+        csel    x12, x12, x19, eq __LF             \
+        csel    x13, x13, x20, eq __LF             \
+        stp     x2, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         stp     x12, x13, [P0+32]
 
 // Almost-Montgomery variant which we use when an input to other muls
@@ -570,245 +570,245 @@
 // *need* the restriction that the other argument is reduced.
 
 #define amontsqr_p384(P0,P1)                    \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x8, x2, x4;                     \
-        adds    x10, x10, x8;                   \
-        mul     x11, x2, x5;                    \
-        mul     x8, x3, x4;                     \
-        adcs    x11, x11, x8;                   \
-        umulh   x12, x2, x5;                    \
-        mul     x8, x3, x5;                     \
-        adcs    x12, x12, x8;                   \
-        ldp     x6, x7, [P1+32];                \
-        mul     x13, x2, x7;                    \
-        mul     x8, x3, x6;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x14, x2, x7;                    \
-        mul     x8, x3, x7;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x15, x5, x6;                    \
-        adcs    x15, x15, xzr;                  \
-        umulh   x16, x5, x6;                    \
-        adc     x16, x16, xzr;                  \
-        umulh   x8, x2, x4;                     \
-        adds    x11, x11, x8;                   \
-        umulh   x8, x3, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x3, x5;                     \
-        adcs    x13, x13, x8;                   \
-        umulh   x8, x3, x6;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x3, x7;                     \
-        adcs    x15, x15, x8;                   \
-        adc     x16, x16, xzr;                  \
-        mul     x8, x2, x6;                     \
-        adds    x12, x12, x8;                   \
-        mul     x8, x4, x5;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x4, x6;                     \
-        adcs    x14, x14, x8;                   \
-        mul     x8, x4, x7;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x5, x7;                     \
-        adcs    x16, x16, x8;                   \
-        mul     x17, x6, x7;                    \
-        adcs    x17, x17, xzr;                  \
-        umulh   x19, x6, x7;                    \
-        adc     x19, x19, xzr;                  \
-        umulh   x8, x2, x6;                     \
-        adds    x13, x13, x8;                   \
-        umulh   x8, x4, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x4, x6;                     \
-        adcs    x15, x15, x8;                   \
-        umulh   x8, x4, x7;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x5, x7;                     \
-        adcs    x17, x17, x8;                   \
-        adc     x19, x19, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        cset    x20, hs;                        \
-        umulh   x8, x2, x2;                     \
-        mul     x2, x2, x2;                     \
-        adds    x9, x9, x8;                     \
-        mul     x8, x3, x3;                     \
-        adcs    x10, x10, x8;                   \
-        umulh   x8, x3, x3;                     \
-        adcs    x11, x11, x8;                   \
-        mul     x8, x4, x4;                     \
-        adcs    x12, x12, x8;                   \
-        umulh   x8, x4, x4;                     \
-        adcs    x13, x13, x8;                   \
-        mul     x8, x5, x5;                     \
-        adcs    x14, x14, x8;                   \
-        umulh   x8, x5, x5;                     \
-        adcs    x15, x15, x8;                   \
-        mul     x8, x6, x6;                     \
-        adcs    x16, x16, x8;                   \
-        umulh   x8, x6, x6;                     \
-        adcs    x17, x17, x8;                   \
-        mul     x8, x7, x7;                     \
-        adcs    x19, x19, x8;                   \
-        umulh   x8, x7, x7;                     \
-        adc     x20, x20, x8;                   \
-        lsl     x5, x2, #32;                    \
-        add     x2, x5, x2;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x2;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x2;                     \
-        umulh   x4, x4, x2;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x2;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x9, x9, x5;                     \
-        sbcs    x10, x10, x4;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbc     x2, x2, xzr;                    \
-        lsl     x5, x9, #32;                    \
-        add     x9, x5, x9;                     \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x9;                     \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x9;                     \
-        umulh   x4, x4, x9;                     \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x3, xzr, xzr;                   \
-        subs    x10, x10, x5;                   \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x9, x9, xzr;                    \
-        lsl     x5, x10, #32;                   \
-        add     x10, x5, x10;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x10;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x10;                    \
-        umulh   x4, x4, x10;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x10;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x11, x11, x5;                   \
-        sbcs    x12, x12, x4;                   \
-        sbcs    x13, x13, x3;                   \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        lsl     x5, x11, #32;                   \
-        add     x11, x5, x11;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x11;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x11;                    \
-        umulh   x4, x4, x11;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x12, x12, x5;                   \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x2, x2, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        lsl     x5, x12, #32;                   \
-        add     x12, x5, x12;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x12;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x12;                    \
-        umulh   x4, x4, x12;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x12;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x13, x13, x5;                   \
-        sbcs    x2, x2, x4;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbc     x12, x12, xzr;                  \
-        lsl     x5, x13, #32;                   \
-        add     x13, x5, x13;                   \
-        mov     x5, #-4294967295;               \
-        umulh   x5, x5, x13;                    \
-        mov     x4, #4294967295;                \
-        mul     x3, x4, x13;                    \
-        umulh   x4, x4, x13;                    \
-        adds    x5, x5, x3;                     \
-        adcs    x4, x4, x13;                    \
-        adc     x3, xzr, xzr;                   \
-        subs    x2, x2, x5;                     \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, x17;                  \
-        adcs    x12, x12, x19;                  \
-        adcs    x13, x13, x20;                  \
-        mov     x14, #-4294967295;              \
-        mov     x15, #4294967295;               \
-        csel    x14, x14, xzr, cs;              \
-        csel    x15, x15, xzr, cs;              \
-        cset    x16, cs;                        \
-        adds    x2, x2, x14;                    \
-        adcs    x9, x9, x15;                    \
-        adcs    x10, x10, x16;                  \
-        adcs    x11, x11, xzr;                  \
-        adcs    x12, x12, xzr;                  \
-        adc     x13, x13, xzr;                  \
-        stp     x2, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x8, x2, x4 __LF                    \
+        adds    x10, x10, x8 __LF                  \
+        mul     x11, x2, x5 __LF                   \
+        mul     x8, x3, x4 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x8, x3, x5 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x13, x2, x7 __LF                   \
+        mul     x8, x3, x6 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x14, x2, x7 __LF                   \
+        mul     x8, x3, x7 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x15, x5, x6 __LF                   \
+        adcs    x15, x15, xzr __LF                 \
+        umulh   x16, x5, x6 __LF                   \
+        adc     x16, x16, xzr __LF                 \
+        umulh   x8, x2, x4 __LF                    \
+        adds    x11, x11, x8 __LF                  \
+        umulh   x8, x3, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x3, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        umulh   x8, x3, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x3, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        adc     x16, x16, xzr __LF                 \
+        mul     x8, x2, x6 __LF                    \
+        adds    x12, x12, x8 __LF                  \
+        mul     x8, x4, x5 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x4, x6 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        mul     x8, x4, x7 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x5, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        mul     x17, x6, x7 __LF                   \
+        adcs    x17, x17, xzr __LF                 \
+        umulh   x19, x6, x7 __LF                   \
+        adc     x19, x19, xzr __LF                 \
+        umulh   x8, x2, x6 __LF                    \
+        adds    x13, x13, x8 __LF                  \
+        umulh   x8, x4, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x4, x6 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        umulh   x8, x4, x7 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x5, x7 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        adc     x19, x19, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x8, x2, x2 __LF                    \
+        mul     x2, x2, x2 __LF                    \
+        adds    x9, x9, x8 __LF                    \
+        mul     x8, x3, x3 __LF                    \
+        adcs    x10, x10, x8 __LF                  \
+        umulh   x8, x3, x3 __LF                    \
+        adcs    x11, x11, x8 __LF                  \
+        mul     x8, x4, x4 __LF                    \
+        adcs    x12, x12, x8 __LF                  \
+        umulh   x8, x4, x4 __LF                    \
+        adcs    x13, x13, x8 __LF                  \
+        mul     x8, x5, x5 __LF                    \
+        adcs    x14, x14, x8 __LF                  \
+        umulh   x8, x5, x5 __LF                    \
+        adcs    x15, x15, x8 __LF                  \
+        mul     x8, x6, x6 __LF                    \
+        adcs    x16, x16, x8 __LF                  \
+        umulh   x8, x6, x6 __LF                    \
+        adcs    x17, x17, x8 __LF                  \
+        mul     x8, x7, x7 __LF                    \
+        adcs    x19, x19, x8 __LF                  \
+        umulh   x8, x7, x7 __LF                    \
+        adc     x20, x20, x8 __LF                  \
+        lsl     x5, x2, #32 __LF                   \
+        add     x2, x5, x2 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x2 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x2 __LF                    \
+        umulh   x4, x4, x2 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x2 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x9, x9, x5 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbc     x2, x2, xzr __LF                   \
+        lsl     x5, x9, #32 __LF                   \
+        add     x9, x5, x9 __LF                    \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x9 __LF                    \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x9 __LF                    \
+        umulh   x4, x4, x9 __LF                    \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x10, x10, x5 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x9, x9, xzr __LF                   \
+        lsl     x5, x10, #32 __LF                  \
+        add     x10, x5, x10 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x10 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x10 __LF                   \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x10 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x11, x11, x5 __LF                  \
+        sbcs    x12, x12, x4 __LF                  \
+        sbcs    x13, x13, x3 __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        lsl     x5, x11, #32 __LF                  \
+        add     x11, x5, x11 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x11 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x11 __LF                   \
+        umulh   x4, x4, x11 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x12, x12, x5 __LF                  \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x2, x2, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        lsl     x5, x12, #32 __LF                  \
+        add     x12, x5, x12 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x12 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x12 __LF                   \
+        umulh   x4, x4, x12 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x13, x13, x5 __LF                  \
+        sbcs    x2, x2, x4 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbc     x12, x12, xzr __LF                 \
+        lsl     x5, x13, #32 __LF                  \
+        add     x13, x5, x13 __LF                  \
+        mov     x5, #-4294967295 __LF              \
+        umulh   x5, x5, x13 __LF                   \
+        mov     x4, #4294967295 __LF               \
+        mul     x3, x4, x13 __LF                   \
+        umulh   x4, x4, x13 __LF                   \
+        adds    x5, x5, x3 __LF                    \
+        adcs    x4, x4, x13 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        subs    x2, x2, x5 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, x17 __LF                 \
+        adcs    x12, x12, x19 __LF                 \
+        adcs    x13, x13, x20 __LF                 \
+        mov     x14, #-4294967295 __LF             \
+        mov     x15, #4294967295 __LF              \
+        csel    x14, x14, xzr, cs __LF             \
+        csel    x15, x15, xzr, cs __LF             \
+        cset    x16, cs __LF                       \
+        adds    x2, x2, x14 __LF                   \
+        adcs    x9, x9, x15 __LF                   \
+        adcs    x10, x10, x16 __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        adcs    x12, x12, xzr __LF                 \
+        adc     x13, x13, xzr __LF                 \
+        stp     x2, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         stp     x12, x13, [P0+32]
 
 // Corresponds exactly to bignum_sub_p384
 
 #define sub_p384(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        csetm   x3, lo;                         \
-        mov     x4, #4294967295;                \
-        and     x4, x4, x3;                     \
-        adds    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        adcs    x6, x6, x4;                     \
-        mov     x4, #-2;                        \
-        and     x4, x4, x3;                     \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        adcs    x9, x9, x3;                     \
-        adc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        csetm   x3, lo __LF                        \
+        mov     x4, #4294967295 __LF               \
+        and     x4, x4, x3 __LF                    \
+        adds    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        adcs    x6, x6, x4 __LF                    \
+        mov     x4, #-2 __LF                       \
+        and     x4, x4, x3 __LF                    \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        adcs    x9, x9, x3 __LF                    \
+        adc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 S2N_BN_SYMBOL(p384_montjmixadd_alt):

--- a/arm/p384/p384_montjscalarmul.S
+++ b/arm/p384/p384_montjscalarmul.S
@@ -61,42 +61,42 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                            \
-        cmp     bf, #(1*I);                       \
-        ldp     x20, x21, [x19];                  \
-        csel    x0, x20, x0, eq;                  \
-        csel    x1, x21, x1, eq;                  \
-        ldp     x20, x21, [x19, #16];             \
-        csel    x2, x20, x2, eq;                  \
-        csel    x3, x21, x3, eq;                  \
-        ldp     x20, x21, [x19, #32];             \
-        csel    x4, x20, x4, eq;                  \
-        csel    x5, x21, x5, eq;                  \
-        ldp     x20, x21, [x19, #48];             \
-        csel    x6, x20, x6, eq;                  \
-        csel    x7, x21, x7, eq;                  \
-        ldp     x20, x21, [x19, #64];             \
-        csel    x8, x20, x8, eq;                  \
-        csel    x9, x21, x9, eq;                  \
-        ldp     x20, x21, [x19, #80];             \
-        csel    x10, x20, x10, eq;                \
-        csel    x11, x21, x11, eq;                \
-        ldp     x20, x21, [x19, #96];             \
-        csel    x12, x20, x12, eq;                \
-        csel    x13, x21, x13, eq;                \
-        ldp     x20, x21, [x19, #112];            \
-        csel    x14, x20, x14, eq;                \
-        csel    x15, x21, x15, eq;                \
-        ldp     x20, x21, [x19, #128];            \
-        csel    x16, x20, x16, eq;                \
-        csel    x17, x21, x17, eq;                \
+        cmp     bf, #(1*I) __LF                      \
+        ldp     x20, x21, [x19] __LF                 \
+        csel    x0, x20, x0, eq __LF                 \
+        csel    x1, x21, x1, eq __LF                 \
+        ldp     x20, x21, [x19, #16] __LF            \
+        csel    x2, x20, x2, eq __LF                 \
+        csel    x3, x21, x3, eq __LF                 \
+        ldp     x20, x21, [x19, #32] __LF            \
+        csel    x4, x20, x4, eq __LF                 \
+        csel    x5, x21, x5, eq __LF                 \
+        ldp     x20, x21, [x19, #48] __LF            \
+        csel    x6, x20, x6, eq __LF                 \
+        csel    x7, x21, x7, eq __LF                 \
+        ldp     x20, x21, [x19, #64] __LF            \
+        csel    x8, x20, x8, eq __LF                 \
+        csel    x9, x21, x9, eq __LF                 \
+        ldp     x20, x21, [x19, #80] __LF            \
+        csel    x10, x20, x10, eq __LF               \
+        csel    x11, x21, x11, eq __LF               \
+        ldp     x20, x21, [x19, #96] __LF            \
+        csel    x12, x20, x12, eq __LF               \
+        csel    x13, x21, x13, eq __LF               \
+        ldp     x20, x21, [x19, #112] __LF           \
+        csel    x14, x20, x14, eq __LF               \
+        csel    x15, x21, x15, eq __LF               \
+        ldp     x20, x21, [x19, #128] __LF           \
+        csel    x16, x20, x16, eq __LF               \
+        csel    x17, x21, x17, eq __LF               \
         add     x19, x19, #JACSIZE
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p384_montjscalarmul):

--- a/arm/p384/p384_montjscalarmul_alt.S
+++ b/arm/p384/p384_montjscalarmul_alt.S
@@ -61,42 +61,42 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                            \
-        cmp     bf, #(1*I);                       \
-        ldp     x20, x21, [x19];                  \
-        csel    x0, x20, x0, eq;                  \
-        csel    x1, x21, x1, eq;                  \
-        ldp     x20, x21, [x19, #16];             \
-        csel    x2, x20, x2, eq;                  \
-        csel    x3, x21, x3, eq;                  \
-        ldp     x20, x21, [x19, #32];             \
-        csel    x4, x20, x4, eq;                  \
-        csel    x5, x21, x5, eq;                  \
-        ldp     x20, x21, [x19, #48];             \
-        csel    x6, x20, x6, eq;                  \
-        csel    x7, x21, x7, eq;                  \
-        ldp     x20, x21, [x19, #64];             \
-        csel    x8, x20, x8, eq;                  \
-        csel    x9, x21, x9, eq;                  \
-        ldp     x20, x21, [x19, #80];             \
-        csel    x10, x20, x10, eq;                \
-        csel    x11, x21, x11, eq;                \
-        ldp     x20, x21, [x19, #96];             \
-        csel    x12, x20, x12, eq;                \
-        csel    x13, x21, x13, eq;                \
-        ldp     x20, x21, [x19, #112];            \
-        csel    x14, x20, x14, eq;                \
-        csel    x15, x21, x15, eq;                \
-        ldp     x20, x21, [x19, #128];            \
-        csel    x16, x20, x16, eq;                \
-        csel    x17, x21, x17, eq;                \
+        cmp     bf, #(1*I) __LF                      \
+        ldp     x20, x21, [x19] __LF                 \
+        csel    x0, x20, x0, eq __LF                 \
+        csel    x1, x21, x1, eq __LF                 \
+        ldp     x20, x21, [x19, #16] __LF            \
+        csel    x2, x20, x2, eq __LF                 \
+        csel    x3, x21, x3, eq __LF                 \
+        ldp     x20, x21, [x19, #32] __LF            \
+        csel    x4, x20, x4, eq __LF                 \
+        csel    x5, x21, x5, eq __LF                 \
+        ldp     x20, x21, [x19, #48] __LF            \
+        csel    x6, x20, x6, eq __LF                 \
+        csel    x7, x21, x7, eq __LF                 \
+        ldp     x20, x21, [x19, #64] __LF            \
+        csel    x8, x20, x8, eq __LF                 \
+        csel    x9, x21, x9, eq __LF                 \
+        ldp     x20, x21, [x19, #80] __LF            \
+        csel    x10, x20, x10, eq __LF               \
+        csel    x11, x21, x11, eq __LF               \
+        ldp     x20, x21, [x19, #96] __LF            \
+        csel    x12, x20, x12, eq __LF               \
+        csel    x13, x21, x13, eq __LF               \
+        ldp     x20, x21, [x19, #112] __LF           \
+        csel    x14, x20, x14, eq __LF               \
+        csel    x15, x21, x15, eq __LF               \
+        ldp     x20, x21, [x19, #128] __LF           \
+        csel    x16, x20, x16, eq __LF               \
+        csel    x17, x21, x17, eq __LF               \
         add     x19, x19, #JACSIZE
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p384_montjscalarmul_alt):

--- a/arm/p384/unopt/bignum_montmul_p384_base.S
+++ b/arm/p384/unopt/bignum_montmul_p384_base.S
@@ -56,7 +56,7 @@
         add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
+/* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
         lsr     t1, d0, #32 __LF                                       \
         subs    t1, t1, d0 __LF                                        \

--- a/arm/p384/unopt/bignum_montmul_p384_base.S
+++ b/arm/p384/unopt/bignum_montmul_p384_base.S
@@ -28,15 +28,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -52,27 +52,27 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-        lsl     t1, d0, #32;                                        \
-        add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway; we only need the w_hi    */  \
+/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-        lsr     t1, d0, #32;                                        \
-        subs    t1, t1, d0;                                         \
-        sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32 __LF                                       \
+        subs    t1, t1, d0 __LF                                        \
+        sbc     t2, d0, xzr __LF                                       \
 /* Now select in t1 the field to subtract from d1                       */  \
-        extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32 __LF                                   \
 /* And now get the terms to subtract from d2 and d3                     */  \
-        lsr     t2, t2, #32;                                        \
-        adds    t2, t2, d0;                                         \
-        adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32 __LF                                       \
+        adds    t2, t2, d0 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Do the subtraction of that portion                                   */  \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
         sbc     d6, d0, xzr
 

--- a/arm/p384/unopt/bignum_montsqr_p384_base.S
+++ b/arm/p384/unopt/bignum_montsqr_p384_base.S
@@ -55,7 +55,7 @@
         add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
+/* bits since by design it will cancel anyway; we only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
         lsr     t1, d0, #32 __LF                                       \
         subs    t1, t1, d0 __LF                                        \

--- a/arm/p384/unopt/bignum_montsqr_p384_base.S
+++ b/arm/p384/unopt/bignum_montsqr_p384_base.S
@@ -27,15 +27,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -51,27 +51,27 @@
 #define montreds(d6,d5,d4,d3,d2,d1,d0, t3,t2,t1)                            \
 /* Our correction multiplier is w = [d0 + (d0<<32)] mod 2^64            */  \
 /* Recycle d0 (which we know gets implicitly cancelled) to store it     */  \
-        lsl     t1, d0, #32;                                        \
-        add     d0, t1, d0;                                         \
+        lsl     t1, d0, #32 __LF                                       \
+        add     d0, t1, d0 __LF                                        \
 /* Now let [t2;t1] = 2^64 * w - w + w_hi where w_hi = floor(w/2^32)     */  \
 /* We need to subtract 2^32 * this, and we can ignore its lower 32      */  \
-/* bits since by design it will cancel anyway; we only need the w_hi    */  \
+/* bits since by design it will cancel anyway __LFwe only need the w_hi    */  \
 /* part to get the carry propagation going.                             */  \
-        lsr     t1, d0, #32;                                        \
-        subs    t1, t1, d0;                                         \
-        sbc     t2, d0, xzr;                                        \
+        lsr     t1, d0, #32 __LF                                       \
+        subs    t1, t1, d0 __LF                                        \
+        sbc     t2, d0, xzr __LF                                       \
 /* Now select in t1 the field to subtract from d1                       */  \
-        extr    t1, t2, t1, #32;                                    \
+        extr    t1, t2, t1, #32 __LF                                   \
 /* And now get the terms to subtract from d2 and d3                     */  \
-        lsr     t2, t2, #32;                                        \
-        adds    t2, t2, d0;                                         \
-        adc     t3, xzr, xzr;                                       \
+        lsr     t2, t2, #32 __LF                                       \
+        adds    t2, t2, d0 __LF                                        \
+        adc     t3, xzr, xzr __LF                                      \
 /* Do the subtraction of that portion                                   */  \
-        subs    d1, d1, t1;                                         \
-        sbcs    d2, d2, t2;                                         \
-        sbcs    d3, d3, t3;                                         \
-        sbcs    d4, d4, xzr;                                        \
-        sbcs    d5, d5, xzr;                                        \
+        subs    d1, d1, t1 __LF                                        \
+        sbcs    d2, d2, t2 __LF                                        \
+        sbcs    d3, d3, t3 __LF                                        \
+        sbcs    d4, d4, xzr __LF                                       \
+        sbcs    d5, d5, xzr __LF                                       \
 /* Now effectively add 2^384 * w by taking d0 as the input for last sbc */  \
         sbc     d6, d0, xzr
 

--- a/arm/p384/unopt/p384_montjdouble.S
+++ b/arm/p384/unopt/p384_montjdouble.S
@@ -891,248 +891,248 @@
 // P0 = 4 * P1 - P2
 
 #define cmsub41_p384(P0,P1,P2)                  \
-        ldp     x1, x2, [P1];                   \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P1+32];                \
-        lsl     x0, x1, #2;                     \
-        ldp     x7, x8, [P2];                   \
-        subs    x0, x0, x7;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x8;                     \
-        ldp     x7, x8, [P2+16];                \
-        extr    x2, x3, x2, #62;                \
-        sbcs    x2, x2, x7;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x8;                     \
-        extr    x4, x5, x4, #62;                \
-        ldp     x7, x8, [P2+32];                \
-        sbcs    x4, x4, x7;                     \
-        extr    x5, x6, x5, #62;                \
-        sbcs    x5, x5, x8;                     \
-        lsr     x6, x6, #62;                    \
-        adc     x6, x6, xzr;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x8, cc;                         \
-        mov     x9, #0xffffffff;                \
-        and     x9, x9, x8;                     \
-        adds    x0, x0, x9;                     \
-        eor     x9, x9, x8;                     \
-        adcs    x1, x1, x9;                     \
-        mov     x9, #0xfffffffffffffffe;        \
-        and     x9, x9, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x8;                     \
-        adcs    x4, x4, x8;                     \
-        adc     x5, x5, x8;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x1, x2, [P1] __LF                  \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P1+32] __LF               \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x7, x8, [P2] __LF                  \
+        subs    x0, x0, x7 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x8 __LF                    \
+        ldp     x7, x8, [P2+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        sbcs    x2, x2, x7 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x8 __LF                    \
+        extr    x4, x5, x4, #62 __LF               \
+        ldp     x7, x8, [P2+32] __LF               \
+        sbcs    x4, x4, x7 __LF                    \
+        extr    x5, x6, x5, #62 __LF               \
+        sbcs    x5, x5, x8 __LF                    \
+        lsr     x6, x6, #62 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x8, cc __LF                        \
+        mov     x9, #0xffffffff __LF               \
+        and     x9, x9, x8 __LF                    \
+        adds    x0, x0, x9 __LF                    \
+        eor     x9, x9, x8 __LF                    \
+        adcs    x1, x1, x9 __LF                    \
+        mov     x9, #0xfffffffffffffffe __LF       \
+        and     x9, x9, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        adcs    x4, x4, x8 __LF                    \
+        adc     x5, x5, x8 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 // P0 = C * P1 - D * P2
 
 #define cmsub_p384(P0,C,P1,D,P2)                \
-        ldp     x0, x1, [P2];                   \
-        mov     x6, #0x00000000ffffffff;        \
-        subs    x6, x6, x0;                     \
-        mov     x7, #0xffffffff00000000;        \
-        sbcs    x7, x7, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        mov     x8, #0xfffffffffffffffe;        \
-        sbcs    x8, x8, x0;                     \
-        mov     x13, #0xffffffffffffffff;       \
-        sbcs    x9, x13, x1;                    \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x10, x13, x0;                   \
-        sbc     x11, x13, x1;                   \
-        mov     x12, D;                         \
-        mul     x0, x12, x6;                    \
-        mul     x1, x12, x7;                    \
-        mul     x2, x12, x8;                    \
-        mul     x3, x12, x9;                    \
-        mul     x4, x12, x10;                   \
-        mul     x5, x12, x11;                   \
-        umulh   x6, x12, x6;                    \
-        umulh   x7, x12, x7;                    \
-        umulh   x8, x12, x8;                    \
-        umulh   x9, x12, x9;                    \
-        umulh   x10, x12, x10;                  \
-        umulh   x12, x12, x11;                  \
-        adds    x1, x1, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x8;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        mov     x6, #1;                         \
-        adc     x6, x12, x6;                    \
-        ldp     x8, x9, [P1];                   \
-        ldp     x10, x11, [P1+16];              \
-        ldp     x12, x13, [P1+32];              \
-        mov     x14, C;                         \
-        mul     x15, x14, x8;                   \
-        umulh   x8, x14, x8;                    \
-        adds    x0, x0, x15;                    \
-        mul     x15, x14, x9;                   \
-        umulh   x9, x14, x9;                    \
-        adcs    x1, x1, x15;                    \
-        mul     x15, x14, x10;                  \
-        umulh   x10, x14, x10;                  \
-        adcs    x2, x2, x15;                    \
-        mul     x15, x14, x11;                  \
-        umulh   x11, x14, x11;                  \
-        adcs    x3, x3, x15;                    \
-        mul     x15, x14, x12;                  \
-        umulh   x12, x14, x12;                  \
-        adcs    x4, x4, x15;                    \
-        mul     x15, x14, x13;                  \
-        umulh   x13, x14, x13;                  \
-        adcs    x5, x5, x15;                    \
-        adc     x6, x6, xzr;                    \
-        adds    x1, x1, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x10;                    \
-        adcs    x4, x4, x11;                    \
-        adcs    x5, x5, x12;                    \
-        adcs    x6, x6, x13;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x6, cc;                         \
-        mov     x7, #0xffffffff;                \
-        and     x7, x7, x6;                     \
-        adds    x0, x0, x7;                     \
-        eor     x7, x7, x6;                     \
-        adcs    x1, x1, x7;                     \
-        mov     x7, #0xfffffffffffffffe;        \
-        and     x7, x7, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x6;                     \
-        adcs    x4, x4, x6;                     \
-        adc     x5, x5, x6;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x0, x1, [P2] __LF                  \
+        mov     x6, #0x00000000ffffffff __LF       \
+        subs    x6, x6, x0 __LF                    \
+        mov     x7, #0xffffffff00000000 __LF       \
+        sbcs    x7, x7, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        mov     x8, #0xfffffffffffffffe __LF       \
+        sbcs    x8, x8, x0 __LF                    \
+        mov     x13, #0xffffffffffffffff __LF      \
+        sbcs    x9, x13, x1 __LF                   \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x10, x13, x0 __LF                  \
+        sbc     x11, x13, x1 __LF                  \
+        mov     x12, D __LF                        \
+        mul     x0, x12, x6 __LF                   \
+        mul     x1, x12, x7 __LF                   \
+        mul     x2, x12, x8 __LF                   \
+        mul     x3, x12, x9 __LF                   \
+        mul     x4, x12, x10 __LF                  \
+        mul     x5, x12, x11 __LF                  \
+        umulh   x6, x12, x6 __LF                   \
+        umulh   x7, x12, x7 __LF                   \
+        umulh   x8, x12, x8 __LF                   \
+        umulh   x9, x12, x9 __LF                   \
+        umulh   x10, x12, x10 __LF                 \
+        umulh   x12, x12, x11 __LF                 \
+        adds    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x8 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        mov     x6, #1 __LF                        \
+        adc     x6, x12, x6 __LF                   \
+        ldp     x8, x9, [P1] __LF                  \
+        ldp     x10, x11, [P1+16] __LF             \
+        ldp     x12, x13, [P1+32] __LF             \
+        mov     x14, C __LF                        \
+        mul     x15, x14, x8 __LF                  \
+        umulh   x8, x14, x8 __LF                   \
+        adds    x0, x0, x15 __LF                   \
+        mul     x15, x14, x9 __LF                  \
+        umulh   x9, x14, x9 __LF                   \
+        adcs    x1, x1, x15 __LF                   \
+        mul     x15, x14, x10 __LF                 \
+        umulh   x10, x14, x10 __LF                 \
+        adcs    x2, x2, x15 __LF                   \
+        mul     x15, x14, x11 __LF                 \
+        umulh   x11, x14, x11 __LF                 \
+        adcs    x3, x3, x15 __LF                   \
+        mul     x15, x14, x12 __LF                 \
+        umulh   x12, x14, x12 __LF                 \
+        adcs    x4, x4, x15 __LF                   \
+        mul     x15, x14, x13 __LF                 \
+        umulh   x13, x14, x13 __LF                 \
+        adcs    x5, x5, x15 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        adds    x1, x1, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x10 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adcs    x5, x5, x12 __LF                   \
+        adcs    x6, x6, x13 __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x6, cc __LF                        \
+        mov     x7, #0xffffffff __LF               \
+        and     x7, x7, x6 __LF                    \
+        adds    x0, x0, x7 __LF                    \
+        eor     x7, x7, x6 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        mov     x7, #0xfffffffffffffffe __LF       \
+        and     x7, x7, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x6 __LF                    \
+        adcs    x4, x4, x6 __LF                    \
+        adc     x5, x5, x6 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 // A weak version of add that only guarantees sum in 6 digits
 
 #define weakadd_p384(P0,P1,P2)                  \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adds    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x3;                   \
-        csetm   x3, cs;                         \
-        mov     x4, #0xffffffff;                \
-        and     x4, x4, x3;                     \
-        subs    x5, x5, x4;                     \
-        eor     x4, x4, x3;                     \
-        sbcs    x6, x6, x4;                     \
-        mov     x4, #0xfffffffffffffffe;        \
-        and     x4, x4, x3;                     \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x3;                     \
-        sbc     x10, x10, x3;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adds    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x3 __LF                  \
+        csetm   x3, cs __LF                        \
+        mov     x4, #0xffffffff __LF               \
+        and     x4, x4, x3 __LF                    \
+        subs    x5, x5, x4 __LF                    \
+        eor     x4, x4, x3 __LF                    \
+        sbcs    x6, x6, x4 __LF                    \
+        mov     x4, #0xfffffffffffffffe __LF       \
+        and     x4, x4, x3 __LF                    \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbc     x10, x10, x3 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
         stp     x9, x10, [P0+32]
 
 // P0 = 3 * P1 - 8 * P2
 
 #define cmsub38_p384(P0,P1,P2)                  \
-        ldp     x0, x1, [P2];                   \
-        mov     x6, #0x00000000ffffffff;        \
-        subs    x6, x6, x0;                     \
-        mov     x7, #0xffffffff00000000;        \
-        sbcs    x7, x7, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        mov     x8, #0xfffffffffffffffe;        \
-        sbcs    x8, x8, x0;                     \
-        mov     x13, #0xffffffffffffffff;       \
-        sbcs    x9, x13, x1;                    \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x10, x13, x0;                   \
-        sbc     x11, x13, x1;                   \
-        lsl     x0, x6, #3;                     \
-        extr    x1, x7, x6, #61;                \
-        extr    x2, x8, x7, #61;                \
-        extr    x3, x9, x8, #61;                \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        lsr     x6, x11, #61;                   \
-        add     x6, x6, #1;                     \
-        ldp     x8, x9, [P1];                   \
-        ldp     x10, x11, [P1+16];              \
-        ldp     x12, x13, [P1+32];              \
-        mov     x14, 3;                         \
-        mul     x15, x14, x8;                   \
-        umulh   x8, x14, x8;                    \
-        adds    x0, x0, x15;                    \
-        mul     x15, x14, x9;                   \
-        umulh   x9, x14, x9;                    \
-        adcs    x1, x1, x15;                    \
-        mul     x15, x14, x10;                  \
-        umulh   x10, x14, x10;                  \
-        adcs    x2, x2, x15;                    \
-        mul     x15, x14, x11;                  \
-        umulh   x11, x14, x11;                  \
-        adcs    x3, x3, x15;                    \
-        mul     x15, x14, x12;                  \
-        umulh   x12, x14, x12;                  \
-        adcs    x4, x4, x15;                    \
-        mul     x15, x14, x13;                  \
-        umulh   x13, x14, x13;                  \
-        adcs    x5, x5, x15;                    \
-        adc     x6, x6, xzr;                    \
-        adds    x1, x1, x8;                     \
-        adcs    x2, x2, x9;                     \
-        adcs    x3, x3, x10;                    \
-        adcs    x4, x4, x11;                    \
-        adcs    x5, x5, x12;                    \
-        adcs    x6, x6, x13;                    \
-        lsl     x7, x6, #32;                    \
-        subs    x8, x6, x7;                     \
-        sbc     x7, x7, xzr;                    \
-        adds    x0, x0, x8;                     \
-        adcs    x1, x1, x7;                     \
-        adcs    x2, x2, x6;                     \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csetm   x6, cc;                         \
-        mov     x7, #0xffffffff;                \
-        and     x7, x7, x6;                     \
-        adds    x0, x0, x7;                     \
-        eor     x7, x7, x6;                     \
-        adcs    x1, x1, x7;                     \
-        mov     x7, #0xfffffffffffffffe;        \
-        and     x7, x7, x6;                     \
-        adcs    x2, x2, x7;                     \
-        adcs    x3, x3, x6;                     \
-        adcs    x4, x4, x6;                     \
-        adc     x5, x5, x6;                     \
-        stp     x0, x1, [P0];                   \
-        stp     x2, x3, [P0+16];                \
+        ldp     x0, x1, [P2] __LF                  \
+        mov     x6, #0x00000000ffffffff __LF       \
+        subs    x6, x6, x0 __LF                    \
+        mov     x7, #0xffffffff00000000 __LF       \
+        sbcs    x7, x7, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        mov     x8, #0xfffffffffffffffe __LF       \
+        sbcs    x8, x8, x0 __LF                    \
+        mov     x13, #0xffffffffffffffff __LF      \
+        sbcs    x9, x13, x1 __LF                   \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x10, x13, x0 __LF                  \
+        sbc     x11, x13, x1 __LF                  \
+        lsl     x0, x6, #3 __LF                    \
+        extr    x1, x7, x6, #61 __LF               \
+        extr    x2, x8, x7, #61 __LF               \
+        extr    x3, x9, x8, #61 __LF               \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        lsr     x6, x11, #61 __LF                  \
+        add     x6, x6, #1 __LF                    \
+        ldp     x8, x9, [P1] __LF                  \
+        ldp     x10, x11, [P1+16] __LF             \
+        ldp     x12, x13, [P1+32] __LF             \
+        mov     x14, 3 __LF                        \
+        mul     x15, x14, x8 __LF                  \
+        umulh   x8, x14, x8 __LF                   \
+        adds    x0, x0, x15 __LF                   \
+        mul     x15, x14, x9 __LF                  \
+        umulh   x9, x14, x9 __LF                   \
+        adcs    x1, x1, x15 __LF                   \
+        mul     x15, x14, x10 __LF                 \
+        umulh   x10, x14, x10 __LF                 \
+        adcs    x2, x2, x15 __LF                   \
+        mul     x15, x14, x11 __LF                 \
+        umulh   x11, x14, x11 __LF                 \
+        adcs    x3, x3, x15 __LF                   \
+        mul     x15, x14, x12 __LF                 \
+        umulh   x12, x14, x12 __LF                 \
+        adcs    x4, x4, x15 __LF                   \
+        mul     x15, x14, x13 __LF                 \
+        umulh   x13, x14, x13 __LF                 \
+        adcs    x5, x5, x15 __LF                   \
+        adc     x6, x6, xzr __LF                   \
+        adds    x1, x1, x8 __LF                    \
+        adcs    x2, x2, x9 __LF                    \
+        adcs    x3, x3, x10 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adcs    x5, x5, x12 __LF                   \
+        adcs    x6, x6, x13 __LF                   \
+        lsl     x7, x6, #32 __LF                   \
+        subs    x8, x6, x7 __LF                    \
+        sbc     x7, x7, xzr __LF                   \
+        adds    x0, x0, x8 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        adcs    x2, x2, x6 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csetm   x6, cc __LF                        \
+        mov     x7, #0xffffffff __LF               \
+        and     x7, x7, x6 __LF                    \
+        adds    x0, x0, x7 __LF                    \
+        eor     x7, x7, x6 __LF                    \
+        adcs    x1, x1, x7 __LF                    \
+        mov     x7, #0xfffffffffffffffe __LF       \
+        and     x7, x7, x6 __LF                    \
+        adcs    x2, x2, x7 __LF                    \
+        adcs    x3, x3, x6 __LF                    \
+        adcs    x4, x4, x6 __LF                    \
+        adc     x5, x5, x6 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
+        stp     x2, x3, [P0+16] __LF               \
         stp     x4, x5, [P0+32]
 
 S2N_BN_SYMBOL(p384_montjdouble):

--- a/arm/p521/bignum_inv_p521.S
+++ b/arm/p521/bignum_inv_p521.S
@@ -80,618 +80,618 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_inv_p521):

--- a/arm/p521/bignum_mod_n521_9.S
+++ b/arm/p521/bignum_mod_n521_9.S
@@ -47,9 +47,9 @@
 #define t d7
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n521_9):

--- a/arm/p521/p521_jadd.S
+++ b/arm/p521/p521_jadd.S
@@ -84,20 +84,20 @@
 // and bignum_sub_p521
 
 #define mul_p521(P0,P1,P2)                      \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
-        add     x2, P2;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
+        add     x2, P2 __LF                        \
         bl      p521_jadd_local_mul_p521
 
 #define sqr_p521(P0,P1)                         \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
         bl      p521_jadd_local_sqr_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
-        add     x2, P2;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
+        add     x2, P2 __LF                        \
         bl      p521_jadd_local_sub_p521
 
 S2N_BN_SYMBOL(p521_jadd):

--- a/arm/p521/p521_jadd_alt.S
+++ b/arm/p521/p521_jadd_alt.S
@@ -82,650 +82,650 @@
 // Corresponds exactly to bignum_mul_p521_alt
 
 #define mul_p521(P0,P1,P2)                      \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x15, x3, x5;                    \
-        umulh   x16, x3, x5;                    \
-        mul     x14, x3, x6;                    \
-        umulh   x17, x3, x6;                    \
-        adds    x16, x16, x14;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x14, x3, x7;                    \
-        umulh   x19, x3, x7;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x8;                    \
-        umulh   x20, x3, x8;                    \
-        adcs    x19, x19, x14;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x14, x3, x9;                    \
-        umulh   x21, x3, x9;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x10;                   \
-        umulh   x22, x3, x10;                   \
-        adcs    x21, x21, x14;                  \
-        ldp     x11, x12, [P2+48];              \
-        mul     x14, x3, x11;                   \
-        umulh   x23, x3, x11;                   \
-        adcs    x22, x22, x14;                  \
-        ldr     x13, [P2+64];                   \
-        mul     x14, x3, x12;                   \
-        umulh   x24, x3, x12;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x13;                   \
-        umulh   x1, x3, x13;                    \
-        adcs    x24, x24, x14;                  \
-        adc     x1, x1, xzr;                    \
-        mul     x14, x4, x5;                    \
-        adds    x16, x16, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x1, x1, x14;                    \
-        cset    x0, hs;                         \
-        umulh   x14, x4, x5;                    \
-        adds    x17, x17, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x13;                   \
-        adc     x0, x0, x14;                    \
-        stp     x15, x16, [P0];                 \
-        ldp     x3, x4, [P1+16];                \
-        mul     x14, x3, x5;                    \
-        adds    x17, x17, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x13;                   \
-        adcs    x0, x0, x14;                    \
-        cset    x15, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x19, x19, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x12;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x13;                   \
-        adc     x15, x15, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x19, x19, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x12;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x13;                   \
-        adcs    x15, x15, x14;                  \
-        cset    x16, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x20, x20, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x11;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x12;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x16, x16, x14;                  \
-        stp     x17, x19, [P0+16];              \
-        ldp     x3, x4, [P1+32];                \
-        mul     x14, x3, x5;                    \
-        adds    x20, x20, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x11;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x12;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x16, x16, x14;                  \
-        cset    x17, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x21, x21, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x10;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x11;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x17, x17, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x21, x21, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x10;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x11;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x17, x17, x14;                  \
-        cset    x19, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x22, x22, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x9;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x10;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x19, x19, x14;                  \
-        stp     x20, x21, [P0+32];              \
-        ldp     x3, x4, [P1+48];                \
-        mul     x14, x3, x5;                    \
-        adds    x22, x22, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x9;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x10;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x19, x19, x14;                  \
-        cset    x20, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x23, x23, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x8;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x9;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x20, x20, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x23, x23, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x8;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x9;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x20, x20, x14;                  \
-        cset    x21, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x24, x24, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x7;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x8;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x21, x21, x14;                  \
-        stp     x22, x23, [P0+48];              \
-        ldr     x3, [P1+64];                    \
-        mul     x14, x3, x5;                    \
-        adds    x24, x24, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x7;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x8;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x13;                   \
-        adc     x21, x21, x14;                  \
-        umulh   x14, x3, x5;                    \
-        adds    x1, x1, x14;                    \
-        umulh   x14, x3, x6;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x7;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adc     x21, x21, x14;                  \
-        cmp     xzr, xzr;                       \
-        ldp     x5, x6, [P0];                   \
-        extr    x14, x1, x24, #9;               \
-        adcs    x5, x5, x14;                    \
-        extr    x14, x0, x1, #9;                \
-        adcs    x6, x6, x14;                    \
-        ldp     x7, x8, [P0+16];                \
-        extr    x14, x15, x0, #9;               \
-        adcs    x7, x7, x14;                    \
-        extr    x14, x16, x15, #9;              \
-        adcs    x8, x8, x14;                    \
-        ldp     x9, x10, [P0+32];               \
-        extr    x14, x17, x16, #9;              \
-        adcs    x9, x9, x14;                    \
-        extr    x14, x19, x17, #9;              \
-        adcs    x10, x10, x14;                  \
-        ldp     x11, x12, [P0+48];              \
-        extr    x14, x20, x19, #9;              \
-        adcs    x11, x11, x14;                  \
-        extr    x14, x21, x20, #9;              \
-        adcs    x12, x12, x14;                  \
-        orr     x13, x24, #0xfffffffffffffe00;  \
-        lsr     x14, x21, #9;                   \
-        adcs    x13, x13, x14;                  \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x15, x3, x5 __LF                   \
+        umulh   x16, x3, x5 __LF                   \
+        mul     x14, x3, x6 __LF                   \
+        umulh   x17, x3, x6 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x14, x3, x7 __LF                   \
+        umulh   x19, x3, x7 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        umulh   x20, x3, x8 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x14, x3, x9 __LF                   \
+        umulh   x21, x3, x9 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        umulh   x22, x3, x10 __LF                  \
+        adcs    x21, x21, x14 __LF                 \
+        ldp     x11, x12, [P2+48] __LF             \
+        mul     x14, x3, x11 __LF                  \
+        umulh   x23, x3, x11 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        ldr     x13, [P2+64] __LF                  \
+        mul     x14, x3, x12 __LF                  \
+        umulh   x24, x3, x12 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        umulh   x1, x3, x13 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        mul     x14, x4, x5 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        cset    x0, hs __LF                        \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x0, x0, x14 __LF                   \
+        stp     x15, x16, [P0] __LF                \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        cset    x15, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x15, x15, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        cset    x16, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x16, x16, x14 __LF                 \
+        stp     x17, x19, [P0+16] __LF             \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        cset    x17, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x17, x17, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        cset    x19, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x19, x19, x14 __LF                 \
+        stp     x20, x21, [P0+32] __LF             \
+        ldp     x3, x4, [P1+48] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x20, x20, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        cset    x21, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        stp     x22, x23, [P0+48] __LF             \
+        ldr     x3, [P1+64] __LF                   \
+        mul     x14, x3, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        cmp     xzr, xzr __LF                      \
+        ldp     x5, x6, [P0] __LF                  \
+        extr    x14, x1, x24, #9 __LF              \
+        adcs    x5, x5, x14 __LF                   \
+        extr    x14, x0, x1, #9 __LF               \
+        adcs    x6, x6, x14 __LF                   \
+        ldp     x7, x8, [P0+16] __LF               \
+        extr    x14, x15, x0, #9 __LF              \
+        adcs    x7, x7, x14 __LF                   \
+        extr    x14, x16, x15, #9 __LF             \
+        adcs    x8, x8, x14 __LF                   \
+        ldp     x9, x10, [P0+32] __LF              \
+        extr    x14, x17, x16, #9 __LF             \
+        adcs    x9, x9, x14 __LF                   \
+        extr    x14, x19, x17, #9 __LF             \
+        adcs    x10, x10, x14 __LF                 \
+        ldp     x11, x12, [P0+48] __LF             \
+        extr    x14, x20, x19, #9 __LF             \
+        adcs    x11, x11, x14 __LF                 \
+        extr    x14, x21, x20, #9 __LF             \
+        adcs    x12, x12, x14 __LF                 \
+        orr     x13, x24, #0xfffffffffffffe00 __LF \
+        lsr     x14, x21, #9 __LF                  \
+        adcs    x13, x13, x14 __LF                 \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Corresponds exactly to bignum_sqr_p521_alt
 
 #define sqr_p521(P0,P1)                         \
-        ldp     x2, x3, [P1];                   \
-        mul     x11, x2, x3;                    \
-        umulh   x12, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x10, x2, x4;                    \
-        umulh   x13, x2, x4;                    \
-        adds    x12, x12, x10;                  \
-        ldp     x6, x7, [P1+32];                \
-        mul     x10, x2, x5;                    \
-        umulh   x14, x2, x5;                    \
-        adcs    x13, x13, x10;                  \
-        ldp     x8, x9, [P1+48];                \
-        mul     x10, x2, x6;                    \
-        umulh   x15, x2, x6;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x2, x7;                    \
-        umulh   x16, x2, x7;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x2, x8;                    \
-        umulh   x17, x2, x8;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x2, x9;                    \
-        umulh   x19, x2, x9;                    \
-        adcs    x17, x17, x10;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x10, x3, x4;                    \
-        adds    x13, x13, x10;                  \
-        mul     x10, x3, x5;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x3, x6;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x3, x7;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x3, x8;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x3, x9;                    \
-        adcs    x19, x19, x10;                  \
-        cset    x20, hs;                        \
-        umulh   x10, x3, x4;                    \
-        adds    x14, x14, x10;                  \
-        umulh   x10, x3, x5;                    \
-        adcs    x15, x15, x10;                  \
-        umulh   x10, x3, x6;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x3, x7;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x3, x8;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x3, x9;                    \
-        adc     x20, x20, x10;                  \
-        mul     x10, x6, x7;                    \
-        umulh   x21, x6, x7;                    \
-        adds    x20, x20, x10;                  \
-        adc     x21, x21, xzr;                  \
-        mul     x10, x4, x5;                    \
-        adds    x15, x15, x10;                  \
-        mul     x10, x4, x6;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x4, x7;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x4, x8;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x4, x9;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x6, x8;                    \
-        adcs    x21, x21, x10;                  \
-        cset    x22, hs;                        \
-        umulh   x10, x4, x5;                    \
-        adds    x16, x16, x10;                  \
-        umulh   x10, x4, x6;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x4, x7;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x4, x8;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x4, x9;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x6, x8;                    \
-        adc     x22, x22, x10;                  \
-        mul     x10, x7, x8;                    \
-        umulh   x23, x7, x8;                    \
-        adds    x22, x22, x10;                  \
-        adc     x23, x23, xzr;                  \
-        mul     x10, x5, x6;                    \
-        adds    x17, x17, x10;                  \
-        mul     x10, x5, x7;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x5, x8;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x5, x9;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x6, x9;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x7, x9;                    \
-        adcs    x23, x23, x10;                  \
-        cset    x24, hs;                        \
-        umulh   x10, x5, x6;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x5, x7;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x5, x8;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x5, x9;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x6, x9;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x7, x9;                    \
-        adc     x24, x24, x10;                  \
-        mul     x10, x8, x9;                    \
-        umulh   x25, x8, x9;                    \
-        adds    x24, x24, x10;                  \
-        adc     x25, x25, xzr;                  \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        adcs    x20, x20, x20;                  \
-        adcs    x21, x21, x21;                  \
-        adcs    x22, x22, x22;                  \
-        adcs    x23, x23, x23;                  \
-        adcs    x24, x24, x24;                  \
-        adcs    x25, x25, x25;                  \
-        cset    x0, hs;                         \
-        umulh   x10, x2, x2;                    \
-        adds    x11, x11, x10;                  \
-        mul     x10, x3, x3;                    \
-        adcs    x12, x12, x10;                  \
-        umulh   x10, x3, x3;                    \
-        adcs    x13, x13, x10;                  \
-        mul     x10, x4, x4;                    \
-        adcs    x14, x14, x10;                  \
-        umulh   x10, x4, x4;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x5, x5;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x5, x5;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x6, x6;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x6, x6;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x7, x7;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x7, x7;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x8, x8;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x8, x8;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x9, x9;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x9, x9;                    \
-        adc     x0, x0, x10;                    \
-        ldr     x1, [P1+64];                    \
-        add     x1, x1, x1;                     \
-        mul     x10, x1, x2;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x1, x2;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x1, x4;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x1, x4;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x1, x6;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x1, x6;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x1, x8;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x1, x8;                    \
-        adcs    x0, x0, x10;                    \
-        lsr     x4, x1, #1;                     \
-        mul     x4, x4, x4;                     \
-        adc     x4, x4, xzr;                    \
-        mul     x10, x1, x3;                    \
-        adds    x20, x20, x10;                  \
-        umulh   x10, x1, x3;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x1, x5;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x1, x5;                    \
-        adcs    x23, x23, x10;                  \
-        mul     x10, x1, x7;                    \
-        adcs    x24, x24, x10;                  \
-        umulh   x10, x1, x7;                    \
-        adcs    x25, x25, x10;                  \
-        mul     x10, x1, x9;                    \
-        adcs    x0, x0, x10;                    \
-        umulh   x10, x1, x9;                    \
-        adc     x4, x4, x10;                    \
-        mul     x2, x2, x2;                     \
-        cmp     xzr, xzr;                       \
-        extr    x10, x20, x19, #9;              \
-        adcs    x2, x2, x10;                    \
-        extr    x10, x21, x20, #9;              \
-        adcs    x11, x11, x10;                  \
-        extr    x10, x22, x21, #9;              \
-        adcs    x12, x12, x10;                  \
-        extr    x10, x23, x22, #9;              \
-        adcs    x13, x13, x10;                  \
-        extr    x10, x24, x23, #9;              \
-        adcs    x14, x14, x10;                  \
-        extr    x10, x25, x24, #9;              \
-        adcs    x15, x15, x10;                  \
-        extr    x10, x0, x25, #9;               \
-        adcs    x16, x16, x10;                  \
-        extr    x10, x4, x0, #9;                \
-        adcs    x17, x17, x10;                  \
-        orr     x19, x19, #0xfffffffffffffe00;  \
-        lsr     x10, x4, #9;                    \
-        adcs    x19, x19, x10;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x19, x19, xzr;                  \
-        and     x19, x19, #0x1ff;               \
-        stp     x2, x11, [P0];                  \
-        stp     x12, x13, [P0+16];              \
-        stp     x14, x15, [P0+32];              \
-        stp     x16, x17, [P0+48];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x11, x2, x3 __LF                   \
+        umulh   x12, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x10, x2, x4 __LF                   \
+        umulh   x13, x2, x4 __LF                   \
+        adds    x12, x12, x10 __LF                 \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x10, x2, x5 __LF                   \
+        umulh   x14, x2, x5 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        ldp     x8, x9, [P1+48] __LF               \
+        mul     x10, x2, x6 __LF                   \
+        umulh   x15, x2, x6 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x2, x7 __LF                   \
+        umulh   x16, x2, x7 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x2, x8 __LF                   \
+        umulh   x17, x2, x8 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x2, x9 __LF                   \
+        umulh   x19, x2, x9 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x10, x3, x4 __LF                   \
+        adds    x13, x13, x10 __LF                 \
+        mul     x10, x3, x5 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x3, x6 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x3, x7 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x3, x8 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x3, x9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x10, x3, x4 __LF                   \
+        adds    x14, x14, x10 __LF                 \
+        umulh   x10, x3, x5 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        umulh   x10, x3, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x3, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x3, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x3, x9 __LF                   \
+        adc     x20, x20, x10 __LF                 \
+        mul     x10, x6, x7 __LF                   \
+        umulh   x21, x6, x7 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        adc     x21, x21, xzr __LF                 \
+        mul     x10, x4, x5 __LF                   \
+        adds    x15, x15, x10 __LF                 \
+        mul     x10, x4, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x4, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x4, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x4, x9 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x6, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        cset    x22, hs __LF                       \
+        umulh   x10, x4, x5 __LF                   \
+        adds    x16, x16, x10 __LF                 \
+        umulh   x10, x4, x6 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x4, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x4, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x4, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x6, x8 __LF                   \
+        adc     x22, x22, x10 __LF                 \
+        mul     x10, x7, x8 __LF                   \
+        umulh   x23, x7, x8 __LF                   \
+        adds    x22, x22, x10 __LF                 \
+        adc     x23, x23, xzr __LF                 \
+        mul     x10, x5, x6 __LF                   \
+        adds    x17, x17, x10 __LF                 \
+        mul     x10, x5, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x5, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x5, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x6, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x7, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        cset    x24, hs __LF                       \
+        umulh   x10, x5, x6 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x5, x7 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x5, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x5, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x6, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x7, x9 __LF                   \
+        adc     x24, x24, x10 __LF                 \
+        mul     x10, x8, x9 __LF                   \
+        umulh   x25, x8, x9 __LF                   \
+        adds    x24, x24, x10 __LF                 \
+        adc     x25, x25, xzr __LF                 \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        adcs    x20, x20, x20 __LF                 \
+        adcs    x21, x21, x21 __LF                 \
+        adcs    x22, x22, x22 __LF                 \
+        adcs    x23, x23, x23 __LF                 \
+        adcs    x24, x24, x24 __LF                 \
+        adcs    x25, x25, x25 __LF                 \
+        cset    x0, hs __LF                        \
+        umulh   x10, x2, x2 __LF                   \
+        adds    x11, x11, x10 __LF                 \
+        mul     x10, x3, x3 __LF                   \
+        adcs    x12, x12, x10 __LF                 \
+        umulh   x10, x3, x3 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        mul     x10, x4, x4 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        umulh   x10, x4, x4 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x5, x5 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x5, x5 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x6, x6 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x6, x6 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x7, x7 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x7, x7 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x8, x8 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x8, x8 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x9, x9 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x9, x9 __LF                   \
+        adc     x0, x0, x10 __LF                   \
+        ldr     x1, [P1+64] __LF                   \
+        add     x1, x1, x1 __LF                    \
+        mul     x10, x1, x2 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x1, x2 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x1, x4 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x1, x4 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x1, x6 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x1, x6 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x1, x8 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x1, x8 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        lsr     x4, x1, #1 __LF                    \
+        mul     x4, x4, x4 __LF                    \
+        adc     x4, x4, xzr __LF                   \
+        mul     x10, x1, x3 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        umulh   x10, x1, x3 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x1, x5 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x1, x5 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        mul     x10, x1, x7 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        umulh   x10, x1, x7 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        mul     x10, x1, x9 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        umulh   x10, x1, x9 __LF                   \
+        adc     x4, x4, x10 __LF                   \
+        mul     x2, x2, x2 __LF                    \
+        cmp     xzr, xzr __LF                      \
+        extr    x10, x20, x19, #9 __LF             \
+        adcs    x2, x2, x10 __LF                   \
+        extr    x10, x21, x20, #9 __LF             \
+        adcs    x11, x11, x10 __LF                 \
+        extr    x10, x22, x21, #9 __LF             \
+        adcs    x12, x12, x10 __LF                 \
+        extr    x10, x23, x22, #9 __LF             \
+        adcs    x13, x13, x10 __LF                 \
+        extr    x10, x24, x23, #9 __LF             \
+        adcs    x14, x14, x10 __LF                 \
+        extr    x10, x25, x24, #9 __LF             \
+        adcs    x15, x15, x10 __LF                 \
+        extr    x10, x0, x25, #9 __LF              \
+        adcs    x16, x16, x10 __LF                 \
+        extr    x10, x4, x0, #9 __LF               \
+        adcs    x17, x17, x10 __LF                 \
+        orr     x19, x19, #0xfffffffffffffe00 __LF \
+        lsr     x10, x4, #9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x19, x19, xzr __LF                 \
+        and     x19, x19, #0x1ff __LF              \
+        stp     x2, x11, [P0] __LF                 \
+        stp     x12, x13, [P0+16] __LF             \
+        stp     x14, x15, [P0+32] __LF             \
+        stp     x16, x17, [P0+48] __LF             \
         str     x19, [P0+64]
 
 // Corresponds exactly to bignum_sub_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 S2N_BN_SYMBOL(p521_jadd_alt):

--- a/arm/p521/p521_jdouble.S
+++ b/arm/p521/p521_jdouble.S
@@ -65,353 +65,353 @@
 // Call local code very close to bignum_mul_p521 and bignum_sqr_p521.
 
 #define mul_p521(P0,P1,P2)                      \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
-        add     x2, P2;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
+        add     x2, P2 __LF                        \
         bl      p521_jdouble_local_mul_p521
 
 // Call local code equivalent to bignum_sqr_p521
 
 #define sqr_p521(P0,P1)                         \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
         bl      p521_jdouble_local_sqr_p521
 
 // Corresponds exactly to bignum_add_p521
 
 #define add_p521(P0,P1,P2)                      \
-        cmp     xzr, xzr;                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adcs    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        adcs    x11, x11, x4;                   \
-        adcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        adc     x13, x13, x4;                   \
-        subs    x4, x13, #512;                  \
-        csetm   x4, hs;                         \
-        sbcs    x5, x5, xzr;                    \
-        and     x4, x4, #0x200;                 \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, x4;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        cmp     xzr, xzr __LF                      \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adcs    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        adcs    x11, x11, x4 __LF                  \
+        adcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        adc     x13, x13, x4 __LF                  \
+        subs    x4, x13, #512 __LF                 \
+        csetm   x4, hs __LF                        \
+        sbcs    x5, x5, xzr __LF                   \
+        and     x4, x4, #0x200 __LF                \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, x4 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Corresponds exactly to bignum_sub_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // P0 = C * P1 - D * P2 == C * P1 + D * (p_521 - P2)
 
 #define cmsub_p521(P0,C,P1,D,P2)                \
-        ldp     x6, x7, [P1];                   \
-        mov     x1, #(C);                       \
-        mul     x3, x1, x6;                     \
-        mul     x4, x1, x7;                     \
-        umulh   x6, x1, x6;                     \
-        adds    x4, x4, x6;                     \
-        umulh   x7, x1, x7;                     \
-        ldp     x8, x9, [P1+16];                \
-        mul     x5, x1, x8;                     \
-        mul     x6, x1, x9;                     \
-        umulh   x8, x1, x8;                     \
-        adcs    x5, x5, x7;                     \
-        umulh   x9, x1, x9;                     \
-        adcs    x6, x6, x8;                     \
-        ldp     x10, x11, [P1+32];              \
-        mul     x7, x1, x10;                    \
-        mul     x8, x1, x11;                    \
-        umulh   x10, x1, x10;                   \
-        adcs    x7, x7, x9;                     \
-        umulh   x11, x1, x11;                   \
-        adcs    x8, x8, x10;                    \
-        ldp     x12, x13, [P1+48];              \
-        mul     x9, x1, x12;                    \
-        mul     x10, x1, x13;                   \
-        umulh   x12, x1, x12;                   \
-        adcs    x9, x9, x11;                    \
-        umulh   x13, x1, x13;                   \
-        adcs    x10, x10, x12;                  \
-        ldr     x14, [P1+64];                   \
-        mul     x11, x1, x14;                   \
-        adc     x11, x11, x13;                  \
-        mov     x1, #(D);                       \
-        ldp     x20, x21, [P2];                 \
-        mvn     x20, x20;                       \
-        mul     x0, x1, x20;                    \
-        umulh   x20, x1, x20;                   \
-        adds    x3, x3, x0;                     \
-        mvn     x21, x21;                       \
-        mul     x0, x1, x21;                    \
-        umulh   x21, x1, x21;                   \
-        adcs    x4, x4, x0;                     \
-        ldp     x22, x23, [P2+16];              \
-        mvn     x22, x22;                       \
-        mul     x0, x1, x22;                    \
-        umulh   x22, x1, x22;                   \
-        adcs    x5, x5, x0;                     \
-        mvn     x23, x23;                       \
-        mul     x0, x1, x23;                    \
-        umulh   x23, x1, x23;                   \
-        adcs    x6, x6, x0;                     \
-        ldp     x17, x19, [P2+32];              \
-        mvn     x17, x17;                       \
-        mul     x0, x1, x17;                    \
-        umulh   x17, x1, x17;                   \
-        adcs    x7, x7, x0;                     \
-        mvn     x19, x19;                       \
-        mul     x0, x1, x19;                    \
-        umulh   x19, x1, x19;                   \
-        adcs    x8, x8, x0;                     \
-        ldp     x2, x16, [P2+48];               \
-        mvn     x2, x2;                         \
-        mul     x0, x1, x2;                     \
-        umulh   x2, x1, x2;                     \
-        adcs    x9, x9, x0;                     \
-        mvn     x16, x16;                       \
-        mul     x0, x1, x16;                    \
-        umulh   x16, x1, x16;                   \
-        adcs    x10, x10, x0;                   \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        mul     x0, x1, x0;                     \
-        adc     x11, x11, x0;                   \
-        adds    x4, x4, x20;                    \
-        adcs    x5, x5, x21;                    \
-        and     x15, x4, x5;                    \
-        adcs    x6, x6, x22;                    \
-        and     x15, x15, x6;                   \
-        adcs    x7, x7, x23;                    \
-        and     x15, x15, x7;                   \
-        adcs    x8, x8, x17;                    \
-        and     x15, x15, x8;                   \
-        adcs    x9, x9, x19;                    \
-        and     x15, x15, x9;                   \
-        adcs    x10, x10, x2;                   \
-        and     x15, x15, x10;                  \
-        adc     x11, x11, x16;                  \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        mov     x1, #(C) __LF                      \
+        mul     x3, x1, x6 __LF                    \
+        mul     x4, x1, x7 __LF                    \
+        umulh   x6, x1, x6 __LF                    \
+        adds    x4, x4, x6 __LF                    \
+        umulh   x7, x1, x7 __LF                    \
+        ldp     x8, x9, [P1+16] __LF               \
+        mul     x5, x1, x8 __LF                    \
+        mul     x6, x1, x9 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        ldp     x10, x11, [P1+32] __LF             \
+        mul     x7, x1, x10 __LF                   \
+        mul     x8, x1, x11 __LF                   \
+        umulh   x10, x1, x10 __LF                  \
+        adcs    x7, x7, x9 __LF                    \
+        umulh   x11, x1, x11 __LF                  \
+        adcs    x8, x8, x10 __LF                   \
+        ldp     x12, x13, [P1+48] __LF             \
+        mul     x9, x1, x12 __LF                   \
+        mul     x10, x1, x13 __LF                  \
+        umulh   x12, x1, x12 __LF                  \
+        adcs    x9, x9, x11 __LF                   \
+        umulh   x13, x1, x13 __LF                  \
+        adcs    x10, x10, x12 __LF                 \
+        ldr     x14, [P1+64] __LF                  \
+        mul     x11, x1, x14 __LF                  \
+        adc     x11, x11, x13 __LF                 \
+        mov     x1, #(D) __LF                      \
+        ldp     x20, x21, [P2] __LF                \
+        mvn     x20, x20 __LF                      \
+        mul     x0, x1, x20 __LF                   \
+        umulh   x20, x1, x20 __LF                  \
+        adds    x3, x3, x0 __LF                    \
+        mvn     x21, x21 __LF                      \
+        mul     x0, x1, x21 __LF                   \
+        umulh   x21, x1, x21 __LF                  \
+        adcs    x4, x4, x0 __LF                    \
+        ldp     x22, x23, [P2+16] __LF             \
+        mvn     x22, x22 __LF                      \
+        mul     x0, x1, x22 __LF                   \
+        umulh   x22, x1, x22 __LF                  \
+        adcs    x5, x5, x0 __LF                    \
+        mvn     x23, x23 __LF                      \
+        mul     x0, x1, x23 __LF                   \
+        umulh   x23, x1, x23 __LF                  \
+        adcs    x6, x6, x0 __LF                    \
+        ldp     x17, x19, [P2+32] __LF             \
+        mvn     x17, x17 __LF                      \
+        mul     x0, x1, x17 __LF                   \
+        umulh   x17, x1, x17 __LF                  \
+        adcs    x7, x7, x0 __LF                    \
+        mvn     x19, x19 __LF                      \
+        mul     x0, x1, x19 __LF                   \
+        umulh   x19, x1, x19 __LF                  \
+        adcs    x8, x8, x0 __LF                    \
+        ldp     x2, x16, [P2+48] __LF              \
+        mvn     x2, x2 __LF                        \
+        mul     x0, x1, x2 __LF                    \
+        umulh   x2, x1, x2 __LF                    \
+        adcs    x9, x9, x0 __LF                    \
+        mvn     x16, x16 __LF                      \
+        mul     x0, x1, x16 __LF                   \
+        umulh   x16, x1, x16 __LF                  \
+        adcs    x10, x10, x0 __LF                  \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        mul     x0, x1, x0 __LF                    \
+        adc     x11, x11, x0 __LF                  \
+        adds    x4, x4, x20 __LF                   \
+        adcs    x5, x5, x21 __LF                   \
+        and     x15, x4, x5 __LF                   \
+        adcs    x6, x6, x22 __LF                   \
+        and     x15, x15, x6 __LF                  \
+        adcs    x7, x7, x23 __LF                   \
+        and     x15, x15, x7 __LF                  \
+        adcs    x8, x8, x17 __LF                   \
+        and     x15, x15, x8 __LF                  \
+        adcs    x9, x9, x19 __LF                   \
+        and     x15, x15, x9 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        adc     x11, x11, x16 __LF                 \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 // P0 = 3 * P1 - 8 * P2 == 3 * P1 + 8 * (p_521 - P2)
 
 #define cmsub38_p521(P0,P1,P2)                  \
-        ldp     x6, x7, [P1];                   \
-        lsl     x3, x6, #1;                     \
-        adds    x3, x3, x6;                     \
-        extr    x4, x7, x6, #63;                \
-        adcs    x4, x4, x7;                     \
-        ldp     x8, x9, [P1+16];                \
-        extr    x5, x8, x7, #63;                \
-        adcs    x5, x5, x8;                     \
-        extr    x6, x9, x8, #63;                \
-        adcs    x6, x6, x9;                     \
-        ldp     x10, x11, [P1+32];              \
-        extr    x7, x10, x9, #63;               \
-        adcs    x7, x7, x10;                    \
-        extr    x8, x11, x10, #63;              \
-        adcs    x8, x8, x11;                    \
-        ldp     x12, x13, [P1+48];              \
-        extr    x9, x12, x11, #63;              \
-        adcs    x9, x9, x12;                    \
-        extr    x10, x13, x12, #63;             \
-        adcs    x10, x10, x13;                  \
-        ldr     x14, [P1+64];                   \
-        extr    x11, x14, x13, #63;             \
-        adc     x11, x11, x14;                  \
-        ldp     x20, x21, [P2];                 \
-        mvn     x20, x20;                       \
-        lsl     x0, x20, #3;                    \
-        adds    x3, x3, x0;                     \
-        mvn     x21, x21;                       \
-        extr    x0, x21, x20, #61;              \
-        adcs    x4, x4, x0;                     \
-        ldp     x22, x23, [P2+16];              \
-        mvn     x22, x22;                       \
-        extr    x0, x22, x21, #61;              \
-        adcs    x5, x5, x0;                     \
-        and     x15, x4, x5;                    \
-        mvn     x23, x23;                       \
-        extr    x0, x23, x22, #61;              \
-        adcs    x6, x6, x0;                     \
-        and     x15, x15, x6;                   \
-        ldp     x20, x21, [P2+32];              \
-        mvn     x20, x20;                       \
-        extr    x0, x20, x23, #61;              \
-        adcs    x7, x7, x0;                     \
-        and     x15, x15, x7;                   \
-        mvn     x21, x21;                       \
-        extr    x0, x21, x20, #61;              \
-        adcs    x8, x8, x0;                     \
-        and     x15, x15, x8;                   \
-        ldp     x22, x23, [P2+48];              \
-        mvn     x22, x22;                       \
-        extr    x0, x22, x21, #61;              \
-        adcs    x9, x9, x0;                     \
-        and     x15, x15, x9;                   \
-        mvn     x23, x23;                       \
-        extr    x0, x23, x22, #61;              \
-        adcs    x10, x10, x0;                   \
-        and     x15, x15, x10;                  \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        extr    x0, x0, x23, #61;               \
-        adc     x11, x11, x0;                   \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        lsl     x3, x6, #1 __LF                    \
+        adds    x3, x3, x6 __LF                    \
+        extr    x4, x7, x6, #63 __LF               \
+        adcs    x4, x4, x7 __LF                    \
+        ldp     x8, x9, [P1+16] __LF               \
+        extr    x5, x8, x7, #63 __LF               \
+        adcs    x5, x5, x8 __LF                    \
+        extr    x6, x9, x8, #63 __LF               \
+        adcs    x6, x6, x9 __LF                    \
+        ldp     x10, x11, [P1+32] __LF             \
+        extr    x7, x10, x9, #63 __LF              \
+        adcs    x7, x7, x10 __LF                   \
+        extr    x8, x11, x10, #63 __LF             \
+        adcs    x8, x8, x11 __LF                   \
+        ldp     x12, x13, [P1+48] __LF             \
+        extr    x9, x12, x11, #63 __LF             \
+        adcs    x9, x9, x12 __LF                   \
+        extr    x10, x13, x12, #63 __LF            \
+        adcs    x10, x10, x13 __LF                 \
+        ldr     x14, [P1+64] __LF                  \
+        extr    x11, x14, x13, #63 __LF            \
+        adc     x11, x11, x14 __LF                 \
+        ldp     x20, x21, [P2] __LF                \
+        mvn     x20, x20 __LF                      \
+        lsl     x0, x20, #3 __LF                   \
+        adds    x3, x3, x0 __LF                    \
+        mvn     x21, x21 __LF                      \
+        extr    x0, x21, x20, #61 __LF             \
+        adcs    x4, x4, x0 __LF                    \
+        ldp     x22, x23, [P2+16] __LF             \
+        mvn     x22, x22 __LF                      \
+        extr    x0, x22, x21, #61 __LF             \
+        adcs    x5, x5, x0 __LF                    \
+        and     x15, x4, x5 __LF                   \
+        mvn     x23, x23 __LF                      \
+        extr    x0, x23, x22, #61 __LF             \
+        adcs    x6, x6, x0 __LF                    \
+        and     x15, x15, x6 __LF                  \
+        ldp     x20, x21, [P2+32] __LF             \
+        mvn     x20, x20 __LF                      \
+        extr    x0, x20, x23, #61 __LF             \
+        adcs    x7, x7, x0 __LF                    \
+        and     x15, x15, x7 __LF                  \
+        mvn     x21, x21 __LF                      \
+        extr    x0, x21, x20, #61 __LF             \
+        adcs    x8, x8, x0 __LF                    \
+        and     x15, x15, x8 __LF                  \
+        ldp     x22, x23, [P2+48] __LF             \
+        mvn     x22, x22 __LF                      \
+        extr    x0, x22, x21, #61 __LF             \
+        adcs    x9, x9, x0 __LF                    \
+        and     x15, x15, x9 __LF                  \
+        mvn     x23, x23 __LF                      \
+        extr    x0, x23, x22, #61 __LF             \
+        adcs    x10, x10, x0 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        extr    x0, x0, x23, #61 __LF              \
+        adc     x11, x11, x0 __LF                  \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 // P0 = 4 * P1 - P2 = 4 * P1 + (p_521 - P2)
 
 #define cmsub41_p521(P0,P1,P2)                  \
-        ldp     x6, x7, [P1];                   \
-        lsl     x3, x6, #2;                     \
-        extr    x4, x7, x6, #62;                \
-        ldp     x8, x9, [P1+16];                \
-        extr    x5, x8, x7, #62;                \
-        extr    x6, x9, x8, #62;                \
-        ldp     x10, x11, [P1+32];              \
-        extr    x7, x10, x9, #62;               \
-        extr    x8, x11, x10, #62;              \
-        ldp     x12, x13, [P1+48];              \
-        extr    x9, x12, x11, #62;              \
-        extr    x10, x13, x12, #62;             \
-        ldr     x14, [P1+64];                   \
-        extr    x11, x14, x13, #62;             \
-        ldp     x0, x1, [P2];                   \
-        mvn     x0, x0;                         \
-        adds    x3, x3, x0;                     \
-        sbcs    x4, x4, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        sbcs    x5, x5, x0;                     \
-        and     x15, x4, x5;                    \
-        sbcs    x6, x6, x1;                     \
-        and     x15, x15, x6;                   \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x7, x7, x0;                     \
-        and     x15, x15, x7;                   \
-        sbcs    x8, x8, x1;                     \
-        and     x15, x15, x8;                   \
-        ldp     x0, x1, [P2+48];                \
-        sbcs    x9, x9, x0;                     \
-        and     x15, x15, x9;                   \
-        sbcs    x10, x10, x1;                   \
-        and     x15, x15, x10;                  \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        adc     x11, x11, x0;                   \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        lsl     x3, x6, #2 __LF                    \
+        extr    x4, x7, x6, #62 __LF               \
+        ldp     x8, x9, [P1+16] __LF               \
+        extr    x5, x8, x7, #62 __LF               \
+        extr    x6, x9, x8, #62 __LF               \
+        ldp     x10, x11, [P1+32] __LF             \
+        extr    x7, x10, x9, #62 __LF              \
+        extr    x8, x11, x10, #62 __LF             \
+        ldp     x12, x13, [P1+48] __LF             \
+        extr    x9, x12, x11, #62 __LF             \
+        extr    x10, x13, x12, #62 __LF            \
+        ldr     x14, [P1+64] __LF                  \
+        extr    x11, x14, x13, #62 __LF            \
+        ldp     x0, x1, [P2] __LF                  \
+        mvn     x0, x0 __LF                        \
+        adds    x3, x3, x0 __LF                    \
+        sbcs    x4, x4, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        sbcs    x5, x5, x0 __LF                    \
+        and     x15, x4, x5 __LF                   \
+        sbcs    x6, x6, x1 __LF                    \
+        and     x15, x15, x6 __LF                  \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x7, x7, x0 __LF                    \
+        and     x15, x15, x7 __LF                  \
+        sbcs    x8, x8, x1 __LF                    \
+        and     x15, x15, x8 __LF                  \
+        ldp     x0, x1, [P2+48] __LF               \
+        sbcs    x9, x9, x0 __LF                    \
+        and     x15, x15, x9 __LF                  \
+        sbcs    x10, x10, x1 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        adc     x11, x11, x0 __LF                  \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 S2N_BN_SYMBOL(p521_jdouble):

--- a/arm/p521/p521_jdouble_alt.S
+++ b/arm/p521/p521_jdouble_alt.S
@@ -64,1315 +64,1315 @@
 // Corresponds exactly to bignum_mul_p521_alt
 
 #define mul_p521(P0,P1,P2)                      \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x15, x3, x5;                    \
-        umulh   x16, x3, x5;                    \
-        mul     x14, x3, x6;                    \
-        umulh   x17, x3, x6;                    \
-        adds    x16, x16, x14;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x14, x3, x7;                    \
-        umulh   x19, x3, x7;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x8;                    \
-        umulh   x20, x3, x8;                    \
-        adcs    x19, x19, x14;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x14, x3, x9;                    \
-        umulh   x21, x3, x9;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x10;                   \
-        umulh   x22, x3, x10;                   \
-        adcs    x21, x21, x14;                  \
-        ldp     x11, x12, [P2+48];              \
-        mul     x14, x3, x11;                   \
-        umulh   x23, x3, x11;                   \
-        adcs    x22, x22, x14;                  \
-        ldr     x13, [P2+64];                   \
-        mul     x14, x3, x12;                   \
-        umulh   x24, x3, x12;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x13;                   \
-        umulh   x1, x3, x13;                    \
-        adcs    x24, x24, x14;                  \
-        adc     x1, x1, xzr;                    \
-        mul     x14, x4, x5;                    \
-        adds    x16, x16, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x1, x1, x14;                    \
-        cset    x0, hs;                         \
-        umulh   x14, x4, x5;                    \
-        adds    x17, x17, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x13;                   \
-        adc     x0, x0, x14;                    \
-        stp     x15, x16, [P0];                 \
-        ldp     x3, x4, [P1+16];                \
-        mul     x14, x3, x5;                    \
-        adds    x17, x17, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x13;                   \
-        adcs    x0, x0, x14;                    \
-        cset    x15, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x19, x19, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x12;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x13;                   \
-        adc     x15, x15, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x19, x19, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x12;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x13;                   \
-        adcs    x15, x15, x14;                  \
-        cset    x16, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x20, x20, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x11;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x12;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x16, x16, x14;                  \
-        stp     x17, x19, [P0+16];              \
-        ldp     x3, x4, [P1+32];                \
-        mul     x14, x3, x5;                    \
-        adds    x20, x20, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x11;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x12;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x16, x16, x14;                  \
-        cset    x17, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x21, x21, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x10;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x11;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x17, x17, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x21, x21, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x10;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x11;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x17, x17, x14;                  \
-        cset    x19, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x22, x22, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x9;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x10;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x19, x19, x14;                  \
-        stp     x20, x21, [P0+32];              \
-        ldp     x3, x4, [P1+48];                \
-        mul     x14, x3, x5;                    \
-        adds    x22, x22, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x9;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x10;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x19, x19, x14;                  \
-        cset    x20, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x23, x23, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x8;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x9;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x20, x20, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x23, x23, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x8;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x9;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x20, x20, x14;                  \
-        cset    x21, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x24, x24, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x7;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x8;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x21, x21, x14;                  \
-        stp     x22, x23, [P0+48];              \
-        ldr     x3, [P1+64];                    \
-        mul     x14, x3, x5;                    \
-        adds    x24, x24, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x7;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x8;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x13;                   \
-        adc     x21, x21, x14;                  \
-        umulh   x14, x3, x5;                    \
-        adds    x1, x1, x14;                    \
-        umulh   x14, x3, x6;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x7;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adc     x21, x21, x14;                  \
-        cmp     xzr, xzr;                       \
-        ldp     x5, x6, [P0];                   \
-        extr    x14, x1, x24, #9;               \
-        adcs    x5, x5, x14;                    \
-        extr    x14, x0, x1, #9;                \
-        adcs    x6, x6, x14;                    \
-        ldp     x7, x8, [P0+16];                \
-        extr    x14, x15, x0, #9;               \
-        adcs    x7, x7, x14;                    \
-        extr    x14, x16, x15, #9;              \
-        adcs    x8, x8, x14;                    \
-        ldp     x9, x10, [P0+32];               \
-        extr    x14, x17, x16, #9;              \
-        adcs    x9, x9, x14;                    \
-        extr    x14, x19, x17, #9;              \
-        adcs    x10, x10, x14;                  \
-        ldp     x11, x12, [P0+48];              \
-        extr    x14, x20, x19, #9;              \
-        adcs    x11, x11, x14;                  \
-        extr    x14, x21, x20, #9;              \
-        adcs    x12, x12, x14;                  \
-        orr     x13, x24, #0xfffffffffffffe00;  \
-        lsr     x14, x21, #9;                   \
-        adcs    x13, x13, x14;                  \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x15, x3, x5 __LF                   \
+        umulh   x16, x3, x5 __LF                   \
+        mul     x14, x3, x6 __LF                   \
+        umulh   x17, x3, x6 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x14, x3, x7 __LF                   \
+        umulh   x19, x3, x7 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        umulh   x20, x3, x8 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x14, x3, x9 __LF                   \
+        umulh   x21, x3, x9 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        umulh   x22, x3, x10 __LF                  \
+        adcs    x21, x21, x14 __LF                 \
+        ldp     x11, x12, [P2+48] __LF             \
+        mul     x14, x3, x11 __LF                  \
+        umulh   x23, x3, x11 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        ldr     x13, [P2+64] __LF                  \
+        mul     x14, x3, x12 __LF                  \
+        umulh   x24, x3, x12 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        umulh   x1, x3, x13 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        mul     x14, x4, x5 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        cset    x0, hs __LF                        \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x0, x0, x14 __LF                   \
+        stp     x15, x16, [P0] __LF                \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        cset    x15, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x15, x15, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        cset    x16, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x16, x16, x14 __LF                 \
+        stp     x17, x19, [P0+16] __LF             \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        cset    x17, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x17, x17, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        cset    x19, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x19, x19, x14 __LF                 \
+        stp     x20, x21, [P0+32] __LF             \
+        ldp     x3, x4, [P1+48] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x20, x20, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        cset    x21, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        stp     x22, x23, [P0+48] __LF             \
+        ldr     x3, [P1+64] __LF                   \
+        mul     x14, x3, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        cmp     xzr, xzr __LF                      \
+        ldp     x5, x6, [P0] __LF                  \
+        extr    x14, x1, x24, #9 __LF              \
+        adcs    x5, x5, x14 __LF                   \
+        extr    x14, x0, x1, #9 __LF               \
+        adcs    x6, x6, x14 __LF                   \
+        ldp     x7, x8, [P0+16] __LF               \
+        extr    x14, x15, x0, #9 __LF              \
+        adcs    x7, x7, x14 __LF                   \
+        extr    x14, x16, x15, #9 __LF             \
+        adcs    x8, x8, x14 __LF                   \
+        ldp     x9, x10, [P0+32] __LF              \
+        extr    x14, x17, x16, #9 __LF             \
+        adcs    x9, x9, x14 __LF                   \
+        extr    x14, x19, x17, #9 __LF             \
+        adcs    x10, x10, x14 __LF                 \
+        ldp     x11, x12, [P0+48] __LF             \
+        extr    x14, x20, x19, #9 __LF             \
+        adcs    x11, x11, x14 __LF                 \
+        extr    x14, x21, x20, #9 __LF             \
+        adcs    x12, x12, x14 __LF                 \
+        orr     x13, x24, #0xfffffffffffffe00 __LF \
+        lsr     x14, x21, #9 __LF                  \
+        adcs    x13, x13, x14 __LF                 \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Corresponds exactly to bignum_sqr_p521_alt
 
 #define sqr_p521(P0,P1)                         \
-        ldp     x2, x3, [P1];                   \
-        mul     x11, x2, x3;                    \
-        umulh   x12, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x10, x2, x4;                    \
-        umulh   x13, x2, x4;                    \
-        adds    x12, x12, x10;                  \
-        ldp     x6, x7, [P1+32];                \
-        mul     x10, x2, x5;                    \
-        umulh   x14, x2, x5;                    \
-        adcs    x13, x13, x10;                  \
-        ldp     x8, x9, [P1+48];                \
-        mul     x10, x2, x6;                    \
-        umulh   x15, x2, x6;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x2, x7;                    \
-        umulh   x16, x2, x7;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x2, x8;                    \
-        umulh   x17, x2, x8;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x2, x9;                    \
-        umulh   x19, x2, x9;                    \
-        adcs    x17, x17, x10;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x10, x3, x4;                    \
-        adds    x13, x13, x10;                  \
-        mul     x10, x3, x5;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x3, x6;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x3, x7;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x3, x8;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x3, x9;                    \
-        adcs    x19, x19, x10;                  \
-        cset    x20, hs;                        \
-        umulh   x10, x3, x4;                    \
-        adds    x14, x14, x10;                  \
-        umulh   x10, x3, x5;                    \
-        adcs    x15, x15, x10;                  \
-        umulh   x10, x3, x6;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x3, x7;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x3, x8;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x3, x9;                    \
-        adc     x20, x20, x10;                  \
-        mul     x10, x6, x7;                    \
-        umulh   x21, x6, x7;                    \
-        adds    x20, x20, x10;                  \
-        adc     x21, x21, xzr;                  \
-        mul     x10, x4, x5;                    \
-        adds    x15, x15, x10;                  \
-        mul     x10, x4, x6;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x4, x7;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x4, x8;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x4, x9;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x6, x8;                    \
-        adcs    x21, x21, x10;                  \
-        cset    x22, hs;                        \
-        umulh   x10, x4, x5;                    \
-        adds    x16, x16, x10;                  \
-        umulh   x10, x4, x6;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x4, x7;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x4, x8;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x4, x9;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x6, x8;                    \
-        adc     x22, x22, x10;                  \
-        mul     x10, x7, x8;                    \
-        umulh   x23, x7, x8;                    \
-        adds    x22, x22, x10;                  \
-        adc     x23, x23, xzr;                  \
-        mul     x10, x5, x6;                    \
-        adds    x17, x17, x10;                  \
-        mul     x10, x5, x7;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x5, x8;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x5, x9;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x6, x9;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x7, x9;                    \
-        adcs    x23, x23, x10;                  \
-        cset    x24, hs;                        \
-        umulh   x10, x5, x6;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x5, x7;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x5, x8;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x5, x9;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x6, x9;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x7, x9;                    \
-        adc     x24, x24, x10;                  \
-        mul     x10, x8, x9;                    \
-        umulh   x25, x8, x9;                    \
-        adds    x24, x24, x10;                  \
-        adc     x25, x25, xzr;                  \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        adcs    x20, x20, x20;                  \
-        adcs    x21, x21, x21;                  \
-        adcs    x22, x22, x22;                  \
-        adcs    x23, x23, x23;                  \
-        adcs    x24, x24, x24;                  \
-        adcs    x25, x25, x25;                  \
-        cset    x0, hs;                         \
-        umulh   x10, x2, x2;                    \
-        adds    x11, x11, x10;                  \
-        mul     x10, x3, x3;                    \
-        adcs    x12, x12, x10;                  \
-        umulh   x10, x3, x3;                    \
-        adcs    x13, x13, x10;                  \
-        mul     x10, x4, x4;                    \
-        adcs    x14, x14, x10;                  \
-        umulh   x10, x4, x4;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x5, x5;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x5, x5;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x6, x6;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x6, x6;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x7, x7;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x7, x7;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x8, x8;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x8, x8;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x9, x9;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x9, x9;                    \
-        adc     x0, x0, x10;                    \
-        ldr     x1, [P1+64];                    \
-        add     x1, x1, x1;                     \
-        mul     x10, x1, x2;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x1, x2;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x1, x4;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x1, x4;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x1, x6;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x1, x6;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x1, x8;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x1, x8;                    \
-        adcs    x0, x0, x10;                    \
-        lsr     x4, x1, #1;                     \
-        mul     x4, x4, x4;                     \
-        adc     x4, x4, xzr;                    \
-        mul     x10, x1, x3;                    \
-        adds    x20, x20, x10;                  \
-        umulh   x10, x1, x3;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x1, x5;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x1, x5;                    \
-        adcs    x23, x23, x10;                  \
-        mul     x10, x1, x7;                    \
-        adcs    x24, x24, x10;                  \
-        umulh   x10, x1, x7;                    \
-        adcs    x25, x25, x10;                  \
-        mul     x10, x1, x9;                    \
-        adcs    x0, x0, x10;                    \
-        umulh   x10, x1, x9;                    \
-        adc     x4, x4, x10;                    \
-        mul     x2, x2, x2;                     \
-        cmp     xzr, xzr;                       \
-        extr    x10, x20, x19, #9;              \
-        adcs    x2, x2, x10;                    \
-        extr    x10, x21, x20, #9;              \
-        adcs    x11, x11, x10;                  \
-        extr    x10, x22, x21, #9;              \
-        adcs    x12, x12, x10;                  \
-        extr    x10, x23, x22, #9;              \
-        adcs    x13, x13, x10;                  \
-        extr    x10, x24, x23, #9;              \
-        adcs    x14, x14, x10;                  \
-        extr    x10, x25, x24, #9;              \
-        adcs    x15, x15, x10;                  \
-        extr    x10, x0, x25, #9;               \
-        adcs    x16, x16, x10;                  \
-        extr    x10, x4, x0, #9;                \
-        adcs    x17, x17, x10;                  \
-        orr     x19, x19, #0xfffffffffffffe00;  \
-        lsr     x10, x4, #9;                    \
-        adcs    x19, x19, x10;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x19, x19, xzr;                  \
-        and     x19, x19, #0x1ff;               \
-        stp     x2, x11, [P0];                  \
-        stp     x12, x13, [P0+16];              \
-        stp     x14, x15, [P0+32];              \
-        stp     x16, x17, [P0+48];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x11, x2, x3 __LF                   \
+        umulh   x12, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x10, x2, x4 __LF                   \
+        umulh   x13, x2, x4 __LF                   \
+        adds    x12, x12, x10 __LF                 \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x10, x2, x5 __LF                   \
+        umulh   x14, x2, x5 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        ldp     x8, x9, [P1+48] __LF               \
+        mul     x10, x2, x6 __LF                   \
+        umulh   x15, x2, x6 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x2, x7 __LF                   \
+        umulh   x16, x2, x7 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x2, x8 __LF                   \
+        umulh   x17, x2, x8 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x2, x9 __LF                   \
+        umulh   x19, x2, x9 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x10, x3, x4 __LF                   \
+        adds    x13, x13, x10 __LF                 \
+        mul     x10, x3, x5 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x3, x6 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x3, x7 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x3, x8 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x3, x9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x10, x3, x4 __LF                   \
+        adds    x14, x14, x10 __LF                 \
+        umulh   x10, x3, x5 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        umulh   x10, x3, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x3, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x3, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x3, x9 __LF                   \
+        adc     x20, x20, x10 __LF                 \
+        mul     x10, x6, x7 __LF                   \
+        umulh   x21, x6, x7 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        adc     x21, x21, xzr __LF                 \
+        mul     x10, x4, x5 __LF                   \
+        adds    x15, x15, x10 __LF                 \
+        mul     x10, x4, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x4, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x4, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x4, x9 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x6, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        cset    x22, hs __LF                       \
+        umulh   x10, x4, x5 __LF                   \
+        adds    x16, x16, x10 __LF                 \
+        umulh   x10, x4, x6 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x4, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x4, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x4, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x6, x8 __LF                   \
+        adc     x22, x22, x10 __LF                 \
+        mul     x10, x7, x8 __LF                   \
+        umulh   x23, x7, x8 __LF                   \
+        adds    x22, x22, x10 __LF                 \
+        adc     x23, x23, xzr __LF                 \
+        mul     x10, x5, x6 __LF                   \
+        adds    x17, x17, x10 __LF                 \
+        mul     x10, x5, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x5, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x5, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x6, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x7, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        cset    x24, hs __LF                       \
+        umulh   x10, x5, x6 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x5, x7 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x5, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x5, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x6, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x7, x9 __LF                   \
+        adc     x24, x24, x10 __LF                 \
+        mul     x10, x8, x9 __LF                   \
+        umulh   x25, x8, x9 __LF                   \
+        adds    x24, x24, x10 __LF                 \
+        adc     x25, x25, xzr __LF                 \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        adcs    x20, x20, x20 __LF                 \
+        adcs    x21, x21, x21 __LF                 \
+        adcs    x22, x22, x22 __LF                 \
+        adcs    x23, x23, x23 __LF                 \
+        adcs    x24, x24, x24 __LF                 \
+        adcs    x25, x25, x25 __LF                 \
+        cset    x0, hs __LF                        \
+        umulh   x10, x2, x2 __LF                   \
+        adds    x11, x11, x10 __LF                 \
+        mul     x10, x3, x3 __LF                   \
+        adcs    x12, x12, x10 __LF                 \
+        umulh   x10, x3, x3 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        mul     x10, x4, x4 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        umulh   x10, x4, x4 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x5, x5 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x5, x5 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x6, x6 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x6, x6 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x7, x7 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x7, x7 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x8, x8 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x8, x8 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x9, x9 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x9, x9 __LF                   \
+        adc     x0, x0, x10 __LF                   \
+        ldr     x1, [P1+64] __LF                   \
+        add     x1, x1, x1 __LF                    \
+        mul     x10, x1, x2 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x1, x2 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x1, x4 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x1, x4 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x1, x6 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x1, x6 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x1, x8 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x1, x8 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        lsr     x4, x1, #1 __LF                    \
+        mul     x4, x4, x4 __LF                    \
+        adc     x4, x4, xzr __LF                   \
+        mul     x10, x1, x3 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        umulh   x10, x1, x3 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x1, x5 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x1, x5 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        mul     x10, x1, x7 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        umulh   x10, x1, x7 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        mul     x10, x1, x9 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        umulh   x10, x1, x9 __LF                   \
+        adc     x4, x4, x10 __LF                   \
+        mul     x2, x2, x2 __LF                    \
+        cmp     xzr, xzr __LF                      \
+        extr    x10, x20, x19, #9 __LF             \
+        adcs    x2, x2, x10 __LF                   \
+        extr    x10, x21, x20, #9 __LF             \
+        adcs    x11, x11, x10 __LF                 \
+        extr    x10, x22, x21, #9 __LF             \
+        adcs    x12, x12, x10 __LF                 \
+        extr    x10, x23, x22, #9 __LF             \
+        adcs    x13, x13, x10 __LF                 \
+        extr    x10, x24, x23, #9 __LF             \
+        adcs    x14, x14, x10 __LF                 \
+        extr    x10, x25, x24, #9 __LF             \
+        adcs    x15, x15, x10 __LF                 \
+        extr    x10, x0, x25, #9 __LF              \
+        adcs    x16, x16, x10 __LF                 \
+        extr    x10, x4, x0, #9 __LF               \
+        adcs    x17, x17, x10 __LF                 \
+        orr     x19, x19, #0xfffffffffffffe00 __LF \
+        lsr     x10, x4, #9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x19, x19, xzr __LF                 \
+        and     x19, x19, #0x1ff __LF              \
+        stp     x2, x11, [P0] __LF                 \
+        stp     x12, x13, [P0+16] __LF             \
+        stp     x14, x15, [P0+32] __LF             \
+        stp     x16, x17, [P0+48] __LF             \
         str     x19, [P0+64]
 
 // Corresponds exactly to bignum_add_p521
 
 #define add_p521(P0,P1,P2)                      \
-        cmp     xzr, xzr;                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        adcs    x5, x5, x4;                     \
-        adcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        adcs    x7, x7, x4;                     \
-        adcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        adcs    x9, x9, x4;                     \
-        adcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        adcs    x11, x11, x4;                   \
-        adcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        adc     x13, x13, x4;                   \
-        subs    x4, x13, #512;                  \
-        csetm   x4, hs;                         \
-        sbcs    x5, x5, xzr;                    \
-        and     x4, x4, #0x200;                 \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, x4;                   \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        cmp     xzr, xzr __LF                      \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        adcs    x5, x5, x4 __LF                    \
+        adcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        adcs    x7, x7, x4 __LF                    \
+        adcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        adcs    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        adcs    x11, x11, x4 __LF                  \
+        adcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        adc     x13, x13, x4 __LF                  \
+        subs    x4, x13, #512 __LF                 \
+        csetm   x4, hs __LF                        \
+        sbcs    x5, x5, xzr __LF                   \
+        and     x4, x4, #0x200 __LF                \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, x4 __LF                  \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Corresponds exactly to bignum_sub_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Weak multiplication not fully reducing
 
 #define weakmul_p521(P0,P1,P2)                  \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x15, x3, x5;                    \
-        umulh   x16, x3, x5;                    \
-        mul     x14, x3, x6;                    \
-        umulh   x17, x3, x6;                    \
-        adds    x16, x16, x14;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x14, x3, x7;                    \
-        umulh   x19, x3, x7;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x8;                    \
-        umulh   x20, x3, x8;                    \
-        adcs    x19, x19, x14;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x14, x3, x9;                    \
-        umulh   x21, x3, x9;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x10;                   \
-        umulh   x22, x3, x10;                   \
-        adcs    x21, x21, x14;                  \
-        ldp     x11, x12, [P2+48];              \
-        mul     x14, x3, x11;                   \
-        umulh   x23, x3, x11;                   \
-        adcs    x22, x22, x14;                  \
-        ldr     x13, [P2+64];                   \
-        mul     x14, x3, x12;                   \
-        umulh   x24, x3, x12;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x13;                   \
-        umulh   x1, x3, x13;                    \
-        adcs    x24, x24, x14;                  \
-        adc     x1, x1, xzr;                    \
-        mul     x14, x4, x5;                    \
-        adds    x16, x16, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x1, x1, x14;                    \
-        cset    x0, hs;                         \
-        umulh   x14, x4, x5;                    \
-        adds    x17, x17, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x13;                   \
-        adc     x0, x0, x14;                    \
-        stp     x15, x16, [P0];                 \
-        ldp     x3, x4, [P1+16];                \
-        mul     x14, x3, x5;                    \
-        adds    x17, x17, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x13;                   \
-        adcs    x0, x0, x14;                    \
-        cset    x15, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x19, x19, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x12;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x13;                   \
-        adc     x15, x15, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x19, x19, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x12;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x13;                   \
-        adcs    x15, x15, x14;                  \
-        cset    x16, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x20, x20, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x11;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x12;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x16, x16, x14;                  \
-        stp     x17, x19, [P0+16];              \
-        ldp     x3, x4, [P1+32];                \
-        mul     x14, x3, x5;                    \
-        adds    x20, x20, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x11;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x12;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x16, x16, x14;                  \
-        cset    x17, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x21, x21, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x10;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x11;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x17, x17, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x21, x21, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x10;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x11;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x17, x17, x14;                  \
-        cset    x19, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x22, x22, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x9;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x10;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x19, x19, x14;                  \
-        stp     x20, x21, [P0+32];              \
-        ldp     x3, x4, [P1+48];                \
-        mul     x14, x3, x5;                    \
-        adds    x22, x22, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x9;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x10;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x19, x19, x14;                  \
-        cset    x20, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x23, x23, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x8;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x9;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x20, x20, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x23, x23, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x8;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x9;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x20, x20, x14;                  \
-        cset    x21, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x24, x24, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x7;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x8;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x21, x21, x14;                  \
-        stp     x22, x23, [P0+48];              \
-        ldr     x3, [P1+64];                    \
-        mul     x14, x3, x5;                    \
-        adds    x24, x24, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x7;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x8;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x13;                   \
-        adc     x21, x21, x14;                  \
-        umulh   x14, x3, x5;                    \
-        adds    x1, x1, x14;                    \
-        umulh   x14, x3, x6;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x7;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adc     x21, x21, x14;                  \
-        ldp     x5, x6, [P0];                   \
-        extr    x14, x1, x24, #9;               \
-        adds    x5, x5, x14;                    \
-        extr    x14, x0, x1, #9;                \
-        adcs    x6, x6, x14;                    \
-        ldp     x7, x8, [P0+16];                \
-        extr    x14, x15, x0, #9;               \
-        adcs    x7, x7, x14;                    \
-        extr    x14, x16, x15, #9;              \
-        adcs    x8, x8, x14;                    \
-        ldp     x9, x10, [P0+32];               \
-        extr    x14, x17, x16, #9;              \
-        adcs    x9, x9, x14;                    \
-        extr    x14, x19, x17, #9;              \
-        adcs    x10, x10, x14;                  \
-        ldp     x11, x12, [P0+48];              \
-        extr    x14, x20, x19, #9;              \
-        adcs    x11, x11, x14;                  \
-        extr    x14, x21, x20, #9;              \
-        adcs    x12, x12, x14;                  \
-        and     x13, x24, #0x1ff;               \
-        lsr     x14, x21, #9;                   \
-        adc     x13, x13, x14;                  \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x15, x3, x5 __LF                   \
+        umulh   x16, x3, x5 __LF                   \
+        mul     x14, x3, x6 __LF                   \
+        umulh   x17, x3, x6 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x14, x3, x7 __LF                   \
+        umulh   x19, x3, x7 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        umulh   x20, x3, x8 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x14, x3, x9 __LF                   \
+        umulh   x21, x3, x9 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        umulh   x22, x3, x10 __LF                  \
+        adcs    x21, x21, x14 __LF                 \
+        ldp     x11, x12, [P2+48] __LF             \
+        mul     x14, x3, x11 __LF                  \
+        umulh   x23, x3, x11 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        ldr     x13, [P2+64] __LF                  \
+        mul     x14, x3, x12 __LF                  \
+        umulh   x24, x3, x12 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        umulh   x1, x3, x13 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        mul     x14, x4, x5 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        cset    x0, hs __LF                        \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x0, x0, x14 __LF                   \
+        stp     x15, x16, [P0] __LF                \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        cset    x15, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x15, x15, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        cset    x16, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x16, x16, x14 __LF                 \
+        stp     x17, x19, [P0+16] __LF             \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        cset    x17, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x17, x17, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        cset    x19, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x19, x19, x14 __LF                 \
+        stp     x20, x21, [P0+32] __LF             \
+        ldp     x3, x4, [P1+48] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x20, x20, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        cset    x21, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        stp     x22, x23, [P0+48] __LF             \
+        ldr     x3, [P1+64] __LF                   \
+        mul     x14, x3, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        ldp     x5, x6, [P0] __LF                  \
+        extr    x14, x1, x24, #9 __LF              \
+        adds    x5, x5, x14 __LF                   \
+        extr    x14, x0, x1, #9 __LF               \
+        adcs    x6, x6, x14 __LF                   \
+        ldp     x7, x8, [P0+16] __LF               \
+        extr    x14, x15, x0, #9 __LF              \
+        adcs    x7, x7, x14 __LF                   \
+        extr    x14, x16, x15, #9 __LF             \
+        adcs    x8, x8, x14 __LF                   \
+        ldp     x9, x10, [P0+32] __LF              \
+        extr    x14, x17, x16, #9 __LF             \
+        adcs    x9, x9, x14 __LF                   \
+        extr    x14, x19, x17, #9 __LF             \
+        adcs    x10, x10, x14 __LF                 \
+        ldp     x11, x12, [P0+48] __LF             \
+        extr    x14, x20, x19, #9 __LF             \
+        adcs    x11, x11, x14 __LF                 \
+        extr    x14, x21, x20, #9 __LF             \
+        adcs    x12, x12, x14 __LF                 \
+        and     x13, x24, #0x1ff __LF              \
+        lsr     x14, x21, #9 __LF                  \
+        adc     x13, x13, x14 __LF                 \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // P0 = C * P1 - D * P2 == C * P1 + D * (p_521 - P2)
 
 #define cmsub_p521(P0,C,P1,D,P2)                \
-        ldp     x6, x7, [P1];                   \
-        mov     x1, #(C);                       \
-        mul     x3, x1, x6;                     \
-        mul     x4, x1, x7;                     \
-        umulh   x6, x1, x6;                     \
-        adds    x4, x4, x6;                     \
-        umulh   x7, x1, x7;                     \
-        ldp     x8, x9, [P1+16];                \
-        mul     x5, x1, x8;                     \
-        mul     x6, x1, x9;                     \
-        umulh   x8, x1, x8;                     \
-        adcs    x5, x5, x7;                     \
-        umulh   x9, x1, x9;                     \
-        adcs    x6, x6, x8;                     \
-        ldp     x10, x11, [P1+32];              \
-        mul     x7, x1, x10;                    \
-        mul     x8, x1, x11;                    \
-        umulh   x10, x1, x10;                   \
-        adcs    x7, x7, x9;                     \
-        umulh   x11, x1, x11;                   \
-        adcs    x8, x8, x10;                    \
-        ldp     x12, x13, [P1+48];              \
-        mul     x9, x1, x12;                    \
-        mul     x10, x1, x13;                   \
-        umulh   x12, x1, x12;                   \
-        adcs    x9, x9, x11;                    \
-        umulh   x13, x1, x13;                   \
-        adcs    x10, x10, x12;                  \
-        ldr     x14, [P1+64];                   \
-        mul     x11, x1, x14;                   \
-        adc     x11, x11, x13;                  \
-        mov     x1, #(D);                       \
-        ldp     x20, x21, [P2];                 \
-        mvn     x20, x20;                       \
-        mul     x0, x1, x20;                    \
-        umulh   x20, x1, x20;                   \
-        adds    x3, x3, x0;                     \
-        mvn     x21, x21;                       \
-        mul     x0, x1, x21;                    \
-        umulh   x21, x1, x21;                   \
-        adcs    x4, x4, x0;                     \
-        ldp     x22, x23, [P2+16];              \
-        mvn     x22, x22;                       \
-        mul     x0, x1, x22;                    \
-        umulh   x22, x1, x22;                   \
-        adcs    x5, x5, x0;                     \
-        mvn     x23, x23;                       \
-        mul     x0, x1, x23;                    \
-        umulh   x23, x1, x23;                   \
-        adcs    x6, x6, x0;                     \
-        ldp     x17, x19, [P2+32];              \
-        mvn     x17, x17;                       \
-        mul     x0, x1, x17;                    \
-        umulh   x17, x1, x17;                   \
-        adcs    x7, x7, x0;                     \
-        mvn     x19, x19;                       \
-        mul     x0, x1, x19;                    \
-        umulh   x19, x1, x19;                   \
-        adcs    x8, x8, x0;                     \
-        ldp     x2, x16, [P2+48];               \
-        mvn     x2, x2;                         \
-        mul     x0, x1, x2;                     \
-        umulh   x2, x1, x2;                     \
-        adcs    x9, x9, x0;                     \
-        mvn     x16, x16;                       \
-        mul     x0, x1, x16;                    \
-        umulh   x16, x1, x16;                   \
-        adcs    x10, x10, x0;                   \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        mul     x0, x1, x0;                     \
-        adc     x11, x11, x0;                   \
-        adds    x4, x4, x20;                    \
-        adcs    x5, x5, x21;                    \
-        and     x15, x4, x5;                    \
-        adcs    x6, x6, x22;                    \
-        and     x15, x15, x6;                   \
-        adcs    x7, x7, x23;                    \
-        and     x15, x15, x7;                   \
-        adcs    x8, x8, x17;                    \
-        and     x15, x15, x8;                   \
-        adcs    x9, x9, x19;                    \
-        and     x15, x15, x9;                   \
-        adcs    x10, x10, x2;                   \
-        and     x15, x15, x10;                  \
-        adc     x11, x11, x16;                  \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        mov     x1, #(C) __LF                      \
+        mul     x3, x1, x6 __LF                    \
+        mul     x4, x1, x7 __LF                    \
+        umulh   x6, x1, x6 __LF                    \
+        adds    x4, x4, x6 __LF                    \
+        umulh   x7, x1, x7 __LF                    \
+        ldp     x8, x9, [P1+16] __LF               \
+        mul     x5, x1, x8 __LF                    \
+        mul     x6, x1, x9 __LF                    \
+        umulh   x8, x1, x8 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        umulh   x9, x1, x9 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        ldp     x10, x11, [P1+32] __LF             \
+        mul     x7, x1, x10 __LF                   \
+        mul     x8, x1, x11 __LF                   \
+        umulh   x10, x1, x10 __LF                  \
+        adcs    x7, x7, x9 __LF                    \
+        umulh   x11, x1, x11 __LF                  \
+        adcs    x8, x8, x10 __LF                   \
+        ldp     x12, x13, [P1+48] __LF             \
+        mul     x9, x1, x12 __LF                   \
+        mul     x10, x1, x13 __LF                  \
+        umulh   x12, x1, x12 __LF                  \
+        adcs    x9, x9, x11 __LF                   \
+        umulh   x13, x1, x13 __LF                  \
+        adcs    x10, x10, x12 __LF                 \
+        ldr     x14, [P1+64] __LF                  \
+        mul     x11, x1, x14 __LF                  \
+        adc     x11, x11, x13 __LF                 \
+        mov     x1, #(D) __LF                      \
+        ldp     x20, x21, [P2] __LF                \
+        mvn     x20, x20 __LF                      \
+        mul     x0, x1, x20 __LF                   \
+        umulh   x20, x1, x20 __LF                  \
+        adds    x3, x3, x0 __LF                    \
+        mvn     x21, x21 __LF                      \
+        mul     x0, x1, x21 __LF                   \
+        umulh   x21, x1, x21 __LF                  \
+        adcs    x4, x4, x0 __LF                    \
+        ldp     x22, x23, [P2+16] __LF             \
+        mvn     x22, x22 __LF                      \
+        mul     x0, x1, x22 __LF                   \
+        umulh   x22, x1, x22 __LF                  \
+        adcs    x5, x5, x0 __LF                    \
+        mvn     x23, x23 __LF                      \
+        mul     x0, x1, x23 __LF                   \
+        umulh   x23, x1, x23 __LF                  \
+        adcs    x6, x6, x0 __LF                    \
+        ldp     x17, x19, [P2+32] __LF             \
+        mvn     x17, x17 __LF                      \
+        mul     x0, x1, x17 __LF                   \
+        umulh   x17, x1, x17 __LF                  \
+        adcs    x7, x7, x0 __LF                    \
+        mvn     x19, x19 __LF                      \
+        mul     x0, x1, x19 __LF                   \
+        umulh   x19, x1, x19 __LF                  \
+        adcs    x8, x8, x0 __LF                    \
+        ldp     x2, x16, [P2+48] __LF              \
+        mvn     x2, x2 __LF                        \
+        mul     x0, x1, x2 __LF                    \
+        umulh   x2, x1, x2 __LF                    \
+        adcs    x9, x9, x0 __LF                    \
+        mvn     x16, x16 __LF                      \
+        mul     x0, x1, x16 __LF                   \
+        umulh   x16, x1, x16 __LF                  \
+        adcs    x10, x10, x0 __LF                  \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        mul     x0, x1, x0 __LF                    \
+        adc     x11, x11, x0 __LF                  \
+        adds    x4, x4, x20 __LF                   \
+        adcs    x5, x5, x21 __LF                   \
+        and     x15, x4, x5 __LF                   \
+        adcs    x6, x6, x22 __LF                   \
+        and     x15, x15, x6 __LF                  \
+        adcs    x7, x7, x23 __LF                   \
+        and     x15, x15, x7 __LF                  \
+        adcs    x8, x8, x17 __LF                   \
+        and     x15, x15, x8 __LF                  \
+        adcs    x9, x9, x19 __LF                   \
+        and     x15, x15, x9 __LF                  \
+        adcs    x10, x10, x2 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        adc     x11, x11, x16 __LF                 \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 // P0 = 3 * P1 - 8 * P2 == 3 * P1 + 8 * (p_521 - P2)
 
 #define cmsub38_p521(P0,P1,P2)                  \
-        ldp     x6, x7, [P1];                   \
-        lsl     x3, x6, #1;                     \
-        adds    x3, x3, x6;                     \
-        extr    x4, x7, x6, #63;                \
-        adcs    x4, x4, x7;                     \
-        ldp     x8, x9, [P1+16];                \
-        extr    x5, x8, x7, #63;                \
-        adcs    x5, x5, x8;                     \
-        extr    x6, x9, x8, #63;                \
-        adcs    x6, x6, x9;                     \
-        ldp     x10, x11, [P1+32];              \
-        extr    x7, x10, x9, #63;               \
-        adcs    x7, x7, x10;                    \
-        extr    x8, x11, x10, #63;              \
-        adcs    x8, x8, x11;                    \
-        ldp     x12, x13, [P1+48];              \
-        extr    x9, x12, x11, #63;              \
-        adcs    x9, x9, x12;                    \
-        extr    x10, x13, x12, #63;             \
-        adcs    x10, x10, x13;                  \
-        ldr     x14, [P1+64];                   \
-        extr    x11, x14, x13, #63;             \
-        adc     x11, x11, x14;                  \
-        ldp     x20, x21, [P2];                 \
-        mvn     x20, x20;                       \
-        lsl     x0, x20, #3;                    \
-        adds    x3, x3, x0;                     \
-        mvn     x21, x21;                       \
-        extr    x0, x21, x20, #61;              \
-        adcs    x4, x4, x0;                     \
-        ldp     x22, x23, [P2+16];              \
-        mvn     x22, x22;                       \
-        extr    x0, x22, x21, #61;              \
-        adcs    x5, x5, x0;                     \
-        and     x15, x4, x5;                    \
-        mvn     x23, x23;                       \
-        extr    x0, x23, x22, #61;              \
-        adcs    x6, x6, x0;                     \
-        and     x15, x15, x6;                   \
-        ldp     x20, x21, [P2+32];              \
-        mvn     x20, x20;                       \
-        extr    x0, x20, x23, #61;              \
-        adcs    x7, x7, x0;                     \
-        and     x15, x15, x7;                   \
-        mvn     x21, x21;                       \
-        extr    x0, x21, x20, #61;              \
-        adcs    x8, x8, x0;                     \
-        and     x15, x15, x8;                   \
-        ldp     x22, x23, [P2+48];              \
-        mvn     x22, x22;                       \
-        extr    x0, x22, x21, #61;              \
-        adcs    x9, x9, x0;                     \
-        and     x15, x15, x9;                   \
-        mvn     x23, x23;                       \
-        extr    x0, x23, x22, #61;              \
-        adcs    x10, x10, x0;                   \
-        and     x15, x15, x10;                  \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        extr    x0, x0, x23, #61;               \
-        adc     x11, x11, x0;                   \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        lsl     x3, x6, #1 __LF                    \
+        adds    x3, x3, x6 __LF                    \
+        extr    x4, x7, x6, #63 __LF               \
+        adcs    x4, x4, x7 __LF                    \
+        ldp     x8, x9, [P1+16] __LF               \
+        extr    x5, x8, x7, #63 __LF               \
+        adcs    x5, x5, x8 __LF                    \
+        extr    x6, x9, x8, #63 __LF               \
+        adcs    x6, x6, x9 __LF                    \
+        ldp     x10, x11, [P1+32] __LF             \
+        extr    x7, x10, x9, #63 __LF              \
+        adcs    x7, x7, x10 __LF                   \
+        extr    x8, x11, x10, #63 __LF             \
+        adcs    x8, x8, x11 __LF                   \
+        ldp     x12, x13, [P1+48] __LF             \
+        extr    x9, x12, x11, #63 __LF             \
+        adcs    x9, x9, x12 __LF                   \
+        extr    x10, x13, x12, #63 __LF            \
+        adcs    x10, x10, x13 __LF                 \
+        ldr     x14, [P1+64] __LF                  \
+        extr    x11, x14, x13, #63 __LF            \
+        adc     x11, x11, x14 __LF                 \
+        ldp     x20, x21, [P2] __LF                \
+        mvn     x20, x20 __LF                      \
+        lsl     x0, x20, #3 __LF                   \
+        adds    x3, x3, x0 __LF                    \
+        mvn     x21, x21 __LF                      \
+        extr    x0, x21, x20, #61 __LF             \
+        adcs    x4, x4, x0 __LF                    \
+        ldp     x22, x23, [P2+16] __LF             \
+        mvn     x22, x22 __LF                      \
+        extr    x0, x22, x21, #61 __LF             \
+        adcs    x5, x5, x0 __LF                    \
+        and     x15, x4, x5 __LF                   \
+        mvn     x23, x23 __LF                      \
+        extr    x0, x23, x22, #61 __LF             \
+        adcs    x6, x6, x0 __LF                    \
+        and     x15, x15, x6 __LF                  \
+        ldp     x20, x21, [P2+32] __LF             \
+        mvn     x20, x20 __LF                      \
+        extr    x0, x20, x23, #61 __LF             \
+        adcs    x7, x7, x0 __LF                    \
+        and     x15, x15, x7 __LF                  \
+        mvn     x21, x21 __LF                      \
+        extr    x0, x21, x20, #61 __LF             \
+        adcs    x8, x8, x0 __LF                    \
+        and     x15, x15, x8 __LF                  \
+        ldp     x22, x23, [P2+48] __LF             \
+        mvn     x22, x22 __LF                      \
+        extr    x0, x22, x21, #61 __LF             \
+        adcs    x9, x9, x0 __LF                    \
+        and     x15, x15, x9 __LF                  \
+        mvn     x23, x23 __LF                      \
+        extr    x0, x23, x22, #61 __LF             \
+        adcs    x10, x10, x0 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        extr    x0, x0, x23, #61 __LF              \
+        adc     x11, x11, x0 __LF                  \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 // P0 = 4 * P1 - P2 = 4 * P1 + (p_521 - P2)
 
 #define cmsub41_p521(P0,P1,P2)                  \
-        ldp     x6, x7, [P1];                   \
-        lsl     x3, x6, #2;                     \
-        extr    x4, x7, x6, #62;                \
-        ldp     x8, x9, [P1+16];                \
-        extr    x5, x8, x7, #62;                \
-        extr    x6, x9, x8, #62;                \
-        ldp     x10, x11, [P1+32];              \
-        extr    x7, x10, x9, #62;               \
-        extr    x8, x11, x10, #62;              \
-        ldp     x12, x13, [P1+48];              \
-        extr    x9, x12, x11, #62;              \
-        extr    x10, x13, x12, #62;             \
-        ldr     x14, [P1+64];                   \
-        extr    x11, x14, x13, #62;             \
-        ldp     x0, x1, [P2];                   \
-        mvn     x0, x0;                         \
-        adds    x3, x3, x0;                     \
-        sbcs    x4, x4, x1;                     \
-        ldp     x0, x1, [P2+16];                \
-        sbcs    x5, x5, x0;                     \
-        and     x15, x4, x5;                    \
-        sbcs    x6, x6, x1;                     \
-        and     x15, x15, x6;                   \
-        ldp     x0, x1, [P2+32];                \
-        sbcs    x7, x7, x0;                     \
-        and     x15, x15, x7;                   \
-        sbcs    x8, x8, x1;                     \
-        and     x15, x15, x8;                   \
-        ldp     x0, x1, [P2+48];                \
-        sbcs    x9, x9, x0;                     \
-        and     x15, x15, x9;                   \
-        sbcs    x10, x10, x1;                   \
-        and     x15, x15, x10;                  \
-        ldr     x0, [P2+64];                    \
-        eor     x0, x0, #0x1ff;                 \
-        adc     x11, x11, x0;                   \
-        lsr     x12, x11, #9;                   \
-        orr     x11, x11, #0xfffffffffffffe00;  \
-        cmp     xzr, xzr;                       \
-        adcs    xzr, x3, x12;                   \
-        adcs    xzr, x15, xzr;                  \
-        adcs    xzr, x11, xzr;                  \
-        adcs    x3, x3, x12;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, xzr;                    \
-        adcs    x7, x7, xzr;                    \
-        adcs    x8, x8, xzr;                    \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        adc     x11, x11, xzr;                  \
-        and     x11, x11, #0x1ff;               \
-        stp     x3, x4, [P0];                   \
-        stp     x5, x6, [P0+16];                \
-        stp     x7, x8, [P0+32];                \
-        stp     x9, x10, [P0+48];               \
+        ldp     x6, x7, [P1] __LF                  \
+        lsl     x3, x6, #2 __LF                    \
+        extr    x4, x7, x6, #62 __LF               \
+        ldp     x8, x9, [P1+16] __LF               \
+        extr    x5, x8, x7, #62 __LF               \
+        extr    x6, x9, x8, #62 __LF               \
+        ldp     x10, x11, [P1+32] __LF             \
+        extr    x7, x10, x9, #62 __LF              \
+        extr    x8, x11, x10, #62 __LF             \
+        ldp     x12, x13, [P1+48] __LF             \
+        extr    x9, x12, x11, #62 __LF             \
+        extr    x10, x13, x12, #62 __LF            \
+        ldr     x14, [P1+64] __LF                  \
+        extr    x11, x14, x13, #62 __LF            \
+        ldp     x0, x1, [P2] __LF                  \
+        mvn     x0, x0 __LF                        \
+        adds    x3, x3, x0 __LF                    \
+        sbcs    x4, x4, x1 __LF                    \
+        ldp     x0, x1, [P2+16] __LF               \
+        sbcs    x5, x5, x0 __LF                    \
+        and     x15, x4, x5 __LF                   \
+        sbcs    x6, x6, x1 __LF                    \
+        and     x15, x15, x6 __LF                  \
+        ldp     x0, x1, [P2+32] __LF               \
+        sbcs    x7, x7, x0 __LF                    \
+        and     x15, x15, x7 __LF                  \
+        sbcs    x8, x8, x1 __LF                    \
+        and     x15, x15, x8 __LF                  \
+        ldp     x0, x1, [P2+48] __LF               \
+        sbcs    x9, x9, x0 __LF                    \
+        and     x15, x15, x9 __LF                  \
+        sbcs    x10, x10, x1 __LF                  \
+        and     x15, x15, x10 __LF                 \
+        ldr     x0, [P2+64] __LF                   \
+        eor     x0, x0, #0x1ff __LF                \
+        adc     x11, x11, x0 __LF                  \
+        lsr     x12, x11, #9 __LF                  \
+        orr     x11, x11, #0xfffffffffffffe00 __LF \
+        cmp     xzr, xzr __LF                      \
+        adcs    xzr, x3, x12 __LF                  \
+        adcs    xzr, x15, xzr __LF                 \
+        adcs    xzr, x11, xzr __LF                 \
+        adcs    x3, x3, x12 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, xzr __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        adcs    x8, x8, xzr __LF                   \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        adc     x11, x11, xzr __LF                 \
+        and     x11, x11, #0x1ff __LF              \
+        stp     x3, x4, [P0] __LF                  \
+        stp     x5, x6, [P0+16] __LF               \
+        stp     x7, x8, [P0+32] __LF               \
+        stp     x9, x10, [P0+48] __LF              \
         str     x11, [P0+64]
 
 S2N_BN_SYMBOL(p521_jdouble_alt):

--- a/arm/p521/p521_jmixadd.S
+++ b/arm/p521/p521_jmixadd.S
@@ -81,20 +81,20 @@
 // and bignum_sub_p521
 
 #define mul_p521(P0,P1,P2)                      \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
-        add     x2, P2;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
+        add     x2, P2 __LF                        \
         bl      p521_jmixadd_local_mul_p521
 
 #define sqr_p521(P0,P1)                         \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
         bl      p521_jmixadd_local_sqr_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        add     x0, P0;                         \
-        add     x1, P1;                         \
-        add     x2, P2;                         \
+        add     x0, P0 __LF                        \
+        add     x1, P1 __LF                        \
+        add     x2, P2 __LF                        \
         bl      p521_jmixadd_local_sub_p521
 
 S2N_BN_SYMBOL(p521_jmixadd):

--- a/arm/p521/p521_jmixadd_alt.S
+++ b/arm/p521/p521_jmixadd_alt.S
@@ -77,650 +77,650 @@
 // Corresponds exactly to bignum_mul_p521_alt
 
 #define mul_p521(P0,P1,P2)                      \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x15, x3, x5;                    \
-        umulh   x16, x3, x5;                    \
-        mul     x14, x3, x6;                    \
-        umulh   x17, x3, x6;                    \
-        adds    x16, x16, x14;                  \
-        ldp     x7, x8, [P2+16];                \
-        mul     x14, x3, x7;                    \
-        umulh   x19, x3, x7;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x8;                    \
-        umulh   x20, x3, x8;                    \
-        adcs    x19, x19, x14;                  \
-        ldp     x9, x10, [P2+32];               \
-        mul     x14, x3, x9;                    \
-        umulh   x21, x3, x9;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x10;                   \
-        umulh   x22, x3, x10;                   \
-        adcs    x21, x21, x14;                  \
-        ldp     x11, x12, [P2+48];              \
-        mul     x14, x3, x11;                   \
-        umulh   x23, x3, x11;                   \
-        adcs    x22, x22, x14;                  \
-        ldr     x13, [P2+64];                   \
-        mul     x14, x3, x12;                   \
-        umulh   x24, x3, x12;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x13;                   \
-        umulh   x1, x3, x13;                    \
-        adcs    x24, x24, x14;                  \
-        adc     x1, x1, xzr;                    \
-        mul     x14, x4, x5;                    \
-        adds    x16, x16, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x1, x1, x14;                    \
-        cset    x0, hs;                         \
-        umulh   x14, x4, x5;                    \
-        adds    x17, x17, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x13;                   \
-        adc     x0, x0, x14;                    \
-        stp     x15, x16, [P0];                 \
-        ldp     x3, x4, [P1+16];                \
-        mul     x14, x3, x5;                    \
-        adds    x17, x17, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x13;                   \
-        adcs    x0, x0, x14;                    \
-        cset    x15, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x19, x19, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x12;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x13;                   \
-        adc     x15, x15, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x19, x19, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x12;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x13;                   \
-        adcs    x15, x15, x14;                  \
-        cset    x16, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x20, x20, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x21, x21, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x11;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x12;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x16, x16, x14;                  \
-        stp     x17, x19, [P0+16];              \
-        ldp     x3, x4, [P1+32];                \
-        mul     x14, x3, x5;                    \
-        adds    x20, x20, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x21, x21, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x11;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x12;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x16, x16, x14;                  \
-        cset    x17, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x21, x21, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x22, x22, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x10;                   \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x11;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x17, x17, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x21, x21, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x22, x22, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x4, x8;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x9;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x10;                   \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x11;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x17, x17, x14;                  \
-        cset    x19, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x22, x22, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x23, x23, x14;                  \
-        umulh   x14, x4, x7;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x9;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x10;                   \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x19, x19, x14;                  \
-        stp     x20, x21, [P0+32];              \
-        ldp     x3, x4, [P1+48];                \
-        mul     x14, x3, x5;                    \
-        adds    x22, x22, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x23, x23, x14;                  \
-        mul     x14, x3, x7;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x3, x8;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x9;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x10;                   \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x13;                   \
-        adcs    x19, x19, x14;                  \
-        cset    x20, hs;                        \
-        umulh   x14, x3, x5;                    \
-        adds    x23, x23, x14;                  \
-        umulh   x14, x3, x6;                    \
-        adcs    x24, x24, x14;                  \
-        umulh   x14, x3, x7;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x3, x8;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x9;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x13;                   \
-        adc     x20, x20, x14;                  \
-        mul     x14, x4, x5;                    \
-        adds    x23, x23, x14;                  \
-        mul     x14, x4, x6;                    \
-        adcs    x24, x24, x14;                  \
-        mul     x14, x4, x7;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x4, x8;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x4, x9;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x4, x10;                   \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x4, x11;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x4, x12;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x4, x13;                   \
-        adcs    x20, x20, x14;                  \
-        cset    x21, hs;                        \
-        umulh   x14, x4, x5;                    \
-        adds    x24, x24, x14;                  \
-        umulh   x14, x4, x6;                    \
-        adcs    x1, x1, x14;                    \
-        umulh   x14, x4, x7;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x4, x8;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x4, x9;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x4, x10;                   \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x4, x11;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x4, x12;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x4, x13;                   \
-        adc     x21, x21, x14;                  \
-        stp     x22, x23, [P0+48];              \
-        ldr     x3, [P1+64];                    \
-        mul     x14, x3, x5;                    \
-        adds    x24, x24, x14;                  \
-        mul     x14, x3, x6;                    \
-        adcs    x1, x1, x14;                    \
-        mul     x14, x3, x7;                    \
-        adcs    x0, x0, x14;                    \
-        mul     x14, x3, x8;                    \
-        adcs    x15, x15, x14;                  \
-        mul     x14, x3, x9;                    \
-        adcs    x16, x16, x14;                  \
-        mul     x14, x3, x10;                   \
-        adcs    x17, x17, x14;                  \
-        mul     x14, x3, x11;                   \
-        adcs    x19, x19, x14;                  \
-        mul     x14, x3, x12;                   \
-        adcs    x20, x20, x14;                  \
-        mul     x14, x3, x13;                   \
-        adc     x21, x21, x14;                  \
-        umulh   x14, x3, x5;                    \
-        adds    x1, x1, x14;                    \
-        umulh   x14, x3, x6;                    \
-        adcs    x0, x0, x14;                    \
-        umulh   x14, x3, x7;                    \
-        adcs    x15, x15, x14;                  \
-        umulh   x14, x3, x8;                    \
-        adcs    x16, x16, x14;                  \
-        umulh   x14, x3, x9;                    \
-        adcs    x17, x17, x14;                  \
-        umulh   x14, x3, x10;                   \
-        adcs    x19, x19, x14;                  \
-        umulh   x14, x3, x11;                   \
-        adcs    x20, x20, x14;                  \
-        umulh   x14, x3, x12;                   \
-        adc     x21, x21, x14;                  \
-        cmp     xzr, xzr;                       \
-        ldp     x5, x6, [P0];                   \
-        extr    x14, x1, x24, #9;               \
-        adcs    x5, x5, x14;                    \
-        extr    x14, x0, x1, #9;                \
-        adcs    x6, x6, x14;                    \
-        ldp     x7, x8, [P0+16];                \
-        extr    x14, x15, x0, #9;               \
-        adcs    x7, x7, x14;                    \
-        extr    x14, x16, x15, #9;              \
-        adcs    x8, x8, x14;                    \
-        ldp     x9, x10, [P0+32];               \
-        extr    x14, x17, x16, #9;              \
-        adcs    x9, x9, x14;                    \
-        extr    x14, x19, x17, #9;              \
-        adcs    x10, x10, x14;                  \
-        ldp     x11, x12, [P0+48];              \
-        extr    x14, x20, x19, #9;              \
-        adcs    x11, x11, x14;                  \
-        extr    x14, x21, x20, #9;              \
-        adcs    x12, x12, x14;                  \
-        orr     x13, x24, #0xfffffffffffffe00;  \
-        lsr     x14, x21, #9;                   \
-        adcs    x13, x13, x14;                  \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbc     x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x15, x3, x5 __LF                   \
+        umulh   x16, x3, x5 __LF                   \
+        mul     x14, x3, x6 __LF                   \
+        umulh   x17, x3, x6 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        ldp     x7, x8, [P2+16] __LF               \
+        mul     x14, x3, x7 __LF                   \
+        umulh   x19, x3, x7 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        umulh   x20, x3, x8 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        ldp     x9, x10, [P2+32] __LF              \
+        mul     x14, x3, x9 __LF                   \
+        umulh   x21, x3, x9 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        umulh   x22, x3, x10 __LF                  \
+        adcs    x21, x21, x14 __LF                 \
+        ldp     x11, x12, [P2+48] __LF             \
+        mul     x14, x3, x11 __LF                  \
+        umulh   x23, x3, x11 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        ldr     x13, [P2+64] __LF                  \
+        mul     x14, x3, x12 __LF                  \
+        umulh   x24, x3, x12 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        umulh   x1, x3, x13 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        mul     x14, x4, x5 __LF                   \
+        adds    x16, x16, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        cset    x0, hs __LF                        \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x0, x0, x14 __LF                   \
+        stp     x15, x16, [P0] __LF                \
+        ldp     x3, x4, [P1+16] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x17, x17, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        cset    x15, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x15, x15, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x19, x19, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        cset    x16, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x16, x16, x14 __LF                 \
+        stp     x17, x19, [P0+16] __LF             \
+        ldp     x3, x4, [P1+32] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x20, x20, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x21, x21, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        cset    x17, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x17, x17, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x21, x21, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x22, x22, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        cset    x19, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x19, x19, x14 __LF                 \
+        stp     x20, x21, [P0+32] __LF             \
+        ldp     x3, x4, [P1+48] __LF               \
+        mul     x14, x3, x5 __LF                   \
+        adds    x22, x22, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x23, x23, x14 __LF                 \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x13 __LF                  \
+        adc     x20, x20, x14 __LF                 \
+        mul     x14, x4, x5 __LF                   \
+        adds    x23, x23, x14 __LF                 \
+        mul     x14, x4, x6 __LF                   \
+        adcs    x24, x24, x14 __LF                 \
+        mul     x14, x4, x7 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x4, x8 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x4, x9 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x4, x10 __LF                  \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x4, x11 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x4, x12 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x4, x13 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        cset    x21, hs __LF                       \
+        umulh   x14, x4, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        umulh   x14, x4, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        umulh   x14, x4, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x4, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x4, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x4, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x4, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x4, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        stp     x22, x23, [P0+48] __LF             \
+        ldr     x3, [P1+64] __LF                   \
+        mul     x14, x3, x5 __LF                   \
+        adds    x24, x24, x14 __LF                 \
+        mul     x14, x3, x6 __LF                   \
+        adcs    x1, x1, x14 __LF                   \
+        mul     x14, x3, x7 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        mul     x14, x3, x8 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        mul     x14, x3, x9 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        mul     x14, x3, x10 __LF                  \
+        adcs    x17, x17, x14 __LF                 \
+        mul     x14, x3, x11 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        mul     x14, x3, x12 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        mul     x14, x3, x13 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        umulh   x14, x3, x5 __LF                   \
+        adds    x1, x1, x14 __LF                   \
+        umulh   x14, x3, x6 __LF                   \
+        adcs    x0, x0, x14 __LF                   \
+        umulh   x14, x3, x7 __LF                   \
+        adcs    x15, x15, x14 __LF                 \
+        umulh   x14, x3, x8 __LF                   \
+        adcs    x16, x16, x14 __LF                 \
+        umulh   x14, x3, x9 __LF                   \
+        adcs    x17, x17, x14 __LF                 \
+        umulh   x14, x3, x10 __LF                  \
+        adcs    x19, x19, x14 __LF                 \
+        umulh   x14, x3, x11 __LF                  \
+        adcs    x20, x20, x14 __LF                 \
+        umulh   x14, x3, x12 __LF                  \
+        adc     x21, x21, x14 __LF                 \
+        cmp     xzr, xzr __LF                      \
+        ldp     x5, x6, [P0] __LF                  \
+        extr    x14, x1, x24, #9 __LF              \
+        adcs    x5, x5, x14 __LF                   \
+        extr    x14, x0, x1, #9 __LF               \
+        adcs    x6, x6, x14 __LF                   \
+        ldp     x7, x8, [P0+16] __LF               \
+        extr    x14, x15, x0, #9 __LF              \
+        adcs    x7, x7, x14 __LF                   \
+        extr    x14, x16, x15, #9 __LF             \
+        adcs    x8, x8, x14 __LF                   \
+        ldp     x9, x10, [P0+32] __LF              \
+        extr    x14, x17, x16, #9 __LF             \
+        adcs    x9, x9, x14 __LF                   \
+        extr    x14, x19, x17, #9 __LF             \
+        adcs    x10, x10, x14 __LF                 \
+        ldp     x11, x12, [P0+48] __LF             \
+        extr    x14, x20, x19, #9 __LF             \
+        adcs    x11, x11, x14 __LF                 \
+        extr    x14, x21, x20, #9 __LF             \
+        adcs    x12, x12, x14 __LF                 \
+        orr     x13, x24, #0xfffffffffffffe00 __LF \
+        lsr     x14, x21, #9 __LF                  \
+        adcs    x13, x13, x14 __LF                 \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbc     x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 // Corresponds exactly to bignum_sqr_p521_alt
 
 #define sqr_p521(P0,P1)                         \
-        ldp     x2, x3, [P1];                   \
-        mul     x11, x2, x3;                    \
-        umulh   x12, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x10, x2, x4;                    \
-        umulh   x13, x2, x4;                    \
-        adds    x12, x12, x10;                  \
-        ldp     x6, x7, [P1+32];                \
-        mul     x10, x2, x5;                    \
-        umulh   x14, x2, x5;                    \
-        adcs    x13, x13, x10;                  \
-        ldp     x8, x9, [P1+48];                \
-        mul     x10, x2, x6;                    \
-        umulh   x15, x2, x6;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x2, x7;                    \
-        umulh   x16, x2, x7;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x2, x8;                    \
-        umulh   x17, x2, x8;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x2, x9;                    \
-        umulh   x19, x2, x9;                    \
-        adcs    x17, x17, x10;                  \
-        adc     x19, x19, xzr;                  \
-        mul     x10, x3, x4;                    \
-        adds    x13, x13, x10;                  \
-        mul     x10, x3, x5;                    \
-        adcs    x14, x14, x10;                  \
-        mul     x10, x3, x6;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x3, x7;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x3, x8;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x3, x9;                    \
-        adcs    x19, x19, x10;                  \
-        cset    x20, hs;                        \
-        umulh   x10, x3, x4;                    \
-        adds    x14, x14, x10;                  \
-        umulh   x10, x3, x5;                    \
-        adcs    x15, x15, x10;                  \
-        umulh   x10, x3, x6;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x3, x7;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x3, x8;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x3, x9;                    \
-        adc     x20, x20, x10;                  \
-        mul     x10, x6, x7;                    \
-        umulh   x21, x6, x7;                    \
-        adds    x20, x20, x10;                  \
-        adc     x21, x21, xzr;                  \
-        mul     x10, x4, x5;                    \
-        adds    x15, x15, x10;                  \
-        mul     x10, x4, x6;                    \
-        adcs    x16, x16, x10;                  \
-        mul     x10, x4, x7;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x4, x8;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x4, x9;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x6, x8;                    \
-        adcs    x21, x21, x10;                  \
-        cset    x22, hs;                        \
-        umulh   x10, x4, x5;                    \
-        adds    x16, x16, x10;                  \
-        umulh   x10, x4, x6;                    \
-        adcs    x17, x17, x10;                  \
-        umulh   x10, x4, x7;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x4, x8;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x4, x9;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x6, x8;                    \
-        adc     x22, x22, x10;                  \
-        mul     x10, x7, x8;                    \
-        umulh   x23, x7, x8;                    \
-        adds    x22, x22, x10;                  \
-        adc     x23, x23, xzr;                  \
-        mul     x10, x5, x6;                    \
-        adds    x17, x17, x10;                  \
-        mul     x10, x5, x7;                    \
-        adcs    x19, x19, x10;                  \
-        mul     x10, x5, x8;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x5, x9;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x6, x9;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x7, x9;                    \
-        adcs    x23, x23, x10;                  \
-        cset    x24, hs;                        \
-        umulh   x10, x5, x6;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x5, x7;                    \
-        adcs    x20, x20, x10;                  \
-        umulh   x10, x5, x8;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x5, x9;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x6, x9;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x7, x9;                    \
-        adc     x24, x24, x10;                  \
-        mul     x10, x8, x9;                    \
-        umulh   x25, x8, x9;                    \
-        adds    x24, x24, x10;                  \
-        adc     x25, x25, xzr;                  \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        adcs    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adcs    x17, x17, x17;                  \
-        adcs    x19, x19, x19;                  \
-        adcs    x20, x20, x20;                  \
-        adcs    x21, x21, x21;                  \
-        adcs    x22, x22, x22;                  \
-        adcs    x23, x23, x23;                  \
-        adcs    x24, x24, x24;                  \
-        adcs    x25, x25, x25;                  \
-        cset    x0, hs;                         \
-        umulh   x10, x2, x2;                    \
-        adds    x11, x11, x10;                  \
-        mul     x10, x3, x3;                    \
-        adcs    x12, x12, x10;                  \
-        umulh   x10, x3, x3;                    \
-        adcs    x13, x13, x10;                  \
-        mul     x10, x4, x4;                    \
-        adcs    x14, x14, x10;                  \
-        umulh   x10, x4, x4;                    \
-        adcs    x15, x15, x10;                  \
-        mul     x10, x5, x5;                    \
-        adcs    x16, x16, x10;                  \
-        umulh   x10, x5, x5;                    \
-        adcs    x17, x17, x10;                  \
-        mul     x10, x6, x6;                    \
-        adcs    x19, x19, x10;                  \
-        umulh   x10, x6, x6;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x7, x7;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x7, x7;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x8, x8;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x8, x8;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x9, x9;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x9, x9;                    \
-        adc     x0, x0, x10;                    \
-        ldr     x1, [P1+64];                    \
-        add     x1, x1, x1;                     \
-        mul     x10, x1, x2;                    \
-        adds    x19, x19, x10;                  \
-        umulh   x10, x1, x2;                    \
-        adcs    x20, x20, x10;                  \
-        mul     x10, x1, x4;                    \
-        adcs    x21, x21, x10;                  \
-        umulh   x10, x1, x4;                    \
-        adcs    x22, x22, x10;                  \
-        mul     x10, x1, x6;                    \
-        adcs    x23, x23, x10;                  \
-        umulh   x10, x1, x6;                    \
-        adcs    x24, x24, x10;                  \
-        mul     x10, x1, x8;                    \
-        adcs    x25, x25, x10;                  \
-        umulh   x10, x1, x8;                    \
-        adcs    x0, x0, x10;                    \
-        lsr     x4, x1, #1;                     \
-        mul     x4, x4, x4;                     \
-        adc     x4, x4, xzr;                    \
-        mul     x10, x1, x3;                    \
-        adds    x20, x20, x10;                  \
-        umulh   x10, x1, x3;                    \
-        adcs    x21, x21, x10;                  \
-        mul     x10, x1, x5;                    \
-        adcs    x22, x22, x10;                  \
-        umulh   x10, x1, x5;                    \
-        adcs    x23, x23, x10;                  \
-        mul     x10, x1, x7;                    \
-        adcs    x24, x24, x10;                  \
-        umulh   x10, x1, x7;                    \
-        adcs    x25, x25, x10;                  \
-        mul     x10, x1, x9;                    \
-        adcs    x0, x0, x10;                    \
-        umulh   x10, x1, x9;                    \
-        adc     x4, x4, x10;                    \
-        mul     x2, x2, x2;                     \
-        cmp     xzr, xzr;                       \
-        extr    x10, x20, x19, #9;              \
-        adcs    x2, x2, x10;                    \
-        extr    x10, x21, x20, #9;              \
-        adcs    x11, x11, x10;                  \
-        extr    x10, x22, x21, #9;              \
-        adcs    x12, x12, x10;                  \
-        extr    x10, x23, x22, #9;              \
-        adcs    x13, x13, x10;                  \
-        extr    x10, x24, x23, #9;              \
-        adcs    x14, x14, x10;                  \
-        extr    x10, x25, x24, #9;              \
-        adcs    x15, x15, x10;                  \
-        extr    x10, x0, x25, #9;               \
-        adcs    x16, x16, x10;                  \
-        extr    x10, x4, x0, #9;                \
-        adcs    x17, x17, x10;                  \
-        orr     x19, x19, #0xfffffffffffffe00;  \
-        lsr     x10, x4, #9;                    \
-        adcs    x19, x19, x10;                  \
-        sbcs    x2, x2, xzr;                    \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbcs    x15, x15, xzr;                  \
-        sbcs    x16, x16, xzr;                  \
-        sbcs    x17, x17, xzr;                  \
-        sbc     x19, x19, xzr;                  \
-        and     x19, x19, #0x1ff;               \
-        stp     x2, x11, [P0];                  \
-        stp     x12, x13, [P0+16];              \
-        stp     x14, x15, [P0+32];              \
-        stp     x16, x17, [P0+48];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x11, x2, x3 __LF                   \
+        umulh   x12, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x10, x2, x4 __LF                   \
+        umulh   x13, x2, x4 __LF                   \
+        adds    x12, x12, x10 __LF                 \
+        ldp     x6, x7, [P1+32] __LF               \
+        mul     x10, x2, x5 __LF                   \
+        umulh   x14, x2, x5 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        ldp     x8, x9, [P1+48] __LF               \
+        mul     x10, x2, x6 __LF                   \
+        umulh   x15, x2, x6 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x2, x7 __LF                   \
+        umulh   x16, x2, x7 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x2, x8 __LF                   \
+        umulh   x17, x2, x8 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x2, x9 __LF                   \
+        umulh   x19, x2, x9 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        adc     x19, x19, xzr __LF                 \
+        mul     x10, x3, x4 __LF                   \
+        adds    x13, x13, x10 __LF                 \
+        mul     x10, x3, x5 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        mul     x10, x3, x6 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x3, x7 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x3, x8 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x3, x9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        cset    x20, hs __LF                       \
+        umulh   x10, x3, x4 __LF                   \
+        adds    x14, x14, x10 __LF                 \
+        umulh   x10, x3, x5 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        umulh   x10, x3, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x3, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x3, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x3, x9 __LF                   \
+        adc     x20, x20, x10 __LF                 \
+        mul     x10, x6, x7 __LF                   \
+        umulh   x21, x6, x7 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        adc     x21, x21, xzr __LF                 \
+        mul     x10, x4, x5 __LF                   \
+        adds    x15, x15, x10 __LF                 \
+        mul     x10, x4, x6 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        mul     x10, x4, x7 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x4, x8 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x4, x9 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x6, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        cset    x22, hs __LF                       \
+        umulh   x10, x4, x5 __LF                   \
+        adds    x16, x16, x10 __LF                 \
+        umulh   x10, x4, x6 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        umulh   x10, x4, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x4, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x4, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x6, x8 __LF                   \
+        adc     x22, x22, x10 __LF                 \
+        mul     x10, x7, x8 __LF                   \
+        umulh   x23, x7, x8 __LF                   \
+        adds    x22, x22, x10 __LF                 \
+        adc     x23, x23, xzr __LF                 \
+        mul     x10, x5, x6 __LF                   \
+        adds    x17, x17, x10 __LF                 \
+        mul     x10, x5, x7 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        mul     x10, x5, x8 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x5, x9 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x6, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x7, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        cset    x24, hs __LF                       \
+        umulh   x10, x5, x6 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x5, x7 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        umulh   x10, x5, x8 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x5, x9 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x6, x9 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x7, x9 __LF                   \
+        adc     x24, x24, x10 __LF                 \
+        mul     x10, x8, x9 __LF                   \
+        umulh   x25, x8, x9 __LF                   \
+        adds    x24, x24, x10 __LF                 \
+        adc     x25, x25, xzr __LF                 \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        adcs    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adcs    x17, x17, x17 __LF                 \
+        adcs    x19, x19, x19 __LF                 \
+        adcs    x20, x20, x20 __LF                 \
+        adcs    x21, x21, x21 __LF                 \
+        adcs    x22, x22, x22 __LF                 \
+        adcs    x23, x23, x23 __LF                 \
+        adcs    x24, x24, x24 __LF                 \
+        adcs    x25, x25, x25 __LF                 \
+        cset    x0, hs __LF                        \
+        umulh   x10, x2, x2 __LF                   \
+        adds    x11, x11, x10 __LF                 \
+        mul     x10, x3, x3 __LF                   \
+        adcs    x12, x12, x10 __LF                 \
+        umulh   x10, x3, x3 __LF                   \
+        adcs    x13, x13, x10 __LF                 \
+        mul     x10, x4, x4 __LF                   \
+        adcs    x14, x14, x10 __LF                 \
+        umulh   x10, x4, x4 __LF                   \
+        adcs    x15, x15, x10 __LF                 \
+        mul     x10, x5, x5 __LF                   \
+        adcs    x16, x16, x10 __LF                 \
+        umulh   x10, x5, x5 __LF                   \
+        adcs    x17, x17, x10 __LF                 \
+        mul     x10, x6, x6 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        umulh   x10, x6, x6 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x7, x7 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x7, x7 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x8, x8 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x8, x8 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x9, x9 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x9, x9 __LF                   \
+        adc     x0, x0, x10 __LF                   \
+        ldr     x1, [P1+64] __LF                   \
+        add     x1, x1, x1 __LF                    \
+        mul     x10, x1, x2 __LF                   \
+        adds    x19, x19, x10 __LF                 \
+        umulh   x10, x1, x2 __LF                   \
+        adcs    x20, x20, x10 __LF                 \
+        mul     x10, x1, x4 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        umulh   x10, x1, x4 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        mul     x10, x1, x6 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        umulh   x10, x1, x6 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        mul     x10, x1, x8 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        umulh   x10, x1, x8 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        lsr     x4, x1, #1 __LF                    \
+        mul     x4, x4, x4 __LF                    \
+        adc     x4, x4, xzr __LF                   \
+        mul     x10, x1, x3 __LF                   \
+        adds    x20, x20, x10 __LF                 \
+        umulh   x10, x1, x3 __LF                   \
+        adcs    x21, x21, x10 __LF                 \
+        mul     x10, x1, x5 __LF                   \
+        adcs    x22, x22, x10 __LF                 \
+        umulh   x10, x1, x5 __LF                   \
+        adcs    x23, x23, x10 __LF                 \
+        mul     x10, x1, x7 __LF                   \
+        adcs    x24, x24, x10 __LF                 \
+        umulh   x10, x1, x7 __LF                   \
+        adcs    x25, x25, x10 __LF                 \
+        mul     x10, x1, x9 __LF                   \
+        adcs    x0, x0, x10 __LF                   \
+        umulh   x10, x1, x9 __LF                   \
+        adc     x4, x4, x10 __LF                   \
+        mul     x2, x2, x2 __LF                    \
+        cmp     xzr, xzr __LF                      \
+        extr    x10, x20, x19, #9 __LF             \
+        adcs    x2, x2, x10 __LF                   \
+        extr    x10, x21, x20, #9 __LF             \
+        adcs    x11, x11, x10 __LF                 \
+        extr    x10, x22, x21, #9 __LF             \
+        adcs    x12, x12, x10 __LF                 \
+        extr    x10, x23, x22, #9 __LF             \
+        adcs    x13, x13, x10 __LF                 \
+        extr    x10, x24, x23, #9 __LF             \
+        adcs    x14, x14, x10 __LF                 \
+        extr    x10, x25, x24, #9 __LF             \
+        adcs    x15, x15, x10 __LF                 \
+        extr    x10, x0, x25, #9 __LF              \
+        adcs    x16, x16, x10 __LF                 \
+        extr    x10, x4, x0, #9 __LF               \
+        adcs    x17, x17, x10 __LF                 \
+        orr     x19, x19, #0xfffffffffffffe00 __LF \
+        lsr     x10, x4, #9 __LF                   \
+        adcs    x19, x19, x10 __LF                 \
+        sbcs    x2, x2, xzr __LF                   \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbcs    x15, x15, xzr __LF                 \
+        sbcs    x16, x16, xzr __LF                 \
+        sbcs    x17, x17, xzr __LF                 \
+        sbc     x19, x19, xzr __LF                 \
+        and     x19, x19, #0x1ff __LF              \
+        stp     x2, x11, [P0] __LF                 \
+        stp     x12, x13, [P0+16] __LF             \
+        stp     x14, x15, [P0+32] __LF             \
+        stp     x16, x17, [P0+48] __LF             \
         str     x19, [P0+64]
 
 // Corresponds exactly to bignum_sub_p521
 
 #define sub_p521(P0,P1,P2)                      \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        ldp     x9, x10, [P1+32];               \
-        ldp     x4, x3, [P2+32];                \
-        sbcs    x9, x9, x4;                     \
-        sbcs    x10, x10, x3;                   \
-        ldp     x11, x12, [P1+48];              \
-        ldp     x4, x3, [P2+48];                \
-        sbcs    x11, x11, x4;                   \
-        sbcs    x12, x12, x3;                   \
-        ldr     x13, [P1+64];                   \
-        ldr     x4, [P2+64];                    \
-        sbcs    x13, x13, x4;                   \
-        sbcs    x5, x5, xzr;                    \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbcs    x11, x11, xzr;                  \
-        sbcs    x12, x12, xzr;                  \
-        sbcs    x13, x13, xzr;                  \
-        and     x13, x13, #0x1ff;               \
-        stp     x5, x6, [P0];                   \
-        stp     x7, x8, [P0+16];                \
-        stp     x9, x10, [P0+32];               \
-        stp     x11, x12, [P0+48];              \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        ldp     x9, x10, [P1+32] __LF              \
+        ldp     x4, x3, [P2+32] __LF               \
+        sbcs    x9, x9, x4 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        ldp     x11, x12, [P1+48] __LF             \
+        ldp     x4, x3, [P2+48] __LF               \
+        sbcs    x11, x11, x4 __LF                  \
+        sbcs    x12, x12, x3 __LF                  \
+        ldr     x13, [P1+64] __LF                  \
+        ldr     x4, [P2+64] __LF                   \
+        sbcs    x13, x13, x4 __LF                  \
+        sbcs    x5, x5, xzr __LF                   \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbcs    x11, x11, xzr __LF                 \
+        sbcs    x12, x12, xzr __LF                 \
+        sbcs    x13, x13, xzr __LF                 \
+        and     x13, x13, #0x1ff __LF              \
+        stp     x5, x6, [P0] __LF                  \
+        stp     x7, x8, [P0+16] __LF               \
+        stp     x9, x10, [P0+32] __LF              \
+        stp     x11, x12, [P0+48] __LF             \
         str     x13, [P0+64]
 
 S2N_BN_SYMBOL(p521_jmixadd_alt):

--- a/arm/p521/p521_jscalarmul.S
+++ b/arm/p521/p521_jscalarmul.S
@@ -59,29 +59,29 @@
 #define NSPACE #(55*NUMSIZE+8)
 
 #define selectblock(I)                            \
-        cmp     bf, #(1*I);                       \
-        ldp     x10, x11, [tabup];                \
-        csel    x0, x10, x0, eq;                  \
-        csel    x1, x11, x1, eq;                  \
-        ldp     x10, x11, [tabup, #16];           \
-        csel    x2, x10, x2, eq;                  \
-        csel    x3, x11, x3, eq;                  \
-        ldp     x10, x11, [tabup, #32];           \
-        csel    x4, x10, x4, eq;                  \
-        csel    x5, x11, x5, eq;                  \
-        ldp     x10, x11, [tabup, #48];           \
-        csel    x6, x10, x6, eq;                  \
-        csel    x7, x11, x7, eq;                  \
-        ldr     x10, [tabup, #64];                \
-        csel    x8, x10, x8, eq;                  \
+        cmp     bf, #(1*I) __LF                      \
+        ldp     x10, x11, [tabup] __LF               \
+        csel    x0, x10, x0, eq __LF                 \
+        csel    x1, x11, x1, eq __LF                 \
+        ldp     x10, x11, [tabup, #16] __LF          \
+        csel    x2, x10, x2, eq __LF                 \
+        csel    x3, x11, x3, eq __LF                 \
+        ldp     x10, x11, [tabup, #32] __LF          \
+        csel    x4, x10, x4, eq __LF                 \
+        csel    x5, x11, x5, eq __LF                 \
+        ldp     x10, x11, [tabup, #48] __LF          \
+        csel    x6, x10, x6, eq __LF                 \
+        csel    x7, x11, x7, eq __LF                 \
+        ldr     x10, [tabup, #64] __LF               \
+        csel    x8, x10, x8, eq __LF                 \
         add     tabup, tabup, #JACSIZE
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p521_jscalarmul):

--- a/arm/p521/p521_jscalarmul_alt.S
+++ b/arm/p521/p521_jscalarmul_alt.S
@@ -59,29 +59,29 @@
 #define NSPACE #(55*NUMSIZE+8)
 
 #define selectblock(I)                            \
-        cmp     bf, #(1*I);                       \
-        ldp     x10, x11, [tabup];                \
-        csel    x0, x10, x0, eq;                  \
-        csel    x1, x11, x1, eq;                  \
-        ldp     x10, x11, [tabup, #16];           \
-        csel    x2, x10, x2, eq;                  \
-        csel    x3, x11, x3, eq;                  \
-        ldp     x10, x11, [tabup, #32];           \
-        csel    x4, x10, x4, eq;                  \
-        csel    x5, x11, x5, eq;                  \
-        ldp     x10, x11, [tabup, #48];           \
-        csel    x6, x10, x6, eq;                  \
-        csel    x7, x11, x7, eq;                  \
-        ldr     x10, [tabup, #64];                \
-        csel    x8, x10, x8, eq;                  \
+        cmp     bf, #(1*I) __LF                      \
+        ldp     x10, x11, [tabup] __LF               \
+        csel    x0, x10, x0, eq __LF                 \
+        csel    x1, x11, x1, eq __LF                 \
+        ldp     x10, x11, [tabup, #16] __LF          \
+        csel    x2, x10, x2, eq __LF                 \
+        csel    x3, x11, x3, eq __LF                 \
+        ldp     x10, x11, [tabup, #32] __LF          \
+        csel    x4, x10, x4, eq __LF                 \
+        csel    x5, x11, x5, eq __LF                 \
+        ldp     x10, x11, [tabup, #48] __LF          \
+        csel    x6, x10, x6, eq __LF                 \
+        csel    x7, x11, x7, eq __LF                 \
+        ldr     x10, [tabup, #64] __LF               \
+        csel    x8, x10, x8, eq __LF                 \
         add     tabup, tabup, #JACSIZE
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(p521_jscalarmul_alt):

--- a/arm/p521/unopt/bignum_montmul_p521_base.S
+++ b/arm/p521/unopt/bignum_montmul_p521_base.S
@@ -33,18 +33,18 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffnadd(b,a,x,y,w,z)        \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        adds    xzr, c, #1;             \
-        eor     l, l, c;                \
-        adcs    a, a, l;                \
-        eor     h, h, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        adds    xzr, c, #1 __LF            \
+        eor     l, l, c __LF               \
+        adcs    a, a, l __LF               \
+        eor     h, h, c __LF               \
         adcs    b, b, h
 
 #define z x0
@@ -85,66 +85,66 @@
 #define mul4                                                            \
 /*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
         \
-        mul     s0, a0, b0;                                     \
-        mul     s4, a1, b1;                                     \
-        mul     s5, a2, b2;                                     \
-        mul     s6, a3, b3;                                     \
+        mul     s0, a0, b0 __LF                                    \
+        mul     s4, a1, b1 __LF                                    \
+        mul     s5, a2, b2 __LF                                    \
+        mul     s6, a3, b3 __LF                                    \
         \
-        umulh   s7, a0, b0;                                     \
-        adds    s4, s4, s7;                                     \
-        umulh   s7, a1, b1;                                     \
-        adcs    s5, s5, s7;                                     \
-        umulh   s7, a2, b2;                                     \
-        adcs    s6, s6, s7;                                     \
-        umulh   s7, a3, b3;                                     \
-        adc     s7, s7, xzr;                                    \
+        umulh   s7, a0, b0 __LF                                    \
+        adds    s4, s4, s7 __LF                                    \
+        umulh   s7, a1, b1 __LF                                    \
+        adcs    s5, s5, s7 __LF                                    \
+        umulh   s7, a2, b2 __LF                                    \
+        adcs    s6, s6, s7 __LF                                    \
+        umulh   s7, a3, b3 __LF                                    \
+        adc     s7, s7, xzr __LF                                   \
         \
 /*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
         \
-        adds    s1, s4, s0;                                     \
-        adcs    s4, s5, s4;                                     \
-        adcs    s5, s6, s5;                                     \
-        adcs    s6, s7, s6;                                     \
-        adc     s7, xzr, s7;                                    \
+        adds    s1, s4, s0 __LF                                    \
+        adcs    s4, s5, s4 __LF                                    \
+        adcs    s5, s6, s5 __LF                                    \
+        adcs    s6, s7, s6 __LF                                    \
+        adc     s7, xzr, s7 __LF                                   \
         \
 /*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
         \
-        adds    s2, s4, s0;                                     \
-        adcs    s3, s5, s1;                                     \
-        adcs    s4, s6, s4;                                     \
-        adcs    s5, s7, s5;                                     \
-        adcs    s6, xzr, s6;                                    \
-        adc     s7, xzr, s7;                                    \
+        adds    s2, s4, s0 __LF                                    \
+        adcs    s3, s5, s1 __LF                                    \
+        adcs    s4, s6, s4 __LF                                    \
+        adcs    s5, s7, s5 __LF                                    \
+        adcs    s6, xzr, s6 __LF                                   \
+        adc     s7, xzr, s7 __LF                                   \
         \
 /*  Now add in all the "complicated" terms. */                          \
         \
-        muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s6,s5, a2,a3, b3,b2) __LF                      \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
-        adcs    s3, s3, c;                                      \
-        adcs    s4, s4, c;                                      \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s2,s1, a0,a1, b1,b0) __LF                      \
+        adcs    s3, s3, c __LF                                     \
+        adcs    s4, s4, c __LF                                     \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s5,s4, a1,a3, b3,b1) __LF                      \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
-        adcs    s4, s4, c;                                      \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s3,s2, a0,a2, b2,b0) __LF                      \
+        adcs    s4, s4, c __LF                                     \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
-        muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
+        muldiffnadd(s4,s3, a0,a3, b3,b0) __LF                      \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
+        muldiffnadd(s4,s3, a1,a2, b2,b1) __LF                      \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
         adc     s7, s7, c                                       \
 
 S2N_BN_SYMBOL(bignum_montmul_p521_base):

--- a/arm/p521/unopt/bignum_mul_p521_base.S
+++ b/arm/p521/unopt/bignum_mul_p521_base.S
@@ -28,18 +28,18 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffnadd(b,a,x,y,w,z)        \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        adds    xzr, c, #1;             \
-        eor     l, l, c;                \
-        adcs    a, a, l;                \
-        eor     h, h, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        adds    xzr, c, #1 __LF            \
+        eor     l, l, c __LF               \
+        adcs    a, a, l __LF               \
+        eor     h, h, c __LF               \
         adcs    b, b, h
 
 #define z x0
@@ -80,66 +80,66 @@
 #define mul4                                                            \
 /*  First accumulate all the "simple" products as [s7,s6,s5,s4,s0] */   \
         \
-        mul     s0, a0, b0;                                     \
-        mul     s4, a1, b1;                                     \
-        mul     s5, a2, b2;                                     \
-        mul     s6, a3, b3;                                     \
+        mul     s0, a0, b0 __LF                                    \
+        mul     s4, a1, b1 __LF                                    \
+        mul     s5, a2, b2 __LF                                    \
+        mul     s6, a3, b3 __LF                                    \
         \
-        umulh   s7, a0, b0;                                     \
-        adds    s4, s4, s7;                                     \
-        umulh   s7, a1, b1;                                     \
-        adcs    s5, s5, s7;                                     \
-        umulh   s7, a2, b2;                                     \
-        adcs    s6, s6, s7;                                     \
-        umulh   s7, a3, b3;                                     \
-        adc     s7, s7, xzr;                                    \
+        umulh   s7, a0, b0 __LF                                    \
+        adds    s4, s4, s7 __LF                                    \
+        umulh   s7, a1, b1 __LF                                    \
+        adcs    s5, s5, s7 __LF                                    \
+        umulh   s7, a2, b2 __LF                                    \
+        adcs    s6, s6, s7 __LF                                    \
+        umulh   s7, a3, b3 __LF                                    \
+        adc     s7, s7, xzr __LF                                   \
         \
 /*  Multiply by B + 1 to get [s7;s6;s5;s4;s1;s0] */                     \
         \
-        adds    s1, s4, s0;                                     \
-        adcs    s4, s5, s4;                                     \
-        adcs    s5, s6, s5;                                     \
-        adcs    s6, s7, s6;                                     \
-        adc     s7, xzr, s7;                                    \
+        adds    s1, s4, s0 __LF                                    \
+        adcs    s4, s5, s4 __LF                                    \
+        adcs    s5, s6, s5 __LF                                    \
+        adcs    s6, s7, s6 __LF                                    \
+        adc     s7, xzr, s7 __LF                                   \
         \
 /*  Multiply by B^2 + 1 to get [s7;s6;s5;s4;s3;s2;s1;s0] */             \
         \
-        adds    s2, s4, s0;                                     \
-        adcs    s3, s5, s1;                                     \
-        adcs    s4, s6, s4;                                     \
-        adcs    s5, s7, s5;                                     \
-        adcs    s6, xzr, s6;                                    \
-        adc     s7, xzr, s7;                                    \
+        adds    s2, s4, s0 __LF                                    \
+        adcs    s3, s5, s1 __LF                                    \
+        adcs    s4, s6, s4 __LF                                    \
+        adcs    s5, s7, s5 __LF                                    \
+        adcs    s6, xzr, s6 __LF                                   \
+        adc     s7, xzr, s7 __LF                                   \
         \
 /*  Now add in all the "complicated" terms. */                          \
         \
-        muldiffnadd(s6,s5, a2,a3, b3,b2);                       \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s6,s5, a2,a3, b3,b2) __LF                      \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s2,s1, a0,a1, b1,b0);                       \
-        adcs    s3, s3, c;                                      \
-        adcs    s4, s4, c;                                      \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s2,s1, a0,a1, b1,b0) __LF                      \
+        adcs    s3, s3, c __LF                                     \
+        adcs    s4, s4, c __LF                                     \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s5,s4, a1,a3, b3,b1);                       \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s5,s4, a1,a3, b3,b1) __LF                      \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s3,s2, a0,a2, b2,b0);                       \
-        adcs    s4, s4, c;                                      \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
+        muldiffnadd(s3,s2, a0,a2, b2,b0) __LF                      \
+        adcs    s4, s4, c __LF                                     \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
         \
-        muldiffnadd(s4,s3, a0,a3, b3,b0);                       \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
-        adc     s7, s7, c;                                      \
-        muldiffnadd(s4,s3, a1,a2, b2,b1);                       \
-        adcs    s5, s5, c;                                      \
-        adcs    s6, s6, c;                                      \
+        muldiffnadd(s4,s3, a0,a3, b3,b0) __LF                      \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
+        adc     s7, s7, c __LF                                     \
+        muldiffnadd(s4,s3, a1,a2, b2,b1) __LF                      \
+        adcs    s5, s5, c __LF                                     \
+        adcs    s6, s6, c __LF                                     \
         adc     s7, s7, c                                       \
 
 S2N_BN_SYMBOL(bignum_mul_p521_base):

--- a/arm/secp256k1/bignum_mod_n256k1_4.S
+++ b/arm/secp256k1/bignum_mod_n256k1_4.S
@@ -35,9 +35,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_n256k1_4):

--- a/arm/secp256k1/bignum_montmul_p256k1.S
+++ b/arm/secp256k1/bignum_montmul_p256k1.S
@@ -24,9 +24,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                              \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 // ---------------------------------------------------------------------------
@@ -36,15 +36,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -55,17 +55,17 @@
 // ---------------------------------------------------------------------------
 
 #define montreds2(d5,d4,d3,d2,d1,d0)                                      \
-        movbig(t2, 0xd838, #0x091d, #0xd225, #0x3531);            \
-        mul     d4, t2, d0;                                       \
-        mov     t3, #977;                                         \
-        orr     t3, t3, #0x100000000;                             \
-        umulh   t1, d4, t3;                                       \
-        subs    d1, d1, t1;                                       \
-        mul     d5, t2, d1;                                       \
-        umulh   t1, d5, t3;                                       \
-        sbcs    d2, d2, t1;                                       \
-        sbcs    d3, d3, xzr;                                      \
-        sbcs    d4, d4, xzr;                                      \
+        movbig(t2, 0xd838, #0x091d, #0xd225, #0x3531) __LF           \
+        mul     d4, t2, d0 __LF                                      \
+        mov     t3, #977 __LF                                        \
+        orr     t3, t3, #0x100000000 __LF                            \
+        umulh   t1, d4, t3 __LF                                      \
+        subs    d1, d1, t1 __LF                                      \
+        mul     d5, t2, d1 __LF                                      \
+        umulh   t1, d5, t3 __LF                                      \
+        sbcs    d2, d2, t1 __LF                                      \
+        sbcs    d3, d3, xzr __LF                                     \
+        sbcs    d4, d4, xzr __LF                                     \
         sbc     d5, d5, xzr
 
 #define a0 x3

--- a/arm/secp256k1/secp256k1_jadd.S
+++ b/arm/secp256k1/secp256k1_jadd.S
@@ -85,321 +85,321 @@
 // re-use of the pconst register for the constant 4294968273
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x7, x3, x5;                     \
-        umulh   x8, x3, x5;                     \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        mul     x11, x3, x5;                    \
-        umulh   x12, x3, x5;                    \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, lo;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, lo;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x9, lo;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, lo;                     \
-        cinv    x9, x9, lo;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #1;                         \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x16, #977;                      \
-        mul     x3, pconst, x11;                \
-        umulh   x5, pconst, x11;                \
-        and     x15, x12, #0xffffffff;          \
-        lsr     x2, x12, #32;                   \
-        mul     x4, x16, x15;                   \
-        madd    x15, x16, x2, x15;              \
-        adds    x4, x4, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x6, x2, x15;                    \
-        mul     x11, pconst, x13;               \
-        umulh   x13, pconst, x13;               \
-        and     x15, x14, #0xffffffff;          \
-        lsr     x2, x14, #32;                   \
-        mul     x12, x16, x15;                  \
-        madd    x15, x16, x2, x15;              \
-        adds    x12, x12, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x14, x2, x15;                   \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        cset    x11, hs;                        \
-        adds    x8, x8, x5;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, x14;                  \
-        add     x0, x11, #1;                    \
-        mul     x3, x16, x0;                    \
-        lsr     x4, x0, #32;                    \
-        adds    x3, x3, x0, lsl #32;            \
-        adc     x4, xzr, x4;                    \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        csel    x1, pconst, xzr, lo;            \
-        subs    x7, x7, x1;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x8, x3, x5 __LF                    \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        umulh   x12, x3, x5 __LF                   \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, lo __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, lo __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x9, lo __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, lo __LF                    \
+        cinv    x9, x9, lo __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #1 __LF                        \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x16, #977 __LF                     \
+        mul     x3, pconst, x11 __LF               \
+        umulh   x5, pconst, x11 __LF               \
+        and     x15, x12, #0xffffffff __LF         \
+        lsr     x2, x12, #32 __LF                  \
+        mul     x4, x16, x15 __LF                  \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x4, x4, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x6, x2, x15 __LF                   \
+        mul     x11, pconst, x13 __LF              \
+        umulh   x13, pconst, x13 __LF              \
+        and     x15, x14, #0xffffffff __LF         \
+        lsr     x2, x14, #32 __LF                  \
+        mul     x12, x16, x15 __LF                 \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x12, x12, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x14, x2, x15 __LF                  \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        cset    x11, hs __LF                       \
+        adds    x8, x8, x5 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, x14 __LF                 \
+        add     x0, x11, #1 __LF                   \
+        mul     x3, x16, x0 __LF                   \
+        lsr     x4, x0, #32 __LF                   \
+        adds    x3, x3, x0, lsl #32 __LF           \
+        adc     x4, xzr, x4 __LF                   \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x1, pconst, xzr, lo __LF           \
+        subs    x7, x7, x1 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1 except for
 // re-use of the pconst register for the constant 4294968273
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, lo;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, lo;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x16, #977;                      \
-        mul     x10, pconst, x6;                \
-        umulh   x13, pconst, x6;                \
-        and     x6, x7, #0xffffffff;            \
-        lsr     x7, x7, #32;                    \
-        mul     x11, x16, x6;                   \
-        madd    x6, x16, x7, x6;                \
-        adds    x11, x11, x6, lsl #32;          \
-        lsr     x6, x6, #32;                    \
-        adc     x14, x7, x6;                    \
-        mul     x12, pconst, x8;                \
-        umulh   x8, pconst, x8;                 \
-        and     x6, x9, #0xffffffff;            \
-        lsr     x7, x9, #32;                    \
-        mul     x9, x16, x6;                    \
-        madd    x6, x16, x7, x6;                \
-        adds    x9, x9, x6, lsl #32;            \
-        lsr     x6, x6, #32;                    \
-        adc     x15, x7, x6;                    \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adcs    x5, x5, x9;                     \
-        cset    x6, hs;                         \
-        adds    x3, x3, x13;                    \
-        adcs    x4, x4, x14;                    \
-        adcs    x5, x5, x8;                     \
-        adc     x6, x6, x15;                    \
-        add     x6, x6, #1;                     \
-        mul     x10, x16, x6;                   \
-        lsr     x11, x6, #32;                   \
-        adds    x10, x10, x6, lsl #32;          \
-        adc     x11, xzr, x11;                  \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csel    x16, pconst, xzr, lo;           \
-        subs    x2, x2, x16;                    \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, xzr;                    \
-        sbc     x5, x5, xzr;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, lo __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, lo __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x16, #977 __LF                     \
+        mul     x10, pconst, x6 __LF               \
+        umulh   x13, pconst, x6 __LF               \
+        and     x6, x7, #0xffffffff __LF           \
+        lsr     x7, x7, #32 __LF                   \
+        mul     x11, x16, x6 __LF                  \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x11, x11, x6, lsl #32 __LF         \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x14, x7, x6 __LF                   \
+        mul     x12, pconst, x8 __LF               \
+        umulh   x8, pconst, x8 __LF                \
+        and     x6, x9, #0xffffffff __LF           \
+        lsr     x7, x9, #32 __LF                   \
+        mul     x9, x16, x6 __LF                   \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x9, x9, x6, lsl #32 __LF           \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x15, x7, x6 __LF                   \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adcs    x5, x5, x9 __LF                    \
+        cset    x6, hs __LF                        \
+        adds    x3, x3, x13 __LF                   \
+        adcs    x4, x4, x14 __LF                   \
+        adcs    x5, x5, x8 __LF                    \
+        adc     x6, x6, x15 __LF                   \
+        add     x6, x6, #1 __LF                    \
+        mul     x10, x16, x6 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        adds    x10, x10, x6, lsl #32 __LF         \
+        adc     x11, xzr, x11 __LF                 \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csel    x16, pconst, xzr, lo __LF          \
+        subs    x2, x2, x16 __LF                   \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, xzr __LF                   \
+        sbc     x5, x5, xzr __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256k1
 
 #define sub_p256k1(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #0x3d1;                     \
-        orr     x3, x4, #0x100000000;           \
-        csel    x3, x3, xzr, cc;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #0x3d1 __LF                    \
+        orr     x3, x4, #0x100000000 __LF          \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jadd):

--- a/arm/secp256k1/secp256k1_jadd_alt.S
+++ b/arm/secp256k1/secp256k1_jadd_alt.S
@@ -80,208 +80,208 @@
 // Corresponds exactly to bignum_mul_p256k1_alt
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x3d1;                     \
-        orr     x7, x7, #0x100000000;           \
-        mul     x11, x7, x1;                    \
-        umulh   x9, x7, x1;                     \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x0, x0, x11;                    \
-        cset    x1, cs;                         \
-        adds    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x0, x0, x4;                     \
-        adc     x1, x1, x5;                     \
-        add     x8, x1, #0x1;                   \
-        mul     x11, x7, x8;                    \
-        umulh   x9, x7, x8;                     \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, xzr;                  \
-        adcs    x0, x0, xzr;                    \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x0, x0, xzr;                    \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x3d1 __LF                    \
+        orr     x7, x7, #0x100000000 __LF          \
+        mul     x11, x7, x1 __LF                   \
+        umulh   x9, x7, x1 __LF                    \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x0, x0, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        adds    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x0, x0, x4 __LF                    \
+        adc     x1, x1, x5 __LF                    \
+        add     x8, x1, #0x1 __LF                  \
+        mul     x11, x7, x8 __LF                   \
+        umulh   x9, x7, x8 __LF                    \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adcs    x0, x0, xzr __LF                   \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x0, x0, xzr __LF                   \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1_alt
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x3d1;                     \
-        orr     x3, x3, #0x100000000;           \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        add     x2, x12, #0x1;                  \
-        mul     x7, x3, x2;                     \
-        umulh   x6, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, xzr;                  \
-        adcs    x11, x11, xzr;                  \
-        csel    x3, x3, xzr, cc;                \
-        subs    x8, x8, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x3d1 __LF                    \
+        orr     x3, x3, #0x100000000 __LF          \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        add     x2, x12, #0x1 __LF                 \
+        mul     x7, x3, x2 __LF                    \
+        umulh   x6, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, xzr __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256k1
 
 #define sub_p256k1(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #0x3d1;                     \
-        orr     x3, x4, #0x100000000;           \
-        csel    x3, x3, xzr, cc;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #0x3d1 __LF                    \
+        orr     x3, x4, #0x100000000 __LF          \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jadd_alt):

--- a/arm/secp256k1/secp256k1_jdouble.S
+++ b/arm/secp256k1/secp256k1_jdouble.S
@@ -671,7 +671,7 @@
         mul     x13, x13, x10 __LF                 \
         adc     x9, x4, x13 __LF                   \
         orr     x9, x9, #0x10000000000 __LF        \
-        /* [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
+        /* [x9; x3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
         mov     x10, D __LF                        \
         ldp     x13, x14, [P2] __LF                \
         mul     x5, x14, x10 __LF                  \
@@ -692,13 +692,13 @@
         mul     x13, x13, x10 __LF                 \
         adcs    x7, x7, x12 __LF                   \
         adc     x8, x8, x13 __LF                   \
-        /* [x8 __LFx7;x6;x5;x4] = D * P2 + 2^40 * k */ \
+        /* [x8; x7;x6;x5;x4] = D * P2 + 2^40 * k */ \
         subs    x0, x0, x4 __LF                    \
         sbcs    x1, x1, x5 __LF                    \
         sbcs    x2, x2, x6 __LF                    \
         sbcs    x3, x3, x7 __LF                    \
         sbc     x4, x9, x8 __LF                    \
-        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
         add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
         mul     x4, pconst, x10 __LF               \
@@ -739,7 +739,7 @@
         mul     x13, x13, x10 __LF                 \
         adc     x9, x4, x13 __LF                   \
         orr     x9, x9, #0x10000000000 __LF        \
-        /*  [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
+        /*  [x9; x3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
         lsl     x12, pconst, #40 __LF              \
         ldp     x13, x14, [P2] __LF                \
         lsl     x4, x13, #3 __LF                   \
@@ -755,13 +755,13 @@
         adcs    x7, x7, xzr __LF                   \
         extr    x8, x13, x12, #61 __LF             \
         adc     x8, x8, xzr __LF                   \
-        /* [x8 __LFx7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
+        /* [x8; x7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
         subs    x0, x0, x4 __LF                    \
         sbcs    x1, x1, x5 __LF                    \
         sbcs    x2, x2, x6 __LF                    \
         sbcs    x3, x3, x7 __LF                    \
         sbc     x4, x9, x8 __LF                    \
-        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
         add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
         mul     x4, pconst, x10 __LF               \

--- a/arm/secp256k1/secp256k1_jdouble.S
+++ b/arm/secp256k1/secp256k1_jdouble.S
@@ -62,589 +62,589 @@
 // re-use of the pconst register for the constant 4294968273
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x7, x3, x5;                     \
-        umulh   x8, x3, x5;                     \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        mul     x11, x3, x5;                    \
-        umulh   x12, x3, x5;                    \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, lo;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, lo;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x9, lo;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, lo;                     \
-        cinv    x9, x9, lo;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #1;                         \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x16, #977;                      \
-        mul     x3, pconst, x11;                \
-        umulh   x5, pconst, x11;                \
-        and     x15, x12, #0xffffffff;          \
-        lsr     x2, x12, #32;                   \
-        mul     x4, x16, x15;                   \
-        madd    x15, x16, x2, x15;              \
-        adds    x4, x4, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x6, x2, x15;                    \
-        mul     x11, pconst, x13;               \
-        umulh   x13, pconst, x13;               \
-        and     x15, x14, #0xffffffff;          \
-        lsr     x2, x14, #32;                   \
-        mul     x12, x16, x15;                  \
-        madd    x15, x16, x2, x15;              \
-        adds    x12, x12, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x14, x2, x15;                   \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        cset    x11, hs;                        \
-        adds    x8, x8, x5;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, x14;                  \
-        add     x0, x11, #1;                    \
-        mul     x3, x16, x0;                    \
-        lsr     x4, x0, #32;                    \
-        adds    x3, x3, x0, lsl #32;            \
-        adc     x4, xzr, x4;                    \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        csel    x1, pconst, xzr, lo;            \
-        subs    x7, x7, x1;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x8, x3, x5 __LF                    \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        umulh   x12, x3, x5 __LF                   \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, lo __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, lo __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x9, lo __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, lo __LF                    \
+        cinv    x9, x9, lo __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #1 __LF                        \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x16, #977 __LF                     \
+        mul     x3, pconst, x11 __LF               \
+        umulh   x5, pconst, x11 __LF               \
+        and     x15, x12, #0xffffffff __LF         \
+        lsr     x2, x12, #32 __LF                  \
+        mul     x4, x16, x15 __LF                  \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x4, x4, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x6, x2, x15 __LF                   \
+        mul     x11, pconst, x13 __LF              \
+        umulh   x13, pconst, x13 __LF              \
+        and     x15, x14, #0xffffffff __LF         \
+        lsr     x2, x14, #32 __LF                  \
+        mul     x12, x16, x15 __LF                 \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x12, x12, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x14, x2, x15 __LF                  \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        cset    x11, hs __LF                       \
+        adds    x8, x8, x5 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, x14 __LF                 \
+        add     x0, x11, #1 __LF                   \
+        mul     x3, x16, x0 __LF                   \
+        lsr     x4, x0, #32 __LF                   \
+        adds    x3, x3, x0, lsl #32 __LF           \
+        adc     x4, xzr, x4 __LF                   \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x1, pconst, xzr, lo __LF           \
+        subs    x7, x7, x1 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1 except for
 // re-use of the pconst register for the constant 4294968273
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, lo;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, lo;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x16, #977;                      \
-        mul     x10, pconst, x6;                \
-        umulh   x13, pconst, x6;                \
-        and     x6, x7, #0xffffffff;            \
-        lsr     x7, x7, #32;                    \
-        mul     x11, x16, x6;                   \
-        madd    x6, x16, x7, x6;                \
-        adds    x11, x11, x6, lsl #32;          \
-        lsr     x6, x6, #32;                    \
-        adc     x14, x7, x6;                    \
-        mul     x12, pconst, x8;                \
-        umulh   x8, pconst, x8;                 \
-        and     x6, x9, #0xffffffff;            \
-        lsr     x7, x9, #32;                    \
-        mul     x9, x16, x6;                    \
-        madd    x6, x16, x7, x6;                \
-        adds    x9, x9, x6, lsl #32;            \
-        lsr     x6, x6, #32;                    \
-        adc     x15, x7, x6;                    \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adcs    x5, x5, x9;                     \
-        cset    x6, hs;                         \
-        adds    x3, x3, x13;                    \
-        adcs    x4, x4, x14;                    \
-        adcs    x5, x5, x8;                     \
-        adc     x6, x6, x15;                    \
-        add     x6, x6, #1;                     \
-        mul     x10, x16, x6;                   \
-        lsr     x11, x6, #32;                   \
-        adds    x10, x10, x6, lsl #32;          \
-        adc     x11, xzr, x11;                  \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csel    x16, pconst, xzr, lo;           \
-        subs    x2, x2, x16;                    \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, xzr;                    \
-        sbc     x5, x5, xzr;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, lo __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, lo __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x16, #977 __LF                     \
+        mul     x10, pconst, x6 __LF               \
+        umulh   x13, pconst, x6 __LF               \
+        and     x6, x7, #0xffffffff __LF           \
+        lsr     x7, x7, #32 __LF                   \
+        mul     x11, x16, x6 __LF                  \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x11, x11, x6, lsl #32 __LF         \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x14, x7, x6 __LF                   \
+        mul     x12, pconst, x8 __LF               \
+        umulh   x8, pconst, x8 __LF                \
+        and     x6, x9, #0xffffffff __LF           \
+        lsr     x7, x9, #32 __LF                   \
+        mul     x9, x16, x6 __LF                   \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x9, x9, x6, lsl #32 __LF           \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x15, x7, x6 __LF                   \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adcs    x5, x5, x9 __LF                    \
+        cset    x6, hs __LF                        \
+        adds    x3, x3, x13 __LF                   \
+        adcs    x4, x4, x14 __LF                   \
+        adcs    x5, x5, x8 __LF                    \
+        adc     x6, x6, x15 __LF                   \
+        add     x6, x6, #1 __LF                    \
+        mul     x10, x16, x6 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        adds    x10, x10, x6, lsl #32 __LF         \
+        adc     x11, xzr, x11 __LF                 \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csel    x16, pconst, xzr, lo __LF          \
+        subs    x2, x2, x16 __LF                   \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, xzr __LF                   \
+        sbc     x5, x5, xzr __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Rough versions producing 5-word results
 
 #define roughmul_p256k1(P0,P1,P2)               \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x7, x3, x5;                     \
-        umulh   x8, x3, x5;                     \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        mul     x11, x3, x5;                    \
-        umulh   x12, x3, x5;                    \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, lo;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, lo;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x9, lo;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, lo;                     \
-        cinv    x9, x9, lo;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #1;                         \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x16, #977;                      \
-        mul     x3, pconst, x11;                \
-        umulh   x5, pconst, x11;                \
-        and     x15, x12, #0xffffffff;          \
-        lsr     x2, x12, #32;                   \
-        mul     x4, x16, x15;                   \
-        madd    x15, x16, x2, x15;              \
-        adds    x4, x4, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x6, x2, x15;                    \
-        mul     x11, pconst, x13;               \
-        umulh   x13, pconst, x13;               \
-        and     x15, x14, #0xffffffff;          \
-        lsr     x2, x14, #32;                   \
-        mul     x12, x16, x15;                  \
-        madd    x15, x16, x2, x15;              \
-        adds    x12, x12, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x14, x2, x15;                   \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        cset    x11, hs;                        \
-        adds    x8, x8, x5;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, x14;                  \
-        stp     x7, x8, [P0];                   \
-        stp     x9, x10, [P0+16];               \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x8, x3, x5 __LF                    \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        umulh   x12, x3, x5 __LF                   \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, lo __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, lo __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x9, lo __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, lo __LF                    \
+        cinv    x9, x9, lo __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #1 __LF                        \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x16, #977 __LF                     \
+        mul     x3, pconst, x11 __LF               \
+        umulh   x5, pconst, x11 __LF               \
+        and     x15, x12, #0xffffffff __LF         \
+        lsr     x2, x12, #32 __LF                  \
+        mul     x4, x16, x15 __LF                  \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x4, x4, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x6, x2, x15 __LF                   \
+        mul     x11, pconst, x13 __LF              \
+        umulh   x13, pconst, x13 __LF              \
+        and     x15, x14, #0xffffffff __LF         \
+        lsr     x2, x14, #32 __LF                  \
+        mul     x12, x16, x15 __LF                 \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x12, x12, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x14, x2, x15 __LF                  \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        cset    x11, hs __LF                       \
+        adds    x8, x8, x5 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, x14 __LF                 \
+        stp     x7, x8, [P0] __LF                  \
+        stp     x9, x10, [P0+16] __LF              \
         str     x11, [P0+32]
 
 #define roughsqr_p256k1(P0,P1)                  \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, lo;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, lo;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x16, #977;                      \
-        mul     x10, pconst, x6;                \
-        umulh   x13, pconst, x6;                \
-        and     x6, x7, #0xffffffff;            \
-        lsr     x7, x7, #32;                    \
-        mul     x11, x16, x6;                   \
-        madd    x6, x16, x7, x6;                \
-        adds    x11, x11, x6, lsl #32;          \
-        lsr     x6, x6, #32;                    \
-        adc     x14, x7, x6;                    \
-        mul     x12, pconst, x8;                \
-        umulh   x8, pconst, x8;                 \
-        and     x6, x9, #0xffffffff;            \
-        lsr     x7, x9, #32;                    \
-        mul     x9, x16, x6;                    \
-        madd    x6, x16, x7, x6;                \
-        adds    x9, x9, x6, lsl #32;            \
-        lsr     x6, x6, #32;                    \
-        adc     x15, x7, x6;                    \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adcs    x5, x5, x9;                     \
-        cset    x6, hs;                         \
-        adds    x3, x3, x13;                    \
-        adcs    x4, x4, x14;                    \
-        adcs    x5, x5, x8;                     \
-        adc     x6, x6, x15;                    \
-        stp     x2, x3, [P0];                   \
-        stp     x4, x5, [P0+16];                \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, lo __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, lo __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x16, #977 __LF                     \
+        mul     x10, pconst, x6 __LF               \
+        umulh   x13, pconst, x6 __LF               \
+        and     x6, x7, #0xffffffff __LF           \
+        lsr     x7, x7, #32 __LF                   \
+        mul     x11, x16, x6 __LF                  \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x11, x11, x6, lsl #32 __LF         \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x14, x7, x6 __LF                   \
+        mul     x12, pconst, x8 __LF               \
+        umulh   x8, pconst, x8 __LF                \
+        and     x6, x9, #0xffffffff __LF           \
+        lsr     x7, x9, #32 __LF                   \
+        mul     x9, x16, x6 __LF                   \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x9, x9, x6, lsl #32 __LF           \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x15, x7, x6 __LF                   \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adcs    x5, x5, x9 __LF                    \
+        cset    x6, hs __LF                        \
+        adds    x3, x3, x13 __LF                   \
+        adcs    x4, x4, x14 __LF                   \
+        adcs    x5, x5, x8 __LF                    \
+        adc     x6, x6, x15 __LF                   \
+        stp     x2, x3, [P0] __LF                  \
+        stp     x4, x5, [P0+16] __LF               \
         str     x6, [P0+32]
 
 // Weak doubling operation, staying in 4 digits but not in general
 // fully normalizing modulo p_256k1
 
 #define weakdouble_p256k1(P0,P1)                \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #1;                     \
-        ldp     x3, x4, [P1+16];                \
-        ands    xzr, x4, #0x8000000000000000;   \
-        csel    x5, pconst, xzr, ne;            \
-        extr    x1, x2, x1, #63;                \
-        adds    x0, x0, x5;                     \
-        extr    x2, x3, x2, #63;                \
-        adcs    x1, x1, xzr;                    \
-        extr    x3, x4, x3, #63;                \
-        adcs    x2, x2, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        adc     x3, x3, xzr;                    \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #1 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        ands    xzr, x4, #0x8000000000000000 __LF  \
+        csel    x5, pconst, xzr, ne __LF           \
+        extr    x1, x2, x1, #63 __LF               \
+        adds    x0, x0, x5 __LF                    \
+        extr    x2, x3, x2, #63 __LF               \
+        adcs    x1, x1, xzr __LF                   \
+        extr    x3, x4, x3, #63 __LF               \
+        adcs    x2, x2, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        adc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = C * P1 - D * P2 with 5-word inputs P1 and P2
@@ -653,67 +653,67 @@
 // where p_256k1 = 2^256 - k (so k = 4294968273)
 
 #define cmsub_p256k1(P0,C,P1,D,P2)              \
-        mov     x10, C;                         \
-        ldp     x4, x5, [P1];                   \
-        mul     x0, x4, x10;                    \
-        mul     x1, x5, x10;                    \
-        ldp     x6, x7, [P1+16];                \
-        mul     x2, x6, x10;                    \
-        mul     x3, x7, x10;                    \
-        ldr     x13, [P1+32];                   \
-        umulh   x4, x4, x10;                    \
-        adds    x1, x1, x4;                     \
-        umulh   x5, x5, x10;                    \
-        adcs    x2, x2, x5;                     \
-        umulh   x6, x6, x10;                    \
-        adcs    x3, x3, x6;                     \
-        umulh   x4, x7, x10;                    \
-        mul     x13, x13, x10;                  \
-        adc     x9, x4, x13;                    \
-        orr     x9, x9, #0x10000000000;         \
-        /* [x9; x3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
-        mov     x10, D;                         \
-        ldp     x13, x14, [P2];                 \
-        mul     x5, x14, x10;                   \
-        umulh   x6, x14, x10;                   \
-        adds    x5, x5, pconst, lsr #24;        \
-        adc     x6, x6, xzr;                    \
-        mul     x4, x13, x10;                   \
-        adds    x4, x4, pconst, lsl #40;        \
-        umulh   x13, x13, x10;                  \
-        adcs    x5, x5, x13;                    \
-        ldp     x13, x14, [P2+16];              \
-        mul     x12, x13, x10;                  \
-        umulh   x7, x13, x10;                   \
-        ldr     x13, [P2+32];                   \
-        adcs    x6, x6, x12;                    \
-        mul     x12, x14, x10;                  \
-        umulh   x8, x14, x10;                   \
-        mul     x13, x13, x10;                  \
-        adcs    x7, x7, x12;                    \
-        adc     x8, x8, x13;                    \
-        /* [x8; x7;x6;x5;x4] = D * P2 + 2^40 * k */ \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, x5;                     \
-        sbcs    x2, x2, x6;                     \
-        sbcs    x3, x3, x7;                     \
-        sbc     x4, x9, x8;                     \
-        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
-        add     x10, x4, #1;                    \
+        mov     x10, C __LF                        \
+        ldp     x4, x5, [P1] __LF                  \
+        mul     x0, x4, x10 __LF                   \
+        mul     x1, x5, x10 __LF                   \
+        ldp     x6, x7, [P1+16] __LF               \
+        mul     x2, x6, x10 __LF                   \
+        mul     x3, x7, x10 __LF                   \
+        ldr     x13, [P1+32] __LF                  \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x1, x1, x4 __LF                    \
+        umulh   x5, x5, x10 __LF                   \
+        adcs    x2, x2, x5 __LF                    \
+        umulh   x6, x6, x10 __LF                   \
+        adcs    x3, x3, x6 __LF                    \
+        umulh   x4, x7, x10 __LF                   \
+        mul     x13, x13, x10 __LF                 \
+        adc     x9, x4, x13 __LF                   \
+        orr     x9, x9, #0x10000000000 __LF        \
+        /* [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
+        mov     x10, D __LF                        \
+        ldp     x13, x14, [P2] __LF                \
+        mul     x5, x14, x10 __LF                  \
+        umulh   x6, x14, x10 __LF                  \
+        adds    x5, x5, pconst, lsr #24 __LF       \
+        adc     x6, x6, xzr __LF                   \
+        mul     x4, x13, x10 __LF                  \
+        adds    x4, x4, pconst, lsl #40 __LF       \
+        umulh   x13, x13, x10 __LF                 \
+        adcs    x5, x5, x13 __LF                   \
+        ldp     x13, x14, [P2+16] __LF             \
+        mul     x12, x13, x10 __LF                 \
+        umulh   x7, x13, x10 __LF                  \
+        ldr     x13, [P2+32] __LF                  \
+        adcs    x6, x6, x12 __LF                   \
+        mul     x12, x14, x10 __LF                 \
+        umulh   x8, x14, x10 __LF                  \
+        mul     x13, x13, x10 __LF                 \
+        adcs    x7, x7, x12 __LF                   \
+        adc     x8, x8, x13 __LF                   \
+        /* [x8 __LFx7;x6;x5;x4] = D * P2 + 2^40 * k */ \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, x5 __LF                    \
+        sbcs    x2, x2, x6 __LF                    \
+        sbcs    x3, x3, x7 __LF                    \
+        sbc     x4, x9, x8 __LF                    \
+        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x10;                \
-        umulh   x5, pconst, x10;                \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x11, pconst, xzr, cc;           \
+        mul     x4, pconst, x10 __LF               \
+        umulh   x5, pconst, x10 __LF               \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x11, pconst, xzr, cc __LF          \
         /* If un-correction needed */           \
-        subs    x0, x0, x11;                    \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x11 __LF                   \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2 with 5-digit P1 and P2
@@ -721,62 +721,62 @@
 // where p_256k1 = 2^256 - k (so k = 4294968273)
 
 #define cmsub38_p256k1(P0,P1,P2)                \
-        mov     x10, #3;                        \
-        ldp     x4, x5, [P1];                   \
-        mul     x0, x4, x10;                    \
-        mul     x1, x5, x10;                    \
-        ldp     x6, x7, [P1+16];                \
-        mul     x2, x6, x10;                    \
-        mul     x3, x7, x10;                    \
-        ldr     x13, [P1+32];                   \
-        umulh   x4, x4, x10;                    \
-        adds    x1, x1, x4;                     \
-        umulh   x5, x5, x10;                    \
-        adcs    x2, x2, x5;                     \
-        umulh   x6, x6, x10;                    \
-        adcs    x3, x3, x6;                     \
-        umulh   x4, x7, x10;                    \
-        mul     x13, x13, x10;                  \
-        adc     x9, x4, x13;                    \
-        orr     x9, x9, #0x10000000000;         \
-        /*  [x9; x3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
-        lsl     x12, pconst, #40;               \
-        ldp     x13, x14, [P2];                 \
-        lsl     x4, x13, #3;                    \
-        adds    x4, x4, x12;                    \
-        extr    x5, x14, x13, #61;              \
-        lsr     x12, pconst, #24;               \
-        adcs    x5, x5, x12;                    \
-        ldp     x11, x12, [P2+16];              \
-        extr    x6, x11, x14, #61;              \
-        adcs    x6, x6, xzr;                    \
-        ldr     x13, [P2+32];                   \
-        extr    x7, x12, x11, #61;              \
-        adcs    x7, x7, xzr;                    \
-        extr    x8, x13, x12, #61;              \
-        adc     x8, x8, xzr;                    \
-        /* [x8; x7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, x5;                     \
-        sbcs    x2, x2, x6;                     \
-        sbcs    x3, x3, x7;                     \
-        sbc     x4, x9, x8;                     \
-        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
-        add     x10, x4, #1;                    \
+        mov     x10, #3 __LF                       \
+        ldp     x4, x5, [P1] __LF                  \
+        mul     x0, x4, x10 __LF                   \
+        mul     x1, x5, x10 __LF                   \
+        ldp     x6, x7, [P1+16] __LF               \
+        mul     x2, x6, x10 __LF                   \
+        mul     x3, x7, x10 __LF                   \
+        ldr     x13, [P1+32] __LF                  \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x1, x1, x4 __LF                    \
+        umulh   x5, x5, x10 __LF                   \
+        adcs    x2, x2, x5 __LF                    \
+        umulh   x6, x6, x10 __LF                   \
+        adcs    x3, x3, x6 __LF                    \
+        umulh   x4, x7, x10 __LF                   \
+        mul     x13, x13, x10 __LF                 \
+        adc     x9, x4, x13 __LF                   \
+        orr     x9, x9, #0x10000000000 __LF        \
+        /*  [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
+        lsl     x12, pconst, #40 __LF              \
+        ldp     x13, x14, [P2] __LF                \
+        lsl     x4, x13, #3 __LF                   \
+        adds    x4, x4, x12 __LF                   \
+        extr    x5, x14, x13, #61 __LF             \
+        lsr     x12, pconst, #24 __LF              \
+        adcs    x5, x5, x12 __LF                   \
+        ldp     x11, x12, [P2+16] __LF             \
+        extr    x6, x11, x14, #61 __LF             \
+        adcs    x6, x6, xzr __LF                   \
+        ldr     x13, [P2+32] __LF                  \
+        extr    x7, x12, x11, #61 __LF             \
+        adcs    x7, x7, xzr __LF                   \
+        extr    x8, x13, x12, #61 __LF             \
+        adc     x8, x8, xzr __LF                   \
+        /* [x8 __LFx7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, x5 __LF                    \
+        sbcs    x2, x2, x6 __LF                    \
+        sbcs    x3, x3, x7 __LF                    \
+        sbc     x4, x9, x8 __LF                    \
+        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x10;                \
-        umulh   x5, pconst, x10;                \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x11, pconst, xzr, cc;           \
+        mul     x4, pconst, x10 __LF               \
+        umulh   x5, pconst, x10 __LF               \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x11, pconst, xzr, cc __LF          \
         /*  If un-correction needed */          \
-        subs    x0, x0, x11;                    \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x11 __LF                   \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = 4 * P1 - P2 with 5-digit P1, 4-digit P2 and result.
@@ -786,36 +786,36 @@
 // long as it is  > -p_256k1, which is the case here.
 
 #define cmsub41_p256k1(P0,P1,P2)                \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        ldr     x5, [P1+32];                    \
-        extr    x4, x5, x4, #62;                \
-        sbc     x4, x4, xzr;                    \
-        add     x5, x4, #1;                     \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        ldr     x5, [P1+32] __LF                   \
+        extr    x4, x5, x4, #62 __LF               \
+        sbc     x4, x4, xzr __LF                   \
+        add     x5, x4, #1 __LF                    \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x5;                 \
-        adds    x0, x0, x4;                     \
-        umulh   x5, pconst, x5;                 \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x4, pconst, xzr, cc;            \
+        mul     x4, pconst, x5 __LF                \
+        adds    x0, x0, x4 __LF                    \
+        umulh   x5, pconst, x5 __LF                \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x4, pconst, xzr, cc __LF           \
         /*  If un-correction needed */          \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jdouble):

--- a/arm/secp256k1/secp256k1_jdouble_alt.S
+++ b/arm/secp256k1/secp256k1_jdouble_alt.S
@@ -443,7 +443,7 @@
         mul     x13, x13, x10 __LF                 \
         adc     x9, x4, x13 __LF                   \
         orr     x9, x9, #0x10000000000 __LF        \
-        /* [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
+        /* [x9; x3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
         mov     x10, D __LF                        \
         ldp     x13, x14, [P2] __LF                \
         mul     x5, x14, x10 __LF                  \
@@ -464,13 +464,13 @@
         mul     x13, x13, x10 __LF                 \
         adcs    x7, x7, x12 __LF                   \
         adc     x8, x8, x13 __LF                   \
-        /* [x8 __LFx7;x6;x5;x4] = D * P2 + 2^40 * k */ \
+        /* [x8; x7;x6;x5;x4] = D * P2 + 2^40 * k */ \
         subs    x0, x0, x4 __LF                    \
         sbcs    x1, x1, x5 __LF                    \
         sbcs    x2, x2, x6 __LF                    \
         sbcs    x3, x3, x7 __LF                    \
         sbc     x4, x9, x8 __LF                    \
-        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
         add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
         mul     x4, pconst, x10 __LF               \
@@ -511,7 +511,7 @@
         mul     x13, x13, x10 __LF                 \
         adc     x9, x4, x13 __LF                   \
         orr     x9, x9, #0x10000000000 __LF        \
-        /*  [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
+        /*  [x9; x3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
         lsl     x12, pconst, #40 __LF              \
         ldp     x13, x14, [P2] __LF                \
         lsl     x4, x13, #3 __LF                   \
@@ -527,13 +527,13 @@
         adcs    x7, x7, xzr __LF                   \
         extr    x8, x13, x12, #61 __LF             \
         adc     x8, x8, xzr __LF                   \
-        /* [x8 __LFx7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
+        /* [x8; x7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
         subs    x0, x0, x4 __LF                    \
         sbcs    x1, x1, x5 __LF                    \
         sbcs    x2, x2, x6 __LF                    \
         sbcs    x3, x3, x7 __LF                    \
         sbc     x4, x9, x8 __LF                    \
-        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
         add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
         mul     x4, pconst, x10 __LF               \

--- a/arm/secp256k1/secp256k1_jdouble_alt.S
+++ b/arm/secp256k1/secp256k1_jdouble_alt.S
@@ -62,361 +62,361 @@
 // re-use of the pconst register for the constant 4294968273
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mul     x11, pconst, x1;                \
-        umulh   x9, pconst, x1;                 \
-        adds    x12, x12, x11;                  \
-        mul     x11, pconst, x3;                \
-        umulh   x3, pconst, x3;                 \
-        adcs    x13, x13, x11;                  \
-        mul     x11, pconst, x4;                \
-        umulh   x4, pconst, x4;                 \
-        adcs    x14, x14, x11;                  \
-        mul     x11, pconst, x5;                \
-        umulh   x5, pconst, x5;                 \
-        adcs    x0, x0, x11;                    \
-        cset    x1, cs;                         \
-        adds    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x0, x0, x4;                     \
-        adc     x1, x1, x5;                     \
-        add     x8, x1, #0x1;                   \
-        mul     x11, pconst, x8;                \
-        umulh   x9, pconst, x8;                 \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, xzr;                  \
-        adcs    x0, x0, xzr;                    \
-        csel    x7, pconst, xzr, cc;            \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x0, x0, xzr;                    \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mul     x11, pconst, x1 __LF               \
+        umulh   x9, pconst, x1 __LF                \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, pconst, x3 __LF               \
+        umulh   x3, pconst, x3 __LF                \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, pconst, x4 __LF               \
+        umulh   x4, pconst, x4 __LF                \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, pconst, x5 __LF               \
+        umulh   x5, pconst, x5 __LF                \
+        adcs    x0, x0, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        adds    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x0, x0, x4 __LF                    \
+        adc     x1, x1, x5 __LF                    \
+        add     x8, x1, #0x1 __LF                  \
+        mul     x11, pconst, x8 __LF               \
+        umulh   x9, pconst, x8 __LF                \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adcs    x0, x0, xzr __LF                   \
+        csel    x7, pconst, xzr, cc __LF           \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x0, x0, xzr __LF                   \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1_alt except for
 // re-use of the pconst register for the constant 4294968273
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mul     x7, pconst, x12;                \
-        umulh   x4, pconst, x12;                \
-        adds    x8, x8, x7;                     \
-        mul     x7, pconst, x13;                \
-        umulh   x13, pconst, x13;               \
-        adcs    x9, x9, x7;                     \
-        mul     x7, pconst, x14;                \
-        umulh   x14, pconst, x14;               \
-        adcs    x10, x10, x7;                   \
-        mul     x7, pconst, x6;                 \
-        umulh   x6, pconst, x6;                 \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        add     x2, x12, #0x1;                  \
-        mul     x7, pconst, x2;                 \
-        umulh   x6, pconst, x2;                 \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, xzr;                  \
-        adcs    x11, x11, xzr;                  \
-        csel    x3, pconst, xzr, cc;            \
-        subs    x8, x8, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mul     x7, pconst, x12 __LF               \
+        umulh   x4, pconst, x12 __LF               \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, pconst, x13 __LF               \
+        umulh   x13, pconst, x13 __LF              \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, pconst, x14 __LF               \
+        umulh   x14, pconst, x14 __LF              \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, pconst, x6 __LF                \
+        umulh   x6, pconst, x6 __LF                \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        add     x2, x12, #0x1 __LF                 \
+        mul     x7, pconst, x2 __LF                \
+        umulh   x6, pconst, x2 __LF                \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, xzr __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csel    x3, pconst, xzr, cc __LF           \
+        subs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Rough versions producing 5-word results
 
 #define roughmul_p256k1(P0,P1,P2)               \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mul     x11, pconst, x1;                \
-        umulh   x9, pconst, x1;                 \
-        adds    x12, x12, x11;                  \
-        mul     x11, pconst, x3;                \
-        umulh   x3, pconst, x3;                 \
-        adcs    x13, x13, x11;                  \
-        mul     x11, pconst, x4;                \
-        umulh   x4, pconst, x4;                 \
-        adcs    x14, x14, x11;                  \
-        mul     x11, pconst, x5;                \
-        umulh   x5, pconst, x5;                 \
-        adcs    x0, x0, x11;                    \
-        cset    x1, cs;                         \
-        adds    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x0, x0, x4;                     \
-        adc     x1, x1, x5;                     \
-        stp     x12, x13, [P0];                 \
-        stp     x14, x0, [P0+16];               \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mul     x11, pconst, x1 __LF               \
+        umulh   x9, pconst, x1 __LF                \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, pconst, x3 __LF               \
+        umulh   x3, pconst, x3 __LF                \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, pconst, x4 __LF               \
+        umulh   x4, pconst, x4 __LF                \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, pconst, x5 __LF               \
+        umulh   x5, pconst, x5 __LF                \
+        adcs    x0, x0, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        adds    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x0, x0, x4 __LF                    \
+        adc     x1, x1, x5 __LF                    \
+        stp     x12, x13, [P0] __LF                \
+        stp     x14, x0, [P0+16] __LF              \
         str     x1, [P0+32]
 
 #define roughsqr_p256k1(P0,P1)                  \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mul     x7, pconst, x12;                \
-        umulh   x4, pconst, x12;                \
-        adds    x8, x8, x7;                     \
-        mul     x7, pconst, x13;                \
-        umulh   x13, pconst, x13;               \
-        adcs    x9, x9, x7;                     \
-        mul     x7, pconst, x14;                \
-        umulh   x14, pconst, x14;               \
-        adcs    x10, x10, x7;                   \
-        mul     x7, pconst, x6;                 \
-        umulh   x6, pconst, x6;                 \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        stp     x8, x9, [P0];                   \
-        stp     x10, x11, [P0+16];              \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mul     x7, pconst, x12 __LF               \
+        umulh   x4, pconst, x12 __LF               \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, pconst, x13 __LF               \
+        umulh   x13, pconst, x13 __LF              \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, pconst, x14 __LF               \
+        umulh   x14, pconst, x14 __LF              \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, pconst, x6 __LF                \
+        umulh   x6, pconst, x6 __LF                \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        stp     x8, x9, [P0] __LF                  \
+        stp     x10, x11, [P0+16] __LF             \
         str     x12, [P0+32]
 
 // Weak doubling operation, staying in 4 digits but not in general
 // fully normalizing modulo p_256k1
 
 #define weakdouble_p256k1(P0,P1)                \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #1;                     \
-        ldp     x3, x4, [P1+16];                \
-        ands    xzr, x4, #0x8000000000000000;   \
-        csel    x5, pconst, xzr, ne;            \
-        extr    x1, x2, x1, #63;                \
-        adds    x0, x0, x5;                     \
-        extr    x2, x3, x2, #63;                \
-        adcs    x1, x1, xzr;                    \
-        extr    x3, x4, x3, #63;                \
-        adcs    x2, x2, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        adc     x3, x3, xzr;                    \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #1 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        ands    xzr, x4, #0x8000000000000000 __LF  \
+        csel    x5, pconst, xzr, ne __LF           \
+        extr    x1, x2, x1, #63 __LF               \
+        adds    x0, x0, x5 __LF                    \
+        extr    x2, x3, x2, #63 __LF               \
+        adcs    x1, x1, xzr __LF                   \
+        extr    x3, x4, x3, #63 __LF               \
+        adcs    x2, x2, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        adc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = C * P1 - D * P2 with 5-word inputs P1 and P2
@@ -425,67 +425,67 @@
 // where p_256k1 = 2^256 - k (so k = 4294968273)
 
 #define cmsub_p256k1(P0,C,P1,D,P2)              \
-        mov     x10, C;                         \
-        ldp     x4, x5, [P1];                   \
-        mul     x0, x4, x10;                    \
-        mul     x1, x5, x10;                    \
-        ldp     x6, x7, [P1+16];                \
-        mul     x2, x6, x10;                    \
-        mul     x3, x7, x10;                    \
-        ldr     x13, [P1+32];                   \
-        umulh   x4, x4, x10;                    \
-        adds    x1, x1, x4;                     \
-        umulh   x5, x5, x10;                    \
-        adcs    x2, x2, x5;                     \
-        umulh   x6, x6, x10;                    \
-        adcs    x3, x3, x6;                     \
-        umulh   x4, x7, x10;                    \
-        mul     x13, x13, x10;                  \
-        adc     x9, x4, x13;                    \
-        orr     x9, x9, #0x10000000000;         \
-        /* [x9; x3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
-        mov     x10, D;                         \
-        ldp     x13, x14, [P2];                 \
-        mul     x5, x14, x10;                   \
-        umulh   x6, x14, x10;                   \
-        adds    x5, x5, pconst, lsr #24;        \
-        adc     x6, x6, xzr;                    \
-        mul     x4, x13, x10;                   \
-        adds    x4, x4, pconst, lsl #40;        \
-        umulh   x13, x13, x10;                  \
-        adcs    x5, x5, x13;                    \
-        ldp     x13, x14, [P2+16];              \
-        mul     x12, x13, x10;                  \
-        umulh   x7, x13, x10;                   \
-        ldr     x13, [P2+32];                   \
-        adcs    x6, x6, x12;                    \
-        mul     x12, x14, x10;                  \
-        umulh   x8, x14, x10;                   \
-        mul     x13, x13, x10;                  \
-        adcs    x7, x7, x12;                    \
-        adc     x8, x8, x13;                    \
-        /* [x8; x7;x6;x5;x4] = D * P2 + 2^40 * k */ \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, x5;                     \
-        sbcs    x2, x2, x6;                     \
-        sbcs    x3, x3, x7;                     \
-        sbc     x4, x9, x8;                     \
-        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
-        add     x10, x4, #1;                    \
+        mov     x10, C __LF                        \
+        ldp     x4, x5, [P1] __LF                  \
+        mul     x0, x4, x10 __LF                   \
+        mul     x1, x5, x10 __LF                   \
+        ldp     x6, x7, [P1+16] __LF               \
+        mul     x2, x6, x10 __LF                   \
+        mul     x3, x7, x10 __LF                   \
+        ldr     x13, [P1+32] __LF                  \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x1, x1, x4 __LF                    \
+        umulh   x5, x5, x10 __LF                   \
+        adcs    x2, x2, x5 __LF                    \
+        umulh   x6, x6, x10 __LF                   \
+        adcs    x3, x3, x6 __LF                    \
+        umulh   x4, x7, x10 __LF                   \
+        mul     x13, x13, x10 __LF                 \
+        adc     x9, x4, x13 __LF                   \
+        orr     x9, x9, #0x10000000000 __LF        \
+        /* [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + C * P1 */ \
+        mov     x10, D __LF                        \
+        ldp     x13, x14, [P2] __LF                \
+        mul     x5, x14, x10 __LF                  \
+        umulh   x6, x14, x10 __LF                  \
+        adds    x5, x5, pconst, lsr #24 __LF       \
+        adc     x6, x6, xzr __LF                   \
+        mul     x4, x13, x10 __LF                  \
+        adds    x4, x4, pconst, lsl #40 __LF       \
+        umulh   x13, x13, x10 __LF                 \
+        adcs    x5, x5, x13 __LF                   \
+        ldp     x13, x14, [P2+16] __LF             \
+        mul     x12, x13, x10 __LF                 \
+        umulh   x7, x13, x10 __LF                  \
+        ldr     x13, [P2+32] __LF                  \
+        adcs    x6, x6, x12 __LF                   \
+        mul     x12, x14, x10 __LF                 \
+        umulh   x8, x14, x10 __LF                  \
+        mul     x13, x13, x10 __LF                 \
+        adcs    x7, x7, x12 __LF                   \
+        adc     x8, x8, x13 __LF                   \
+        /* [x8 __LFx7;x6;x5;x4] = D * P2 + 2^40 * k */ \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, x5 __LF                    \
+        sbcs    x2, x2, x6 __LF                    \
+        sbcs    x3, x3, x7 __LF                    \
+        sbc     x4, x9, x8 __LF                    \
+        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x10;                \
-        umulh   x5, pconst, x10;                \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x11, pconst, xzr, cc;           \
+        mul     x4, pconst, x10 __LF               \
+        umulh   x5, pconst, x10 __LF               \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x11, pconst, xzr, cc __LF          \
         /* If un-correction needed */           \
-        subs    x0, x0, x11;                    \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x11 __LF                   \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2 with 5-digit P1 and P2
@@ -493,62 +493,62 @@
 // where p_256k1 = 2^256 - k (so k = 4294968273)
 
 #define cmsub38_p256k1(P0,P1,P2)                \
-        mov     x10, #3;                        \
-        ldp     x4, x5, [P1];                   \
-        mul     x0, x4, x10;                    \
-        mul     x1, x5, x10;                    \
-        ldp     x6, x7, [P1+16];                \
-        mul     x2, x6, x10;                    \
-        mul     x3, x7, x10;                    \
-        ldr     x13, [P1+32];                   \
-        umulh   x4, x4, x10;                    \
-        adds    x1, x1, x4;                     \
-        umulh   x5, x5, x10;                    \
-        adcs    x2, x2, x5;                     \
-        umulh   x6, x6, x10;                    \
-        adcs    x3, x3, x6;                     \
-        umulh   x4, x7, x10;                    \
-        mul     x13, x13, x10;                  \
-        adc     x9, x4, x13;                    \
-        orr     x9, x9, #0x10000000000;         \
-        /*  [x9; x3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
-        lsl     x12, pconst, #40;               \
-        ldp     x13, x14, [P2];                 \
-        lsl     x4, x13, #3;                    \
-        adds    x4, x4, x12;                    \
-        extr    x5, x14, x13, #61;              \
-        lsr     x12, pconst, #24;               \
-        adcs    x5, x5, x12;                    \
-        ldp     x11, x12, [P2+16];              \
-        extr    x6, x11, x14, #61;              \
-        adcs    x6, x6, xzr;                    \
-        ldr     x13, [P2+32];                   \
-        extr    x7, x12, x11, #61;              \
-        adcs    x7, x7, xzr;                    \
-        extr    x8, x13, x12, #61;              \
-        adc     x8, x8, xzr;                    \
-        /* [x8; x7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, x5;                     \
-        sbcs    x2, x2, x6;                     \
-        sbcs    x3, x3, x7;                     \
-        sbc     x4, x9, x8;                     \
-        /* [x4; x3;x2;x1;x0] = 2^40*p_256k1+result */ \
-        add     x10, x4, #1;                    \
+        mov     x10, #3 __LF                       \
+        ldp     x4, x5, [P1] __LF                  \
+        mul     x0, x4, x10 __LF                   \
+        mul     x1, x5, x10 __LF                   \
+        ldp     x6, x7, [P1+16] __LF               \
+        mul     x2, x6, x10 __LF                   \
+        mul     x3, x7, x10 __LF                   \
+        ldr     x13, [P1+32] __LF                  \
+        umulh   x4, x4, x10 __LF                   \
+        adds    x1, x1, x4 __LF                    \
+        umulh   x5, x5, x10 __LF                   \
+        adcs    x2, x2, x5 __LF                    \
+        umulh   x6, x6, x10 __LF                   \
+        adcs    x3, x3, x6 __LF                    \
+        umulh   x4, x7, x10 __LF                   \
+        mul     x13, x13, x10 __LF                 \
+        adc     x9, x4, x13 __LF                   \
+        orr     x9, x9, #0x10000000000 __LF        \
+        /*  [x9 __LFx3;x2;x1;x0] = 2^40 * 2^256 + 3 * P1 */ \
+        lsl     x12, pconst, #40 __LF              \
+        ldp     x13, x14, [P2] __LF                \
+        lsl     x4, x13, #3 __LF                   \
+        adds    x4, x4, x12 __LF                   \
+        extr    x5, x14, x13, #61 __LF             \
+        lsr     x12, pconst, #24 __LF              \
+        adcs    x5, x5, x12 __LF                   \
+        ldp     x11, x12, [P2+16] __LF             \
+        extr    x6, x11, x14, #61 __LF             \
+        adcs    x6, x6, xzr __LF                   \
+        ldr     x13, [P2+32] __LF                  \
+        extr    x7, x12, x11, #61 __LF             \
+        adcs    x7, x7, xzr __LF                   \
+        extr    x8, x13, x12, #61 __LF             \
+        adc     x8, x8, xzr __LF                   \
+        /* [x8 __LFx7;x6;x5;x4] = 8 * P2 + 2^40 * k */ \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, x5 __LF                    \
+        sbcs    x2, x2, x6 __LF                    \
+        sbcs    x3, x3, x7 __LF                    \
+        sbc     x4, x9, x8 __LF                    \
+        /* [x4 __LFx3;x2;x1;x0] = 2^40*p_256k1+result */ \
+        add     x10, x4, #1 __LF                   \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x10;                \
-        umulh   x5, pconst, x10;                \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x11, pconst, xzr, cc;           \
+        mul     x4, pconst, x10 __LF               \
+        umulh   x5, pconst, x10 __LF               \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x11, pconst, xzr, cc __LF          \
         /*  If un-correction needed */          \
-        subs    x0, x0, x11;                    \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x11 __LF                   \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 // P0 = 4 * P1 - P2 with 5-digit P1, 4-digit P2 and result.
@@ -558,36 +558,36 @@
 // long as it is  > -p_256k1, which is the case here.
 
 #define cmsub41_p256k1(P0,P1,P2)                \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        ldr     x5, [P1+32];                    \
-        extr    x4, x5, x4, #62;                \
-        sbc     x4, x4, xzr;                    \
-        add     x5, x4, #1;                     \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        ldr     x5, [P1+32] __LF                   \
+        extr    x4, x5, x4, #62 __LF               \
+        sbc     x4, x4, xzr __LF                   \
+        add     x5, x4, #1 __LF                    \
         /* (h + 1) is quotient estimate */      \
-        mul     x4, pconst, x5;                 \
-        adds    x0, x0, x4;                     \
-        umulh   x5, pconst, x5;                 \
-        adcs    x1, x1, x5;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, xzr;                    \
-        csel    x4, pconst, xzr, cc;            \
+        mul     x4, pconst, x5 __LF                \
+        adds    x0, x0, x4 __LF                    \
+        umulh   x5, pconst, x5 __LF                \
+        adcs    x1, x1, x5 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, xzr __LF                   \
+        csel    x4, pconst, xzr, cc __LF           \
         /*  If un-correction needed */          \
-        subs    x0, x0, x4;                     \
-        sbcs    x1, x1, xzr;                    \
-        stp     x0, x1, [P0];                   \
-        sbcs    x2, x2, xzr;                    \
-        sbc     x3, x3, xzr;                    \
+        subs    x0, x0, x4 __LF                    \
+        sbcs    x1, x1, xzr __LF                   \
+        stp     x0, x1, [P0] __LF                  \
+        sbcs    x2, x2, xzr __LF                   \
+        sbc     x3, x3, xzr __LF                   \
         stp     x2, x3, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jdouble_alt):

--- a/arm/secp256k1/secp256k1_jmixadd.S
+++ b/arm/secp256k1/secp256k1_jmixadd.S
@@ -82,321 +82,321 @@
 // re-use of the pconst register for the constant 4294968273
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P2];                   \
-        mul     x7, x3, x5;                     \
-        umulh   x8, x3, x5;                     \
-        mul     x9, x4, x6;                     \
-        umulh   x10, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x9, x9, x8;                     \
-        adc     x10, x10, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x8, x7, x9;                     \
-        adcs    x9, x9, x10;                    \
-        adc     x10, x10, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x8, x15, x8;                    \
-        eor     x3, x3, x16;                    \
-        adcs    x9, x3, x9;                     \
-        adc     x10, x10, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x5, x6, [P2+16];                \
-        mul     x11, x3, x5;                    \
-        umulh   x12, x3, x5;                    \
-        mul     x13, x4, x6;                    \
-        umulh   x14, x4, x6;                    \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x16, lo;                        \
-        adds    x13, x13, x12;                  \
-        adc     x14, x14, xzr;                  \
-        subs    x3, x5, x6;                     \
-        cneg    x3, x3, lo;                     \
-        cinv    x16, x16, lo;                   \
-        mul     x15, x4, x3;                    \
-        umulh   x3, x4, x3;                     \
-        adds    x12, x11, x13;                  \
-        adcs    x13, x13, x14;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x15, x15, x16;                  \
-        adcs    x12, x15, x12;                  \
-        eor     x3, x3, x16;                    \
-        adcs    x13, x3, x13;                   \
-        adc     x14, x14, x16;                  \
-        ldp     x3, x4, [P1+16];                \
-        ldp     x15, x16, [P1];                 \
-        subs    x3, x3, x15;                    \
-        sbcs    x4, x4, x16;                    \
-        csetm   x16, lo;                        \
-        ldp     x15, x0, [P2];                  \
-        subs    x5, x15, x5;                    \
-        sbcs    x6, x0, x6;                     \
-        csetm   x0, lo;                         \
-        eor     x3, x3, x16;                    \
-        subs    x3, x3, x16;                    \
-        eor     x4, x4, x16;                    \
-        sbc     x4, x4, x16;                    \
-        eor     x5, x5, x0;                     \
-        subs    x5, x5, x0;                     \
-        eor     x6, x6, x0;                     \
-        sbc     x6, x6, x0;                     \
-        eor     x16, x0, x16;                   \
-        adds    x11, x11, x9;                   \
-        adcs    x12, x12, x10;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        mul     x2, x3, x5;                     \
-        umulh   x0, x3, x5;                     \
-        mul     x15, x4, x6;                    \
-        umulh   x1, x4, x6;                     \
-        subs    x4, x4, x3;                     \
-        cneg    x4, x4, lo;                     \
-        csetm   x9, lo;                         \
-        adds    x15, x15, x0;                   \
-        adc     x1, x1, xzr;                    \
-        subs    x6, x5, x6;                     \
-        cneg    x6, x6, lo;                     \
-        cinv    x9, x9, lo;                     \
-        mul     x5, x4, x6;                     \
-        umulh   x6, x4, x6;                     \
-        adds    x0, x2, x15;                    \
-        adcs    x15, x15, x1;                   \
-        adc     x1, x1, xzr;                    \
-        cmn     x9, #1;                         \
-        eor     x5, x5, x9;                     \
-        adcs    x0, x5, x0;                     \
-        eor     x6, x6, x9;                     \
-        adcs    x15, x6, x15;                   \
-        adc     x1, x1, x9;                     \
-        adds    x9, x11, x7;                    \
-        adcs    x10, x12, x8;                   \
-        adcs    x11, x13, x11;                  \
-        adcs    x12, x14, x12;                  \
-        adcs    x13, x13, xzr;                  \
-        adc     x14, x14, xzr;                  \
-        cmn     x16, #1;                        \
-        eor     x2, x2, x16;                    \
-        adcs    x9, x2, x9;                     \
-        eor     x0, x0, x16;                    \
-        adcs    x10, x0, x10;                   \
-        eor     x15, x15, x16;                  \
-        adcs    x11, x15, x11;                  \
-        eor     x1, x1, x16;                    \
-        adcs    x12, x1, x12;                   \
-        adcs    x13, x13, x16;                  \
-        adc     x14, x14, x16;                  \
-        mov     x16, #977;                      \
-        mul     x3, pconst, x11;                \
-        umulh   x5, pconst, x11;                \
-        and     x15, x12, #0xffffffff;          \
-        lsr     x2, x12, #32;                   \
-        mul     x4, x16, x15;                   \
-        madd    x15, x16, x2, x15;              \
-        adds    x4, x4, x15, lsl #32;           \
-        lsr     x15, x15, #32;                  \
-        adc     x6, x2, x15;                    \
-        mul     x11, pconst, x13;               \
-        umulh   x13, pconst, x13;               \
-        and     x15, x14, #0xffffffff;          \
-        lsr     x2, x14, #32;                   \
-        mul     x12, x16, x15;                  \
-        madd    x15, x16, x2, x15;              \
-        adds    x12, x12, x15, lsl #32;         \
-        lsr     x15, x15, #32;                  \
-        adc     x14, x2, x15;                   \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        cset    x11, hs;                        \
-        adds    x8, x8, x5;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, x13;                  \
-        adc     x11, x11, x14;                  \
-        add     x0, x11, #1;                    \
-        mul     x3, x16, x0;                    \
-        lsr     x4, x0, #32;                    \
-        adds    x3, x3, x0, lsl #32;            \
-        adc     x4, xzr, x4;                    \
-        adds    x7, x7, x3;                     \
-        adcs    x8, x8, x4;                     \
-        adcs    x9, x9, xzr;                    \
-        adcs    x10, x10, xzr;                  \
-        csel    x1, pconst, xzr, lo;            \
-        subs    x7, x7, x1;                     \
-        sbcs    x8, x8, xzr;                    \
-        sbcs    x9, x9, xzr;                    \
-        sbc     x10, x10, xzr;                  \
-        stp     x7, x8, [P0];                   \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P2] __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x8, x3, x5 __LF                    \
+        mul     x9, x4, x6 __LF                    \
+        umulh   x10, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x9, x9, x8 __LF                    \
+        adc     x10, x10, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x8, x7, x9 __LF                    \
+        adcs    x9, x9, x10 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x8, x15, x8 __LF                   \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x9, x3, x9 __LF                    \
+        adc     x10, x10, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x5, x6, [P2+16] __LF               \
+        mul     x11, x3, x5 __LF                   \
+        umulh   x12, x3, x5 __LF                   \
+        mul     x13, x4, x6 __LF                   \
+        umulh   x14, x4, x6 __LF                   \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x16, lo __LF                       \
+        adds    x13, x13, x12 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        subs    x3, x5, x6 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        cinv    x16, x16, lo __LF                  \
+        mul     x15, x4, x3 __LF                   \
+        umulh   x3, x4, x3 __LF                    \
+        adds    x12, x11, x13 __LF                 \
+        adcs    x13, x13, x14 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x12, x15, x12 __LF                 \
+        eor     x3, x3, x16 __LF                   \
+        adcs    x13, x3, x13 __LF                  \
+        adc     x14, x14, x16 __LF                 \
+        ldp     x3, x4, [P1+16] __LF               \
+        ldp     x15, x16, [P1] __LF                \
+        subs    x3, x3, x15 __LF                   \
+        sbcs    x4, x4, x16 __LF                   \
+        csetm   x16, lo __LF                       \
+        ldp     x15, x0, [P2] __LF                 \
+        subs    x5, x15, x5 __LF                   \
+        sbcs    x6, x0, x6 __LF                    \
+        csetm   x0, lo __LF                        \
+        eor     x3, x3, x16 __LF                   \
+        subs    x3, x3, x16 __LF                   \
+        eor     x4, x4, x16 __LF                   \
+        sbc     x4, x4, x16 __LF                   \
+        eor     x5, x5, x0 __LF                    \
+        subs    x5, x5, x0 __LF                    \
+        eor     x6, x6, x0 __LF                    \
+        sbc     x6, x6, x0 __LF                    \
+        eor     x16, x0, x16 __LF                  \
+        adds    x11, x11, x9 __LF                  \
+        adcs    x12, x12, x10 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        mul     x2, x3, x5 __LF                    \
+        umulh   x0, x3, x5 __LF                    \
+        mul     x15, x4, x6 __LF                   \
+        umulh   x1, x4, x6 __LF                    \
+        subs    x4, x4, x3 __LF                    \
+        cneg    x4, x4, lo __LF                    \
+        csetm   x9, lo __LF                        \
+        adds    x15, x15, x0 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        subs    x6, x5, x6 __LF                    \
+        cneg    x6, x6, lo __LF                    \
+        cinv    x9, x9, lo __LF                    \
+        mul     x5, x4, x6 __LF                    \
+        umulh   x6, x4, x6 __LF                    \
+        adds    x0, x2, x15 __LF                   \
+        adcs    x15, x15, x1 __LF                  \
+        adc     x1, x1, xzr __LF                   \
+        cmn     x9, #1 __LF                        \
+        eor     x5, x5, x9 __LF                    \
+        adcs    x0, x5, x0 __LF                    \
+        eor     x6, x6, x9 __LF                    \
+        adcs    x15, x6, x15 __LF                  \
+        adc     x1, x1, x9 __LF                    \
+        adds    x9, x11, x7 __LF                   \
+        adcs    x10, x12, x8 __LF                  \
+        adcs    x11, x13, x11 __LF                 \
+        adcs    x12, x14, x12 __LF                 \
+        adcs    x13, x13, xzr __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        cmn     x16, #1 __LF                       \
+        eor     x2, x2, x16 __LF                   \
+        adcs    x9, x2, x9 __LF                    \
+        eor     x0, x0, x16 __LF                   \
+        adcs    x10, x0, x10 __LF                  \
+        eor     x15, x15, x16 __LF                 \
+        adcs    x11, x15, x11 __LF                 \
+        eor     x1, x1, x16 __LF                   \
+        adcs    x12, x1, x12 __LF                  \
+        adcs    x13, x13, x16 __LF                 \
+        adc     x14, x14, x16 __LF                 \
+        mov     x16, #977 __LF                     \
+        mul     x3, pconst, x11 __LF               \
+        umulh   x5, pconst, x11 __LF               \
+        and     x15, x12, #0xffffffff __LF         \
+        lsr     x2, x12, #32 __LF                  \
+        mul     x4, x16, x15 __LF                  \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x4, x4, x15, lsl #32 __LF          \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x6, x2, x15 __LF                   \
+        mul     x11, pconst, x13 __LF              \
+        umulh   x13, pconst, x13 __LF              \
+        and     x15, x14, #0xffffffff __LF         \
+        lsr     x2, x14, #32 __LF                  \
+        mul     x12, x16, x15 __LF                 \
+        madd    x15, x16, x2, x15 __LF             \
+        adds    x12, x12, x15, lsl #32 __LF        \
+        lsr     x15, x15, #32 __LF                 \
+        adc     x14, x2, x15 __LF                  \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        cset    x11, hs __LF                       \
+        adds    x8, x8, x5 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adc     x11, x11, x14 __LF                 \
+        add     x0, x11, #1 __LF                   \
+        mul     x3, x16, x0 __LF                   \
+        lsr     x4, x0, #32 __LF                   \
+        adds    x3, x3, x0, lsl #32 __LF           \
+        adc     x4, xzr, x4 __LF                   \
+        adds    x7, x7, x3 __LF                    \
+        adcs    x8, x8, x4 __LF                    \
+        adcs    x9, x9, xzr __LF                   \
+        adcs    x10, x10, xzr __LF                 \
+        csel    x1, pconst, xzr, lo __LF           \
+        subs    x7, x7, x1 __LF                    \
+        sbcs    x8, x8, xzr __LF                   \
+        sbcs    x9, x9, xzr __LF                   \
+        sbc     x10, x10, xzr __LF                 \
+        stp     x7, x8, [P0] __LF                  \
         stp     x9, x10, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1 except for
 // re-use of the pconst register for the constant 4294968273
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x10, x11, [P1];                 \
-        ldp     x12, x13, [P1+16];              \
-        umull   x2, w10, w10;                   \
-        lsr     x14, x10, #32;                  \
-        umull   x3, w14, w14;                   \
-        umull   x14, w10, w14;                  \
-        adds    x2, x2, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x3, x3, x14;                    \
-        umull   x4, w11, w11;                   \
-        lsr     x14, x11, #32;                  \
-        umull   x5, w14, w14;                   \
-        umull   x14, w11, w14;                  \
-        mul     x15, x10, x11;                  \
-        umulh   x16, x10, x11;                  \
-        adds    x4, x4, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x5, x5, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x5, x5, xzr;                    \
-        adds    x3, x3, x15;                    \
-        adcs    x4, x4, x16;                    \
-        adc     x5, x5, xzr;                    \
-        umull   x6, w12, w12;                   \
-        lsr     x14, x12, #32;                  \
-        umull   x7, w14, w14;                   \
-        umull   x14, w12, w14;                  \
-        adds    x6, x6, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x7, x7, x14;                    \
-        umull   x8, w13, w13;                   \
-        lsr     x14, x13, #32;                  \
-        umull   x9, w14, w14;                   \
-        umull   x14, w13, w14;                  \
-        mul     x15, x12, x13;                  \
-        umulh   x16, x12, x13;                  \
-        adds    x8, x8, x14, lsl #33;           \
-        lsr     x14, x14, #31;                  \
-        adc     x9, x9, x14;                    \
-        adds    x15, x15, x15;                  \
-        adcs    x16, x16, x16;                  \
-        adc     x9, x9, xzr;                    \
-        adds    x7, x7, x15;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, xzr;                    \
-        subs    x10, x10, x12;                  \
-        sbcs    x11, x11, x13;                  \
-        csetm   x16, lo;                        \
-        eor     x10, x10, x16;                  \
-        subs    x10, x10, x16;                  \
-        eor     x11, x11, x16;                  \
-        sbc     x11, x11, x16;                  \
-        adds    x6, x6, x4;                     \
-        adcs    x7, x7, x5;                     \
-        adcs    x8, x8, xzr;                    \
-        adc     x9, x9, xzr;                    \
-        umull   x12, w10, w10;                  \
-        lsr     x5, x10, #32;                   \
-        umull   x13, w5, w5;                    \
-        umull   x5, w10, w5;                    \
-        adds    x12, x12, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x13, x13, x5;                   \
-        umull   x15, w11, w11;                  \
-        lsr     x5, x11, #32;                   \
-        umull   x14, w5, w5;                    \
-        umull   x5, w11, w5;                    \
-        mul     x4, x10, x11;                   \
-        umulh   x16, x10, x11;                  \
-        adds    x15, x15, x5, lsl #33;          \
-        lsr     x5, x5, #31;                    \
-        adc     x14, x14, x5;                   \
-        adds    x4, x4, x4;                     \
-        adcs    x16, x16, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x13, x13, x4;                   \
-        adcs    x15, x15, x16;                  \
-        adc     x14, x14, xzr;                  \
-        adds    x4, x2, x6;                     \
-        adcs    x5, x3, x7;                     \
-        adcs    x6, x6, x8;                     \
-        adcs    x7, x7, x9;                     \
-        csetm   x16, lo;                        \
-        subs    x4, x4, x12;                    \
-        sbcs    x5, x5, x13;                    \
-        sbcs    x6, x6, x15;                    \
-        sbcs    x7, x7, x14;                    \
-        adcs    x8, x8, x16;                    \
-        adc     x9, x9, x16;                    \
-        mov     x16, #977;                      \
-        mul     x10, pconst, x6;                \
-        umulh   x13, pconst, x6;                \
-        and     x6, x7, #0xffffffff;            \
-        lsr     x7, x7, #32;                    \
-        mul     x11, x16, x6;                   \
-        madd    x6, x16, x7, x6;                \
-        adds    x11, x11, x6, lsl #32;          \
-        lsr     x6, x6, #32;                    \
-        adc     x14, x7, x6;                    \
-        mul     x12, pconst, x8;                \
-        umulh   x8, pconst, x8;                 \
-        and     x6, x9, #0xffffffff;            \
-        lsr     x7, x9, #32;                    \
-        mul     x9, x16, x6;                    \
-        madd    x6, x16, x7, x6;                \
-        adds    x9, x9, x6, lsl #32;            \
-        lsr     x6, x6, #32;                    \
-        adc     x15, x7, x6;                    \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adcs    x5, x5, x9;                     \
-        cset    x6, hs;                         \
-        adds    x3, x3, x13;                    \
-        adcs    x4, x4, x14;                    \
-        adcs    x5, x5, x8;                     \
-        adc     x6, x6, x15;                    \
-        add     x6, x6, #1;                     \
-        mul     x10, x16, x6;                   \
-        lsr     x11, x6, #32;                   \
-        adds    x10, x10, x6, lsl #32;          \
-        adc     x11, xzr, x11;                  \
-        adds    x2, x2, x10;                    \
-        adcs    x3, x3, x11;                    \
-        adcs    x4, x4, xzr;                    \
-        adcs    x5, x5, xzr;                    \
-        csel    x16, pconst, xzr, lo;           \
-        subs    x2, x2, x16;                    \
-        sbcs    x3, x3, xzr;                    \
-        sbcs    x4, x4, xzr;                    \
-        sbc     x5, x5, xzr;                    \
-        stp     x2, x3, [P0];                   \
+        ldp     x10, x11, [P1] __LF                \
+        ldp     x12, x13, [P1+16] __LF             \
+        umull   x2, w10, w10 __LF                  \
+        lsr     x14, x10, #32 __LF                 \
+        umull   x3, w14, w14 __LF                  \
+        umull   x14, w10, w14 __LF                 \
+        adds    x2, x2, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x3, x3, x14 __LF                   \
+        umull   x4, w11, w11 __LF                  \
+        lsr     x14, x11, #32 __LF                 \
+        umull   x5, w14, w14 __LF                  \
+        umull   x14, w11, w14 __LF                 \
+        mul     x15, x10, x11 __LF                 \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x4, x4, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x5, x5, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x5, x5, xzr __LF                   \
+        adds    x3, x3, x15 __LF                   \
+        adcs    x4, x4, x16 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umull   x6, w12, w12 __LF                  \
+        lsr     x14, x12, #32 __LF                 \
+        umull   x7, w14, w14 __LF                  \
+        umull   x14, w12, w14 __LF                 \
+        adds    x6, x6, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x7, x7, x14 __LF                   \
+        umull   x8, w13, w13 __LF                  \
+        lsr     x14, x13, #32 __LF                 \
+        umull   x9, w14, w14 __LF                  \
+        umull   x14, w13, w14 __LF                 \
+        mul     x15, x12, x13 __LF                 \
+        umulh   x16, x12, x13 __LF                 \
+        adds    x8, x8, x14, lsl #33 __LF          \
+        lsr     x14, x14, #31 __LF                 \
+        adc     x9, x9, x14 __LF                   \
+        adds    x15, x15, x15 __LF                 \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x9, x9, xzr __LF                   \
+        adds    x7, x7, x15 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        subs    x10, x10, x12 __LF                 \
+        sbcs    x11, x11, x13 __LF                 \
+        csetm   x16, lo __LF                       \
+        eor     x10, x10, x16 __LF                 \
+        subs    x10, x10, x16 __LF                 \
+        eor     x11, x11, x16 __LF                 \
+        sbc     x11, x11, x16 __LF                 \
+        adds    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x5 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        umull   x12, w10, w10 __LF                 \
+        lsr     x5, x10, #32 __LF                  \
+        umull   x13, w5, w5 __LF                   \
+        umull   x5, w10, w5 __LF                   \
+        adds    x12, x12, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x13, x13, x5 __LF                  \
+        umull   x15, w11, w11 __LF                 \
+        lsr     x5, x11, #32 __LF                  \
+        umull   x14, w5, w5 __LF                   \
+        umull   x5, w11, w5 __LF                   \
+        mul     x4, x10, x11 __LF                  \
+        umulh   x16, x10, x11 __LF                 \
+        adds    x15, x15, x5, lsl #33 __LF         \
+        lsr     x5, x5, #31 __LF                   \
+        adc     x14, x14, x5 __LF                  \
+        adds    x4, x4, x4 __LF                    \
+        adcs    x16, x16, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x13, x13, x4 __LF                  \
+        adcs    x15, x15, x16 __LF                 \
+        adc     x14, x14, xzr __LF                 \
+        adds    x4, x2, x6 __LF                    \
+        adcs    x5, x3, x7 __LF                    \
+        adcs    x6, x6, x8 __LF                    \
+        adcs    x7, x7, x9 __LF                    \
+        csetm   x16, lo __LF                       \
+        subs    x4, x4, x12 __LF                   \
+        sbcs    x5, x5, x13 __LF                   \
+        sbcs    x6, x6, x15 __LF                   \
+        sbcs    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x16 __LF                   \
+        adc     x9, x9, x16 __LF                   \
+        mov     x16, #977 __LF                     \
+        mul     x10, pconst, x6 __LF               \
+        umulh   x13, pconst, x6 __LF               \
+        and     x6, x7, #0xffffffff __LF           \
+        lsr     x7, x7, #32 __LF                   \
+        mul     x11, x16, x6 __LF                  \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x11, x11, x6, lsl #32 __LF         \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x14, x7, x6 __LF                   \
+        mul     x12, pconst, x8 __LF               \
+        umulh   x8, pconst, x8 __LF                \
+        and     x6, x9, #0xffffffff __LF           \
+        lsr     x7, x9, #32 __LF                   \
+        mul     x9, x16, x6 __LF                   \
+        madd    x6, x16, x7, x6 __LF               \
+        adds    x9, x9, x6, lsl #32 __LF           \
+        lsr     x6, x6, #32 __LF                   \
+        adc     x15, x7, x6 __LF                   \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adcs    x5, x5, x9 __LF                    \
+        cset    x6, hs __LF                        \
+        adds    x3, x3, x13 __LF                   \
+        adcs    x4, x4, x14 __LF                   \
+        adcs    x5, x5, x8 __LF                    \
+        adc     x6, x6, x15 __LF                   \
+        add     x6, x6, #1 __LF                    \
+        mul     x10, x16, x6 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        adds    x10, x10, x6, lsl #32 __LF         \
+        adc     x11, xzr, x11 __LF                 \
+        adds    x2, x2, x10 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adcs    x4, x4, xzr __LF                   \
+        adcs    x5, x5, xzr __LF                   \
+        csel    x16, pconst, xzr, lo __LF          \
+        subs    x2, x2, x16 __LF                   \
+        sbcs    x3, x3, xzr __LF                   \
+        sbcs    x4, x4, xzr __LF                   \
+        sbc     x5, x5, xzr __LF                   \
+        stp     x2, x3, [P0] __LF                  \
         stp     x4, x5, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256k1
 
 #define sub_p256k1(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #0x3d1;                     \
-        orr     x3, x4, #0x100000000;           \
-        csel    x3, x3, xzr, cc;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #0x3d1 __LF                    \
+        orr     x3, x4, #0x100000000 __LF          \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jmixadd):

--- a/arm/secp256k1/secp256k1_jmixadd_alt.S
+++ b/arm/secp256k1/secp256k1_jmixadd_alt.S
@@ -77,208 +77,208 @@
 // Corresponds exactly to bignum_mul_p256k1_alt
 
 #define mul_p256k1(P0,P1,P2)                    \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        mov     x7, #0x3d1;                     \
-        orr     x7, x7, #0x100000000;           \
-        mul     x11, x7, x1;                    \
-        umulh   x9, x7, x1;                     \
-        adds    x12, x12, x11;                  \
-        mul     x11, x7, x3;                    \
-        umulh   x3, x7, x3;                     \
-        adcs    x13, x13, x11;                  \
-        mul     x11, x7, x4;                    \
-        umulh   x4, x7, x4;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x7, x5;                    \
-        umulh   x5, x7, x5;                     \
-        adcs    x0, x0, x11;                    \
-        cset    x1, cs;                         \
-        adds    x13, x13, x9;                   \
-        adcs    x14, x14, x3;                   \
-        adcs    x0, x0, x4;                     \
-        adc     x1, x1, x5;                     \
-        add     x8, x1, #0x1;                   \
-        mul     x11, x7, x8;                    \
-        umulh   x9, x7, x8;                     \
-        adds    x12, x12, x11;                  \
-        adcs    x13, x13, x9;                   \
-        adcs    x14, x14, xzr;                  \
-        adcs    x0, x0, xzr;                    \
-        csel    x7, x7, xzr, cc;                \
-        subs    x12, x12, x7;                   \
-        sbcs    x13, x13, xzr;                  \
-        sbcs    x14, x14, xzr;                  \
-        sbc     x0, x0, xzr;                    \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        mov     x7, #0x3d1 __LF                    \
+        orr     x7, x7, #0x100000000 __LF          \
+        mul     x11, x7, x1 __LF                   \
+        umulh   x9, x7, x1 __LF                    \
+        adds    x12, x12, x11 __LF                 \
+        mul     x11, x7, x3 __LF                   \
+        umulh   x3, x7, x3 __LF                    \
+        adcs    x13, x13, x11 __LF                 \
+        mul     x11, x7, x4 __LF                   \
+        umulh   x4, x7, x4 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x7, x5 __LF                   \
+        umulh   x5, x7, x5 __LF                    \
+        adcs    x0, x0, x11 __LF                   \
+        cset    x1, cs __LF                        \
+        adds    x13, x13, x9 __LF                  \
+        adcs    x14, x14, x3 __LF                  \
+        adcs    x0, x0, x4 __LF                    \
+        adc     x1, x1, x5 __LF                    \
+        add     x8, x1, #0x1 __LF                  \
+        mul     x11, x7, x8 __LF                   \
+        umulh   x9, x7, x8 __LF                    \
+        adds    x12, x12, x11 __LF                 \
+        adcs    x13, x13, x9 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adcs    x0, x0, xzr __LF                   \
+        csel    x7, x7, xzr, cc __LF               \
+        subs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, xzr __LF                 \
+        sbcs    x14, x14, xzr __LF                 \
+        sbc     x0, x0, xzr __LF                   \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds exactly to bignum_sqr_p256k1_alt
 
 #define sqr_p256k1(P0,P1)                       \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x7, x2, x4;                     \
-        umulh   x6, x2, x4;                     \
-        adds    x10, x10, x7;                   \
-        adcs    x11, x11, x6;                   \
-        mul     x7, x3, x4;                     \
-        umulh   x6, x3, x4;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x11, x11, x7;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x6;                   \
-        mul     x7, x3, x5;                     \
-        umulh   x6, x3, x5;                     \
-        adc     x6, x6, xzr;                    \
-        adds    x12, x12, x7;                   \
-        adcs    x13, x13, x6;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x6, cs;                         \
-        umulh   x7, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x7;                     \
-        mul     x7, x3, x3;                     \
-        adcs    x10, x10, x7;                   \
-        umulh   x7, x3, x3;                     \
-        adcs    x11, x11, x7;                   \
-        mul     x7, x4, x4;                     \
-        adcs    x12, x12, x7;                   \
-        umulh   x7, x4, x4;                     \
-        adcs    x13, x13, x7;                   \
-        mul     x7, x5, x5;                     \
-        adcs    x14, x14, x7;                   \
-        umulh   x7, x5, x5;                     \
-        adc     x6, x6, x7;                     \
-        mov     x3, #0x3d1;                     \
-        orr     x3, x3, #0x100000000;           \
-        mul     x7, x3, x12;                    \
-        umulh   x4, x3, x12;                    \
-        adds    x8, x8, x7;                     \
-        mul     x7, x3, x13;                    \
-        umulh   x13, x3, x13;                   \
-        adcs    x9, x9, x7;                     \
-        mul     x7, x3, x14;                    \
-        umulh   x14, x3, x14;                   \
-        adcs    x10, x10, x7;                   \
-        mul     x7, x3, x6;                     \
-        umulh   x6, x3, x6;                     \
-        adcs    x11, x11, x7;                   \
-        cset    x12, cs;                        \
-        adds    x9, x9, x4;                     \
-        adcs    x10, x10, x13;                  \
-        adcs    x11, x11, x14;                  \
-        adc     x12, x12, x6;                   \
-        add     x2, x12, #0x1;                  \
-        mul     x7, x3, x2;                     \
-        umulh   x6, x3, x2;                     \
-        adds    x8, x8, x7;                     \
-        adcs    x9, x9, x6;                     \
-        adcs    x10, x10, xzr;                  \
-        adcs    x11, x11, xzr;                  \
-        csel    x3, x3, xzr, cc;                \
-        subs    x8, x8, x3;                     \
-        sbcs    x9, x9, xzr;                    \
-        sbcs    x10, x10, xzr;                  \
-        sbc     x11, x11, xzr;                  \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x7, x2, x4 __LF                    \
+        umulh   x6, x2, x4 __LF                    \
+        adds    x10, x10, x7 __LF                  \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x7, x3, x4 __LF                    \
+        umulh   x6, x3, x4 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x11, x11, x7 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x6 __LF                  \
+        mul     x7, x3, x5 __LF                    \
+        umulh   x6, x3, x5 __LF                    \
+        adc     x6, x6, xzr __LF                   \
+        adds    x12, x12, x7 __LF                  \
+        adcs    x13, x13, x6 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x6, cs __LF                        \
+        umulh   x7, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x7 __LF                    \
+        mul     x7, x3, x3 __LF                    \
+        adcs    x10, x10, x7 __LF                  \
+        umulh   x7, x3, x3 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x7, x4, x4 __LF                    \
+        adcs    x12, x12, x7 __LF                  \
+        umulh   x7, x4, x4 __LF                    \
+        adcs    x13, x13, x7 __LF                  \
+        mul     x7, x5, x5 __LF                    \
+        adcs    x14, x14, x7 __LF                  \
+        umulh   x7, x5, x5 __LF                    \
+        adc     x6, x6, x7 __LF                    \
+        mov     x3, #0x3d1 __LF                    \
+        orr     x3, x3, #0x100000000 __LF          \
+        mul     x7, x3, x12 __LF                   \
+        umulh   x4, x3, x12 __LF                   \
+        adds    x8, x8, x7 __LF                    \
+        mul     x7, x3, x13 __LF                   \
+        umulh   x13, x3, x13 __LF                  \
+        adcs    x9, x9, x7 __LF                    \
+        mul     x7, x3, x14 __LF                   \
+        umulh   x14, x3, x14 __LF                  \
+        adcs    x10, x10, x7 __LF                  \
+        mul     x7, x3, x6 __LF                    \
+        umulh   x6, x3, x6 __LF                    \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x12, cs __LF                       \
+        adds    x9, x9, x4 __LF                    \
+        adcs    x10, x10, x13 __LF                 \
+        adcs    x11, x11, x14 __LF                 \
+        adc     x12, x12, x6 __LF                  \
+        add     x2, x12, #0x1 __LF                 \
+        mul     x7, x3, x2 __LF                    \
+        umulh   x6, x3, x2 __LF                    \
+        adds    x8, x8, x7 __LF                    \
+        adcs    x9, x9, x6 __LF                    \
+        adcs    x10, x10, xzr __LF                 \
+        adcs    x11, x11, xzr __LF                 \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, xzr __LF                   \
+        sbcs    x10, x10, xzr __LF                 \
+        sbc     x11, x11, xzr __LF                 \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_p256k1
 
 #define sub_p256k1(P0,P1,P2)                    \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        mov     x4, #0x3d1;                     \
-        orr     x3, x4, #0x100000000;           \
-        csel    x3, x3, xzr, cc;                \
-        subs    x5, x5, x3;                     \
-        sbcs    x6, x6, xzr;                    \
-        sbcs    x7, x7, xzr;                    \
-        sbc     x8, x8, xzr;                    \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        mov     x4, #0x3d1 __LF                    \
+        orr     x3, x4, #0x100000000 __LF          \
+        csel    x3, x3, xzr, cc __LF               \
+        subs    x5, x5, x3 __LF                    \
+        sbcs    x6, x6, xzr __LF                   \
+        sbcs    x7, x7, xzr __LF                   \
+        sbc     x8, x8, xzr __LF                   \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(secp256k1_jmixadd_alt):

--- a/arm/sm2/bignum_deamont_sm2.S
+++ b/arm/sm2/bignum_deamont_sm2.S
@@ -31,14 +31,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 // Input parameters

--- a/arm/sm2/bignum_demont_sm2.S
+++ b/arm/sm2/bignum_demont_sm2.S
@@ -30,14 +30,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 // Input parameters

--- a/arm/sm2/bignum_inv_sm2.S
+++ b/arm/sm2/bignum_inv_sm2.S
@@ -85,33 +85,33 @@
 #define amontred(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* We only know the input is -2^316 < x < 2^316. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_sm2.     */      \
-        mov     t0, #0xe000000000000000;                                    \
-        adds    d0, d0, t0;                                                 \
-        mov     t1, #0x1fffffffffffffff;                                    \
-        adcs    d1, d1, t1;                                                 \
-        mov     t2, #0xffffffffe0000000;                                    \
-        adcs    d2, d2, t2;                                                 \
-        sbcs    d3, d3, xzr;                                                \
-        and     t0, t1, #0xffffffffdfffffff;                                \
-        adc     d4, d4, t0;                                                 \
+        mov     t0, #0xe000000000000000 __LF                                   \
+        adds    d0, d0, t0 __LF                                                \
+        mov     t1, #0x1fffffffffffffff __LF                                   \
+        adcs    d1, d1, t1 __LF                                                \
+        mov     t2, #0xffffffffe0000000 __LF                                   \
+        adcs    d2, d2, t2 __LF                                                \
+        sbcs    d3, d3, xzr __LF                                               \
+        and     t0, t1, #0xffffffffdfffffff __LF                               \
+        adc     d4, d4, t0 __LF                                                \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0 */             \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0] */                    \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
-        sbc     t0, d0, t3;                                                 \
-        adds    d4, d4, t0;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
+        sbc     t0, d0, t3 __LF                                                \
+        adds    d4, d4, t0 __LF                                                \
 /* Now capture top carry and subtract p_sm2 if set (almost-Montgomery) */   \
-        csetm   t0, cs;                                                     \
-        subs    d1, d1, t0;                                                 \
-        and     t1, t0, #0xffffffff00000000;                                \
-        sbcs    d2, d2, t1;                                                 \
-        and     t2, t0, #0xfffffffeffffffff;                                \
-        sbcs    d3, d3, t0;                                                 \
+        csetm   t0, cs __LF                                                    \
+        subs    d1, d1, t0 __LF                                                \
+        and     t1, t0, #0xffffffff00000000 __LF                               \
+        sbcs    d2, d2, t1 __LF                                                \
+        and     t2, t0, #0xfffffffeffffffff __LF                               \
+        sbcs    d3, d3, t0 __LF                                                \
         sbc     d4, d4, t2
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -122,610 +122,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_inv_sm2):

--- a/arm/sm2/bignum_mod_nsm2.S
+++ b/arm/sm2/bignum_mod_nsm2.S
@@ -48,9 +48,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_nsm2):

--- a/arm/sm2/bignum_mod_nsm2_4.S
+++ b/arm/sm2/bignum_mod_nsm2_4.S
@@ -35,9 +35,9 @@
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(bignum_mod_nsm2_4):

--- a/arm/sm2/bignum_montinv_sm2.S
+++ b/arm/sm2/bignum_montinv_sm2.S
@@ -90,33 +90,33 @@
 #define amontred(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* We only know the input is -2^316 < x < 2^316. To do traditional  */      \
 /* unsigned Montgomery reduction, start by adding 2^61 * p_sm2.     */      \
-        mov     t0, #0xe000000000000000;                                    \
-        adds    d0, d0, t0;                                                 \
-        mov     t1, #0x1fffffffffffffff;                                    \
-        adcs    d1, d1, t1;                                                 \
-        mov     t2, #0xffffffffe0000000;                                    \
-        adcs    d2, d2, t2;                                                 \
-        sbcs    d3, d3, xzr;                                                \
-        and     t0, t1, #0xffffffffdfffffff;                                \
-        adc     d4, d4, t0;                                                 \
+        mov     t0, #0xe000000000000000 __LF                                   \
+        adds    d0, d0, t0 __LF                                                \
+        mov     t1, #0x1fffffffffffffff __LF                                   \
+        adcs    d1, d1, t1 __LF                                                \
+        mov     t2, #0xffffffffe0000000 __LF                                   \
+        adcs    d2, d2, t2 __LF                                                \
+        sbcs    d3, d3, xzr __LF                                               \
+        and     t0, t1, #0xffffffffdfffffff __LF                               \
+        adc     d4, d4, t0 __LF                                                \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0 */             \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0] */                    \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
-        sbc     t0, d0, t3;                                                 \
-        adds    d4, d4, t0;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
+        sbc     t0, d0, t3 __LF                                                \
+        adds    d4, d4, t0 __LF                                                \
 /* Now capture top carry and subtract p_sm2 if set (almost-Montgomery) */   \
-        csetm   t0, cs;                                                     \
-        subs    d1, d1, t0;                                                 \
-        and     t1, t0, #0xffffffff00000000;                                \
-        sbcs    d2, d2, t1;                                                 \
-        and     t2, t0, #0xfffffffeffffffff;                                \
-        sbcs    d3, d3, t0;                                                 \
+        csetm   t0, cs __LF                                                    \
+        subs    d1, d1, t0 __LF                                                \
+        and     t1, t0, #0xffffffff00000000 __LF                               \
+        sbcs    d2, d2, t1 __LF                                                \
+        and     t2, t0, #0xfffffffeffffffff __LF                               \
+        sbcs    d3, d3, t0 __LF                                                \
         sbc     d4, d4, t2
 
 // Very similar to a subroutine call to the s2n-bignum word_divstep59.
@@ -127,610 +127,610 @@
 // [ m10  m11]
 
 #define divstep59()                                                     \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x8, x4, #0x100, lsl #12;                                \
-        sbfx    x8, x8, #21, #21;                                       \
-        mov     x11, #0x100000;                                         \
-        add     x11, x11, x11, lsl #21;                                 \
-        add     x9, x4, x11;                                            \
-        asr     x9, x9, #42;                                            \
-        add     x10, x5, #0x100, lsl #12;                               \
-        sbfx    x10, x10, #21, #21;                                     \
-        add     x11, x5, x11;                                           \
-        asr     x11, x11, #42;                                          \
-        mul     x6, x8, x2;                                             \
-        mul     x7, x9, x3;                                             \
-        mul     x2, x10, x2;                                            \
-        mul     x3, x11, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #21, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #42;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #21, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #42;                                          \
-        mul     x6, x12, x2;                                            \
-        mul     x7, x13, x3;                                            \
-        mul     x2, x14, x2;                                            \
-        mul     x3, x15, x3;                                            \
-        add     x4, x6, x7;                                             \
-        add     x5, x2, x3;                                             \
-        asr     x2, x4, #20;                                            \
-        asr     x3, x5, #20;                                            \
-        and     x4, x2, #0xfffff;                                       \
-        orr     x4, x4, #0xfffffe0000000000;                            \
-        and     x5, x3, #0xfffff;                                       \
-        orr     x5, x5, #0xc000000000000000;                            \
-        tst     x5, #0x1;                                               \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        mul     x2, x12, x8;                                            \
-        mul     x3, x12, x9;                                            \
-        mul     x6, x14, x8;                                            \
-        mul     x7, x14, x9;                                            \
-        madd    x8, x13, x10, x2;                                       \
-        madd    x9, x13, x11, x3;                                       \
-        madd    x16, x15, x10, x6;                                      \
-        madd    x17, x15, x11, x7;                                      \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        tst     x5, #0x2;                                               \
-        asr     x5, x5, #1;                                             \
-        csel    x6, x4, xzr, ne;                                        \
-        ccmp    x1, xzr, #0x8, ne;                                      \
-        cneg    x1, x1, ge;                                             \
-        cneg    x6, x6, ge;                                             \
-        csel    x4, x5, x4, ge;                                         \
-        add     x5, x5, x6;                                             \
-        add     x1, x1, #0x2;                                           \
-        asr     x5, x5, #1;                                             \
-        add     x12, x4, #0x100, lsl #12;                               \
-        sbfx    x12, x12, #22, #21;                                     \
-        mov     x15, #0x100000;                                         \
-        add     x15, x15, x15, lsl #21;                                 \
-        add     x13, x4, x15;                                           \
-        asr     x13, x13, #43;                                          \
-        add     x14, x5, #0x100, lsl #12;                               \
-        sbfx    x14, x14, #22, #21;                                     \
-        add     x15, x5, x15;                                           \
-        asr     x15, x15, #43;                                          \
-        mneg    x2, x12, x8;                                            \
-        mneg    x3, x12, x9;                                            \
-        mneg    x4, x14, x8;                                            \
-        mneg    x5, x14, x9;                                            \
-        msub    m00, x13, x16, x2;                                      \
-        msub    m01, x13, x17, x3;                                      \
-        msub    m10, x15, x16, x4;                                      \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x8, x4, #0x100, lsl #12 __LF                               \
+        sbfx    x8, x8, #21, #21 __LF                                      \
+        mov     x11, #0x100000 __LF                                        \
+        add     x11, x11, x11, lsl #21 __LF                                \
+        add     x9, x4, x11 __LF                                           \
+        asr     x9, x9, #42 __LF                                           \
+        add     x10, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x10, x10, #21, #21 __LF                                    \
+        add     x11, x5, x11 __LF                                          \
+        asr     x11, x11, #42 __LF                                         \
+        mul     x6, x8, x2 __LF                                            \
+        mul     x7, x9, x3 __LF                                            \
+        mul     x2, x10, x2 __LF                                           \
+        mul     x3, x11, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #21, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #42 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #21, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #42 __LF                                         \
+        mul     x6, x12, x2 __LF                                           \
+        mul     x7, x13, x3 __LF                                           \
+        mul     x2, x14, x2 __LF                                           \
+        mul     x3, x15, x3 __LF                                           \
+        add     x4, x6, x7 __LF                                            \
+        add     x5, x2, x3 __LF                                            \
+        asr     x2, x4, #20 __LF                                           \
+        asr     x3, x5, #20 __LF                                           \
+        and     x4, x2, #0xfffff __LF                                      \
+        orr     x4, x4, #0xfffffe0000000000 __LF                           \
+        and     x5, x3, #0xfffff __LF                                      \
+        orr     x5, x5, #0xc000000000000000 __LF                           \
+        tst     x5, #0x1 __LF                                              \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        mul     x2, x12, x8 __LF                                           \
+        mul     x3, x12, x9 __LF                                           \
+        mul     x6, x14, x8 __LF                                           \
+        mul     x7, x14, x9 __LF                                           \
+        madd    x8, x13, x10, x2 __LF                                      \
+        madd    x9, x13, x11, x3 __LF                                      \
+        madd    x16, x15, x10, x6 __LF                                     \
+        madd    x17, x15, x11, x7 __LF                                     \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        tst     x5, #0x2 __LF                                              \
+        asr     x5, x5, #1 __LF                                            \
+        csel    x6, x4, xzr, ne __LF                                       \
+        ccmp    x1, xzr, #0x8, ne __LF                                     \
+        cneg    x1, x1, ge __LF                                            \
+        cneg    x6, x6, ge __LF                                            \
+        csel    x4, x5, x4, ge __LF                                        \
+        add     x5, x5, x6 __LF                                            \
+        add     x1, x1, #0x2 __LF                                          \
+        asr     x5, x5, #1 __LF                                            \
+        add     x12, x4, #0x100, lsl #12 __LF                              \
+        sbfx    x12, x12, #22, #21 __LF                                    \
+        mov     x15, #0x100000 __LF                                        \
+        add     x15, x15, x15, lsl #21 __LF                                \
+        add     x13, x4, x15 __LF                                          \
+        asr     x13, x13, #43 __LF                                         \
+        add     x14, x5, #0x100, lsl #12 __LF                              \
+        sbfx    x14, x14, #22, #21 __LF                                    \
+        add     x15, x5, x15 __LF                                          \
+        asr     x15, x15, #43 __LF                                         \
+        mneg    x2, x12, x8 __LF                                           \
+        mneg    x3, x12, x9 __LF                                           \
+        mneg    x4, x14, x8 __LF                                           \
+        mneg    x5, x14, x9 __LF                                           \
+        msub    m00, x13, x16, x2 __LF                                     \
+        msub    m01, x13, x17, x3 __LF                                     \
+        msub    m10, x15, x16, x4 __LF                                     \
         msub    m11, x15, x17, x5
 
 S2N_BN_SYMBOL(bignum_montinv_sm2):

--- a/arm/sm2/bignum_montmul_sm2.S
+++ b/arm/sm2/bignum_montmul_sm2.S
@@ -28,15 +28,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -49,14 +49,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 #define a0 x3

--- a/arm/sm2/bignum_montmul_sm2_alt.S
+++ b/arm/sm2/bignum_montmul_sm2_alt.S
@@ -31,14 +31,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 #define z x0

--- a/arm/sm2/bignum_montsqr_sm2.S
+++ b/arm/sm2/bignum_montsqr_sm2.S
@@ -27,15 +27,15 @@
 // ---------------------------------------------------------------------------
 
 #define muldiffn(c,h,l, t, x,y, w,z)    \
-        subs    t, x, y;                \
-        cneg    t, t, cc;               \
-        csetm   c, cc;                  \
-        subs    h, w, z;                \
-        cneg    h, h, cc;               \
-        mul     l, t, h;                \
-        umulh   h, t, h;                \
-        cinv    c, c, cc;               \
-        eor     l, l, c;                \
+        subs    t, x, y __LF               \
+        cneg    t, t, cc __LF              \
+        csetm   c, cc __LF                 \
+        subs    h, w, z __LF               \
+        cneg    h, h, cc __LF              \
+        mul     l, t, h __LF               \
+        umulh   h, t, h __LF               \
+        cinv    c, c, cc __LF              \
+        eor     l, l, c __LF               \
         eor     h, h, c
 
 // ---------------------------------------------------------------------------
@@ -47,16 +47,16 @@
 
 #define montrede(d5, d4,d3,d2,d1,d0, t3,t2,t1,t0)                           \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
-        sbc     t0, d0, t3;                                                 \
-        adds    d4, d4, t0;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
+        sbc     t0, d0, t3 __LF                                                \
+        adds    d4, d4, t0 __LF                                                \
         adc     d5, xzr, xzr
 
 // ---------------------------------------------------------------------------
@@ -69,14 +69,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 #define a0 x2

--- a/arm/sm2/bignum_montsqr_sm2_alt.S
+++ b/arm/sm2/bignum_montsqr_sm2_alt.S
@@ -30,14 +30,14 @@
 
 #define montreds(d4,d3,d2,d1,d0, t3,t2,t1,t0)                               \
 /* First let [t3;t2] = 2^32 * d0 and [t1;t0] = (2^32-1) * d0             */ \
-        lsl     t2, d0, #32;                                                \
-        lsr     t3, d0, #32;                                                \
-        subs    t0, t2, d0;                                                 \
-        sbc     t1, t3, xzr;                                                \
+        lsl     t2, d0, #32 __LF                                               \
+        lsr     t3, d0, #32 __LF                                               \
+        subs    t0, t2, d0 __LF                                                \
+        sbc     t1, t3, xzr __LF                                               \
 /* Now [d4;d3;d2;d1] := [d0;d3;d2;d1] - [t3;t2;t1;t0]                    */ \
-        subs    d1, d1, t0;                                                 \
-        sbcs    d2, d2, t1;                                                 \
-        sbcs    d3, d3, t2;                                                 \
+        subs    d1, d1, t0 __LF                                                \
+        sbcs    d2, d2, t1 __LF                                                \
+        sbcs    d3, d3, t2 __LF                                                \
         sbc     d4, d0, t3
 
 #define z x0

--- a/arm/sm2/bignum_tomont_sm2.S
+++ b/arm/sm2/bignum_tomont_sm2.S
@@ -28,29 +28,29 @@
 /* Writing the input, with a lowest zero digit appended, as     */      \
 /* z = 2^256 * d3 + 2^192 * d2 + t, quotient approximation is   */      \
 /* MIN ((d3 * (1 + 2^32 + 2^64) + d2 + 2^64) >> 64) (2^64 - 1)  */      \
-        adds    t3, d2, d3;                                             \
-        mov     t2, #1;                                                 \
-        adc     t1, d3, t2;                                             \
-        add     t2, d3, t3, lsr #32;                                    \
-        adds    q, t1, t2, lsr #32;                                     \
-        cinv    q, q, cs;                                               \
+        adds    t3, d2, d3 __LF                                            \
+        mov     t2, #1 __LF                                                \
+        adc     t1, d3, t2 __LF                                            \
+        add     t2, d3, t3, lsr #32 __LF                                   \
+        adds    q, t1, t2, lsr #32 __LF                                    \
+        cinv    q, q, cs __LF                                              \
 /* Let t3 = q<<32 and t4 = q>>32 then [t2;t1] = 2^32 * q - q    */      \
-        lsl     t3, q, #32;                                             \
-        subs    t1, t3, q;                                              \
-        lsr     t4, q, #32;                                             \
-        sbc     t2, t4, xzr;                                            \
+        lsl     t3, q, #32 __LF                                            \
+        subs    t1, t3, q __LF                                             \
+        lsr     t4, q, #32 __LF                                            \
+        sbc     t2, t4, xzr __LF                                           \
 /* Do the basic correction [t4;t3;t2;t1;q] = 2^256 * x - q * p  */      \
-        adds    t1, t1, d0;                                             \
-        sub     d3, d3, q;                                              \
-        adcs    t2, t2, d1;                                             \
-        adcs    t3, t3, d2;                                             \
-        adc     t4, t4, d3;                                             \
+        adds    t1, t1, d0 __LF                                            \
+        sub     d3, d3, q __LF                                             \
+        adcs    t2, t2, d1 __LF                                            \
+        adcs    t3, t3, d2 __LF                                            \
+        adc     t4, t4, d3 __LF                                            \
 /* Use top word as mask to correct */                                   \
-        adds    d0, q, t4;                                              \
-        and     t0, t4, #0xffffffff00000000;                            \
-        adcs    d1, t1, t0;                                             \
-        adcs    d2, t2, t4;                                             \
-        and     t0, t4, #0xfffffffeffffffff;                            \
+        adds    d0, q, t4 __LF                                             \
+        and     t0, t4, #0xffffffff00000000 __LF                           \
+        adcs    d1, t1, t0 __LF                                            \
+        adcs    d2, t2, t4 __LF                                            \
+        and     t0, t4, #0xfffffffeffffffff __LF                           \
         adc     d3, t3, t0
 
 #define d0 x2

--- a/arm/sm2/sm2_montjadd.S
+++ b/arm/sm2/sm2_montjadd.S
@@ -77,326 +77,326 @@
 // Corresponds to bignum_montmul_sm2 with x0 in place of x17
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2];                   \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x3, x4;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x0;                   \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x0;                   \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        stp     x13, x14, [P0];                 \
-        stp     x11, x12, [P0+16];              \
-        mul     x11, x5, x9;                    \
-        mul     x13, x6, x10;                   \
-        umulh   x12, x5, x9;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x6, x10;                   \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x5, x6;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x10, x9;                    \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        subs    x3, x5, x3;                     \
-        sbcs    x4, x6, x4;                     \
-        ngc     x5, xzr;                        \
-        cmn     x5, #1;                         \
-        eor     x3, x3, x5;                     \
-        adcs    x3, x3, xzr;                    \
-        eor     x4, x4, x5;                     \
-        adcs    x4, x4, xzr;                    \
-        subs    x7, x7, x9;                     \
-        sbcs    x8, x8, x10;                    \
-        ngc     x9, xzr;                        \
-        cmn     x9, #1;                         \
-        eor     x7, x7, x9;                     \
-        adcs    x7, x7, xzr;                    \
-        eor     x8, x8, x9;                     \
-        adcs    x8, x8, xzr;                    \
-        eor     x10, x5, x9;                    \
-        ldp     x15, x1, [P0];                  \
-        adds    x15, x11, x15;                  \
-        adcs    x1, x12, x1;                    \
-        ldp     x5, x9, [P0+16];                \
-        adcs    x5, x13, x5;                    \
-        adcs    x9, x14, x9;                    \
-        adc     x2, xzr, xzr;                   \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x3, x3, x4;                     \
-        cneg    x3, x3, lo;                     \
-        csetm   x4, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x3, x0;                    \
-        umulh   x0, x3, x0;                     \
-        cinv    x4, x4, lo;                     \
-        eor     x16, x16, x4;                   \
-        eor     x0, x0, x4;                     \
-        cmn     x4, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x4;                   \
-        cmn     x10, #1;                        \
-        eor     x11, x11, x10;                  \
-        adcs    x11, x11, x15;                  \
-        eor     x12, x12, x10;                  \
-        adcs    x12, x12, x1;                   \
-        eor     x13, x13, x10;                  \
-        adcs    x13, x13, x5;                   \
-        eor     x14, x14, x10;                  \
-        adcs    x14, x14, x9;                   \
-        adcs    x3, x2, x10;                    \
-        adcs    x4, x10, xzr;                   \
-        adc     x10, x10, xzr;                  \
-        adds    x13, x13, x15;                  \
-        adcs    x14, x14, x1;                   \
-        adcs    x3, x3, x5;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x10, x10, x2;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x0;                   \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x0;                   \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        adds    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adc     x10, x10, xzr;                  \
-        add     x2, x10, #1;                    \
-        lsl     x15, x2, #32;                   \
-        sub     x16, x15, x2;                   \
-        adds    x13, x13, x2;                   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, x15;                    \
-        csetm   x7, lo;                         \
-        adds    x13, x13, x7;                   \
-        and     x16, x7, #0xffffffff00000000;   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, x7;                     \
-        and     x15, x7, #0xfffffffeffffffff;   \
-        adc     x4, x4, x15;                    \
-        stp     x13, x14, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2] __LF                  \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x3, x4 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x0 __LF                  \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x0 __LF                  \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        stp     x13, x14, [P0] __LF                \
+        stp     x11, x12, [P0+16] __LF             \
+        mul     x11, x5, x9 __LF                   \
+        mul     x13, x6, x10 __LF                  \
+        umulh   x12, x5, x9 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x6, x10 __LF                  \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x5, x6 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x10, x9 __LF                   \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        subs    x3, x5, x3 __LF                    \
+        sbcs    x4, x6, x4 __LF                    \
+        ngc     x5, xzr __LF                       \
+        cmn     x5, #1 __LF                        \
+        eor     x3, x3, x5 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        eor     x4, x4, x5 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        subs    x7, x7, x9 __LF                    \
+        sbcs    x8, x8, x10 __LF                   \
+        ngc     x9, xzr __LF                       \
+        cmn     x9, #1 __LF                        \
+        eor     x7, x7, x9 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        eor     x8, x8, x9 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        eor     x10, x5, x9 __LF                   \
+        ldp     x15, x1, [P0] __LF                 \
+        adds    x15, x11, x15 __LF                 \
+        adcs    x1, x12, x1 __LF                   \
+        ldp     x5, x9, [P0+16] __LF               \
+        adcs    x5, x13, x5 __LF                   \
+        adcs    x9, x14, x9 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x3, x3, x4 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        csetm   x4, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x3, x0 __LF                   \
+        umulh   x0, x3, x0 __LF                    \
+        cinv    x4, x4, lo __LF                    \
+        eor     x16, x16, x4 __LF                  \
+        eor     x0, x0, x4 __LF                    \
+        cmn     x4, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x4 __LF                  \
+        cmn     x10, #1 __LF                       \
+        eor     x11, x11, x10 __LF                 \
+        adcs    x11, x11, x15 __LF                 \
+        eor     x12, x12, x10 __LF                 \
+        adcs    x12, x12, x1 __LF                  \
+        eor     x13, x13, x10 __LF                 \
+        adcs    x13, x13, x5 __LF                  \
+        eor     x14, x14, x10 __LF                 \
+        adcs    x14, x14, x9 __LF                  \
+        adcs    x3, x2, x10 __LF                   \
+        adcs    x4, x10, xzr __LF                  \
+        adc     x10, x10, xzr __LF                 \
+        adds    x13, x13, x15 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adcs    x3, x3, x5 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x10, x10, x2 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x0 __LF                  \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x0 __LF                  \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        adds    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        add     x2, x10, #1 __LF                   \
+        lsl     x15, x2, #32 __LF                  \
+        sub     x16, x15, x2 __LF                  \
+        adds    x13, x13, x2 __LF                  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, x15 __LF                   \
+        csetm   x7, lo __LF                        \
+        adds    x13, x13, x7 __LF                  \
+        and     x16, x7, #0xffffffff00000000 __LF  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, x7 __LF                    \
+        and     x15, x7, #0xfffffffeffffffff __LF  \
+        adc     x4, x4, x15 __LF                   \
+        stp     x13, x14, [P0] __LF                \
         stp     x3, x4, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2 with x0 in place of x17
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        ldp     x4, x5, [P1+16];                \
-        umull   x15, w2, w2;                    \
-        lsr     x11, x2, #32;                   \
-        umull   x16, w11, w11;                  \
-        umull   x11, w2, w11;                   \
-        adds    x15, x15, x11, lsl #33;         \
-        lsr     x11, x11, #31;                  \
-        adc     x16, x16, x11;                  \
-        umull   x0, w3, w3;                     \
-        lsr     x11, x3, #32;                   \
-        umull   x1, w11, w11;                   \
-        umull   x11, w3, w11;                   \
-        mul     x12, x2, x3;                    \
-        umulh   x13, x2, x3;                    \
-        adds    x0, x0, x11, lsl #33;           \
-        lsr     x11, x11, #31;                  \
-        adc     x1, x1, x11;                    \
-        adds    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x16, x12;                  \
-        adcs    x0, x0, x13;                    \
-        adc     x1, x1, xzr;                    \
-        lsl     x12, x15, #32;                  \
-        lsr     x11, x15, #32;                  \
-        subs    x14, x12, x15;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x16, x16, x14;                  \
-        sbcs    x0, x0, x13;                    \
-        sbcs    x1, x1, x12;                    \
-        sbc     x15, x15, x11;                  \
-        lsl     x12, x16, #32;                  \
-        lsr     x11, x16, #32;                  \
-        subs    x14, x12, x16;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x0, x0, x14;                    \
-        sbcs    x1, x1, x13;                    \
-        sbcs    x15, x15, x12;                  \
-        sbc     x16, x16, x11;                  \
-        mul     x6, x2, x4;                     \
-        mul     x14, x3, x5;                    \
-        umulh   x8, x2, x4;                     \
-        subs    x10, x2, x3;                    \
-        cneg    x10, x10, lo;                   \
-        csetm   x13, lo;                        \
-        subs    x12, x5, x4;                    \
-        cneg    x12, x12, lo;                   \
-        mul     x11, x10, x12;                  \
-        umulh   x12, x10, x12;                  \
-        cinv    x13, x13, lo;                   \
-        eor     x11, x11, x13;                  \
-        eor     x12, x12, x13;                  \
-        adds    x7, x6, x8;                     \
-        adc     x8, x8, xzr;                    \
-        umulh   x9, x3, x5;                     \
-        adds    x7, x7, x14;                    \
-        adcs    x8, x8, x9;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x8, x8, x14;                    \
-        adc     x9, x9, xzr;                    \
-        cmn     x13, #1;                        \
-        adcs    x7, x7, x11;                    \
-        adcs    x8, x8, x12;                    \
-        adc     x9, x9, x13;                    \
-        adds    x6, x6, x6;                     \
-        adcs    x7, x7, x7;                     \
-        adcs    x8, x8, x8;                     \
-        adcs    x9, x9, x9;                     \
-        adc     x10, xzr, xzr;                  \
-        adds    x6, x6, x0;                     \
-        adcs    x7, x7, x1;                     \
-        adcs    x8, x8, x15;                    \
-        adcs    x9, x9, x16;                    \
-        adc     x10, x10, xzr;                  \
-        lsl     x12, x6, #32;                   \
-        lsr     x11, x6, #32;                   \
-        subs    x14, x12, x6;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x7, x7, x14;                    \
-        sbcs    x8, x8, x13;                    \
-        sbcs    x9, x9, x12;                    \
-        sbc     x14, x6, x11;                   \
-        adds    x10, x10, x14;                  \
-        adc     x6, xzr, xzr;                   \
-        lsl     x12, x7, #32;                   \
-        lsr     x11, x7, #32;                   \
-        subs    x14, x12, x7;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x8, x8, x14;                    \
-        sbcs    x9, x9, x13;                    \
-        sbcs    x10, x10, x12;                  \
-        sbc     x14, x7, x11;                   \
-        adds    x6, x6, x14;                    \
-        adc     x7, xzr, xzr;                   \
-        mul     x11, x4, x4;                    \
-        adds    x8, x8, x11;                    \
-        mul     x12, x5, x5;                    \
-        umulh   x11, x4, x4;                    \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        umulh   x12, x5, x5;                    \
-        adcs    x6, x6, x12;                    \
-        adc     x7, x7, xzr;                    \
-        mul     x11, x4, x5;                    \
-        umulh   x12, x4, x5;                    \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adc     x13, xzr, xzr;                  \
-        adds    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        adcs    x6, x6, x13;                    \
-        adcs    x7, x7, xzr;                    \
-        mov     x11, #-4294967296;              \
-        adds    x5, x8, #1;                     \
-        sbcs    x11, x9, x11;                   \
-        mov     x13, #-4294967297;              \
-        adcs    x12, x10, xzr;                  \
-        sbcs    x13, x6, x13;                   \
-        sbcs    xzr, x7, xzr;                   \
-        csel    x8, x5, x8, hs;                 \
-        csel    x9, x11, x9, hs;                \
-        csel    x10, x12, x10, hs;              \
-        csel    x6, x13, x6, hs;                \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        ldp     x4, x5, [P1+16] __LF               \
+        umull   x15, w2, w2 __LF                   \
+        lsr     x11, x2, #32 __LF                  \
+        umull   x16, w11, w11 __LF                 \
+        umull   x11, w2, w11 __LF                  \
+        adds    x15, x15, x11, lsl #33 __LF        \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x16, x16, x11 __LF                 \
+        umull   x0, w3, w3 __LF                    \
+        lsr     x11, x3, #32 __LF                  \
+        umull   x1, w11, w11 __LF                  \
+        umull   x11, w3, w11 __LF                  \
+        mul     x12, x2, x3 __LF                   \
+        umulh   x13, x2, x3 __LF                   \
+        adds    x0, x0, x11, lsl #33 __LF          \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x1, x1, x11 __LF                   \
+        adds    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x16, x12 __LF                 \
+        adcs    x0, x0, x13 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        lsl     x12, x15, #32 __LF                 \
+        lsr     x11, x15, #32 __LF                 \
+        subs    x14, x12, x15 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x16, x16, x14 __LF                 \
+        sbcs    x0, x0, x13 __LF                   \
+        sbcs    x1, x1, x12 __LF                   \
+        sbc     x15, x15, x11 __LF                 \
+        lsl     x12, x16, #32 __LF                 \
+        lsr     x11, x16, #32 __LF                 \
+        subs    x14, x12, x16 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x0, x0, x14 __LF                   \
+        sbcs    x1, x1, x13 __LF                   \
+        sbcs    x15, x15, x12 __LF                 \
+        sbc     x16, x16, x11 __LF                 \
+        mul     x6, x2, x4 __LF                    \
+        mul     x14, x3, x5 __LF                   \
+        umulh   x8, x2, x4 __LF                    \
+        subs    x10, x2, x3 __LF                   \
+        cneg    x10, x10, lo __LF                  \
+        csetm   x13, lo __LF                       \
+        subs    x12, x5, x4 __LF                   \
+        cneg    x12, x12, lo __LF                  \
+        mul     x11, x10, x12 __LF                 \
+        umulh   x12, x10, x12 __LF                 \
+        cinv    x13, x13, lo __LF                  \
+        eor     x11, x11, x13 __LF                 \
+        eor     x12, x12, x13 __LF                 \
+        adds    x7, x6, x8 __LF                    \
+        adc     x8, x8, xzr __LF                   \
+        umulh   x9, x3, x5 __LF                    \
+        adds    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x9 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x8, x8, x14 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        cmn     x13, #1 __LF                       \
+        adcs    x7, x7, x11 __LF                   \
+        adcs    x8, x8, x12 __LF                   \
+        adc     x9, x9, x13 __LF                   \
+        adds    x6, x6, x6 __LF                    \
+        adcs    x7, x7, x7 __LF                    \
+        adcs    x8, x8, x8 __LF                    \
+        adcs    x9, x9, x9 __LF                    \
+        adc     x10, xzr, xzr __LF                 \
+        adds    x6, x6, x0 __LF                    \
+        adcs    x7, x7, x1 __LF                    \
+        adcs    x8, x8, x15 __LF                   \
+        adcs    x9, x9, x16 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        lsl     x12, x6, #32 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        subs    x14, x12, x6 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x7, x7, x14 __LF                   \
+        sbcs    x8, x8, x13 __LF                   \
+        sbcs    x9, x9, x12 __LF                   \
+        sbc     x14, x6, x11 __LF                  \
+        adds    x10, x10, x14 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        lsl     x12, x7, #32 __LF                  \
+        lsr     x11, x7, #32 __LF                  \
+        subs    x14, x12, x7 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x8, x8, x14 __LF                   \
+        sbcs    x9, x9, x13 __LF                   \
+        sbcs    x10, x10, x12 __LF                 \
+        sbc     x14, x7, x11 __LF                  \
+        adds    x6, x6, x14 __LF                   \
+        adc     x7, xzr, xzr __LF                  \
+        mul     x11, x4, x4 __LF                   \
+        adds    x8, x8, x11 __LF                   \
+        mul     x12, x5, x5 __LF                   \
+        umulh   x11, x4, x4 __LF                   \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        umulh   x12, x5, x5 __LF                   \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        umulh   x12, x4, x5 __LF                   \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adc     x13, xzr, xzr __LF                 \
+        adds    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        adcs    x6, x6, x13 __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x11, #-4294967296 __LF             \
+        adds    x5, x8, #1 __LF                    \
+        sbcs    x11, x9, x11 __LF                  \
+        mov     x13, #-4294967297 __LF             \
+        adcs    x12, x10, xzr __LF                 \
+        sbcs    x13, x6, x13 __LF                  \
+        sbcs    xzr, x7, xzr __LF                  \
+        csel    x8, x5, x8, hs __LF                \
+        csel    x9, x11, x9, hs __LF               \
+        csel    x10, x12, x10, hs __LF             \
+        csel    x6, x13, x6, hs __LF               \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x6, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjadd):

--- a/arm/sm2/sm2_montjadd_alt.S
+++ b/arm/sm2/sm2_montjadd_alt.S
@@ -77,337 +77,337 @@
 // Corresponds to bignum_montmul_sm2_alt except for registers
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        lsl     x11, x12, #32;                  \
-        lsr     x6, x12, #32;                   \
-        subs    x8, x11, x12;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x13, x13, x8;                   \
-        sbcs    x14, x14, x7;                   \
-        sbcs    x0, x0, x11;                    \
-        sbc     x12, x12, x6;                   \
-        lsl     x11, x13, #32;                  \
-        lsr     x6, x13, #32;                   \
-        subs    x8, x11, x13;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x14, x14, x8;                   \
-        sbcs    x0, x0, x7;                     \
-        sbcs    x12, x12, x11;                  \
-        sbc     x13, x13, x6;                   \
-        lsl     x11, x14, #32;                  \
-        lsr     x6, x14, #32;                   \
-        subs    x8, x11, x14;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x0, x0, x8;                     \
-        sbcs    x12, x12, x7;                   \
-        sbcs    x13, x13, x11;                  \
-        sbc     x14, x14, x6;                   \
-        lsl     x11, x0, #32;                   \
-        lsr     x6, x0, #32;                    \
-        subs    x8, x11, x0;                    \
-        sbc     x7, x6, xzr;                    \
-        subs    x12, x12, x8;                   \
-        sbcs    x13, x13, x7;                   \
-        sbcs    x14, x14, x11;                  \
-        sbc     x0, x0, x6;                     \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff00000000;       \
-        mov     x6, #0xfffffffeffffffff;        \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        adcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x6;                     \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        lsl     x11, x12, #32 __LF                 \
+        lsr     x6, x12, #32 __LF                  \
+        subs    x8, x11, x12 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x13, x13, x8 __LF                  \
+        sbcs    x14, x14, x7 __LF                  \
+        sbcs    x0, x0, x11 __LF                   \
+        sbc     x12, x12, x6 __LF                  \
+        lsl     x11, x13, #32 __LF                 \
+        lsr     x6, x13, #32 __LF                  \
+        subs    x8, x11, x13 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x14, x14, x8 __LF                  \
+        sbcs    x0, x0, x7 __LF                    \
+        sbcs    x12, x12, x11 __LF                 \
+        sbc     x13, x13, x6 __LF                  \
+        lsl     x11, x14, #32 __LF                 \
+        lsr     x6, x14, #32 __LF                  \
+        subs    x8, x11, x14 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x0, x0, x8 __LF                    \
+        sbcs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x11 __LF                 \
+        sbc     x14, x14, x6 __LF                  \
+        lsl     x11, x0, #32 __LF                  \
+        lsr     x6, x0, #32 __LF                   \
+        subs    x8, x11, x0 __LF                   \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x12, x12, x8 __LF                  \
+        sbcs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x11 __LF                 \
+        sbc     x0, x0, x6 __LF                    \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff00000000 __LF      \
+        mov     x6, #0xfffffffeffffffff __LF       \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        adcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x6 __LF                    \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2_alt exactly
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        lsl     x4, x8, #32;                    \
-        lsr     x5, x8, #32;                    \
-        subs    x2, x4, x8;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x9, x9, x2;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x4;                   \
-        sbc     x8, x8, x5;                     \
-        lsl     x4, x9, #32;                    \
-        lsr     x5, x9, #32;                    \
-        subs    x2, x4, x9;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x10, x10, x2;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x8, x8, x4;                     \
-        sbc     x9, x9, x5;                     \
-        lsl     x4, x10, #32;                   \
-        lsr     x5, x10, #32;                   \
-        subs    x2, x4, x10;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x11, x11, x2;                   \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x4;                     \
-        sbc     x10, x10, x5;                   \
-        lsl     x4, x11, #32;                   \
-        lsr     x5, x11, #32;                   \
-        subs    x2, x4, x11;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, x4;                   \
-        sbc     x11, x11, x5;                   \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, cs;                         \
-        mov     x3, #0xffffffff00000000;        \
-        mov     x5, #0xfffffffeffffffff;        \
-        adds    x12, x8, #0x1;                  \
-        sbcs    x13, x9, x3;                    \
-        adcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, cc;                \
-        csel    x9, x9, x13, cc;                \
-        csel    x10, x10, x14, cc;              \
-        csel    x11, x11, x7, cc;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        lsl     x4, x8, #32 __LF                   \
+        lsr     x5, x8, #32 __LF                   \
+        subs    x2, x4, x8 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x9, x9, x2 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        lsl     x4, x9, #32 __LF                   \
+        lsr     x5, x9, #32 __LF                   \
+        subs    x2, x4, x9 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x10, x10, x2 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x8, x8, x4 __LF                    \
+        sbc     x9, x9, x5 __LF                    \
+        lsl     x4, x10, #32 __LF                  \
+        lsr     x5, x10, #32 __LF                  \
+        subs    x2, x4, x10 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x11, x11, x2 __LF                  \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbc     x10, x10, x5 __LF                  \
+        lsl     x4, x11, #32 __LF                  \
+        lsr     x5, x11, #32 __LF                  \
+        subs    x2, x4, x11 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, cs __LF                        \
+        mov     x3, #0xffffffff00000000 __LF       \
+        mov     x5, #0xfffffffeffffffff __LF       \
+        adds    x12, x8, #0x1 __LF                 \
+        sbcs    x13, x9, x3 __LF                   \
+        adcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, cc __LF               \
+        csel    x9, x9, x13, cc __LF               \
+        csel    x10, x10, x14, cc __LF             \
+        csel    x11, x11, x7, cc __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Almost-Montgomery variant which we use when an input to other muls
 // with the other argument fully reduced (which is always safe).
 
 #define amontsqr_sm2(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        lsl     x4, x8, #32;                    \
-        lsr     x5, x8, #32;                    \
-        subs    x2, x4, x8;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x9, x9, x2;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x4;                   \
-        sbc     x8, x8, x5;                     \
-        lsl     x4, x9, #32;                    \
-        lsr     x5, x9, #32;                    \
-        subs    x2, x4, x9;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x10, x10, x2;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x8, x8, x4;                     \
-        sbc     x9, x9, x5;                     \
-        lsl     x4, x10, #32;                   \
-        lsr     x5, x10, #32;                   \
-        subs    x2, x4, x10;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x11, x11, x2;                   \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x4;                     \
-        sbc     x10, x10, x5;                   \
-        lsl     x4, x11, #32;                   \
-        lsr     x5, x11, #32;                   \
-        subs    x2, x4, x11;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, x4;                   \
-        sbc     x11, x11, x5;                   \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        csetm   x2, cs;                         \
-        subs    x8, x8, x2;                     \
-        and     x3, x2, #0xffffffff00000000;    \
-        sbcs    x9, x9, x3;                     \
-        and     x5, x2, #0xfffffffeffffffff;    \
-        sbcs    x10, x10, x2;                   \
-        sbc     x11, x11, x5;                   \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        lsl     x4, x8, #32 __LF                   \
+        lsr     x5, x8, #32 __LF                   \
+        subs    x2, x4, x8 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x9, x9, x2 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        lsl     x4, x9, #32 __LF                   \
+        lsr     x5, x9, #32 __LF                   \
+        subs    x2, x4, x9 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x10, x10, x2 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x8, x8, x4 __LF                    \
+        sbc     x9, x9, x5 __LF                    \
+        lsl     x4, x10, #32 __LF                  \
+        lsr     x5, x10, #32 __LF                  \
+        subs    x2, x4, x10 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x11, x11, x2 __LF                  \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbc     x10, x10, x5 __LF                  \
+        lsl     x4, x11, #32 __LF                  \
+        lsr     x5, x11, #32 __LF                  \
+        subs    x2, x4, x11 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        csetm   x2, cs __LF                        \
+        subs    x8, x8, x2 __LF                    \
+        and     x3, x2, #0xffffffff00000000 __LF   \
+        sbcs    x9, x9, x3 __LF                    \
+        and     x5, x2, #0xfffffffeffffffff __LF   \
+        sbcs    x10, x10, x2 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjadd_alt):

--- a/arm/sm2/sm2_montjdouble.S
+++ b/arm/sm2/sm2_montjdouble.S
@@ -63,373 +63,373 @@
 // Corresponds to bignum_montmul_sm2 exactly
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2];                   \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x17, x12, x14;                  \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x3, x4;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x17, x8, x7;                    \
-        cneg    x17, x17, lo;                   \
-        mul     x16, x15, x17;                  \
-        umulh   x17, x15, x17;                  \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x17, x17, x1;                   \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adc     x14, x14, x1;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x17, x15, xzr;                  \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x17;                  \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x17, x15, xzr;                  \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x17;                  \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        stp     x13, x14, [P0];                 \
-        stp     x11, x12, [P0+16];              \
-        mul     x11, x5, x9;                    \
-        mul     x13, x6, x10;                   \
-        umulh   x12, x5, x9;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x6, x10;                   \
-        adcs    x17, x12, x14;                  \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x5, x6;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x17, x10, x9;                   \
-        cneg    x17, x17, lo;                   \
-        mul     x16, x15, x17;                  \
-        umulh   x17, x15, x17;                  \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x17, x17, x1;                   \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adc     x14, x14, x1;                   \
-        subs    x3, x5, x3;                     \
-        sbcs    x4, x6, x4;                     \
-        ngc     x5, xzr;                        \
-        cmn     x5, #1;                         \
-        eor     x3, x3, x5;                     \
-        adcs    x3, x3, xzr;                    \
-        eor     x4, x4, x5;                     \
-        adcs    x4, x4, xzr;                    \
-        subs    x7, x7, x9;                     \
-        sbcs    x8, x8, x10;                    \
-        ngc     x9, xzr;                        \
-        cmn     x9, #1;                         \
-        eor     x7, x7, x9;                     \
-        adcs    x7, x7, xzr;                    \
-        eor     x8, x8, x9;                     \
-        adcs    x8, x8, xzr;                    \
-        eor     x10, x5, x9;                    \
-        ldp     x15, x1, [P0];                  \
-        adds    x15, x11, x15;                  \
-        adcs    x1, x12, x1;                    \
-        ldp     x5, x9, [P0+16];                \
-        adcs    x5, x13, x5;                    \
-        adcs    x9, x14, x9;                    \
-        adc     x2, xzr, xzr;                   \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x17, x12, x14;                  \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adcs    x14, x14, xzr;                  \
-        subs    x3, x3, x4;                     \
-        cneg    x3, x3, lo;                     \
-        csetm   x4, lo;                         \
-        subs    x17, x8, x7;                    \
-        cneg    x17, x17, lo;                   \
-        mul     x16, x3, x17;                   \
-        umulh   x17, x3, x17;                   \
-        cinv    x4, x4, lo;                     \
-        eor     x16, x16, x4;                   \
-        eor     x17, x17, x4;                   \
-        cmn     x4, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x17;                  \
-        adc     x14, x14, x4;                   \
-        cmn     x10, #1;                        \
-        eor     x11, x11, x10;                  \
-        adcs    x11, x11, x15;                  \
-        eor     x12, x12, x10;                  \
-        adcs    x12, x12, x1;                   \
-        eor     x13, x13, x10;                  \
-        adcs    x13, x13, x5;                   \
-        eor     x14, x14, x10;                  \
-        adcs    x14, x14, x9;                   \
-        adcs    x3, x2, x10;                    \
-        adcs    x4, x10, xzr;                   \
-        adc     x10, x10, xzr;                  \
-        adds    x13, x13, x15;                  \
-        adcs    x14, x14, x1;                   \
-        adcs    x3, x3, x5;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x10, x10, x2;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x17, x15, xzr;                  \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x17;                  \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x17, x15, xzr;                  \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x17;                  \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        adds    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adc     x10, x10, xzr;                  \
-        add     x2, x10, #1;                    \
-        lsl     x15, x2, #32;                   \
-        sub     x16, x15, x2;                   \
-        adds    x13, x13, x2;                   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, x15;                    \
-        csetm   x7, lo;                         \
-        adds    x13, x13, x7;                   \
-        and     x16, x7, #0xffffffff00000000;   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, x7;                     \
-        and     x15, x7, #0xfffffffeffffffff;   \
-        adc     x4, x4, x15;                    \
-        stp     x13, x14, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2] __LF                  \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x17, x12, x14 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x3, x4 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x17, x8, x7 __LF                   \
+        cneg    x17, x17, lo __LF                  \
+        mul     x16, x15, x17 __LF                 \
+        umulh   x17, x15, x17 __LF                 \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x17, x17, x1 __LF                  \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adc     x14, x14, x1 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x17, x15, xzr __LF                 \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x17 __LF                 \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x17, x15, xzr __LF                 \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x17 __LF                 \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        stp     x13, x14, [P0] __LF                \
+        stp     x11, x12, [P0+16] __LF             \
+        mul     x11, x5, x9 __LF                   \
+        mul     x13, x6, x10 __LF                  \
+        umulh   x12, x5, x9 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x6, x10 __LF                  \
+        adcs    x17, x12, x14 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x5, x6 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x17, x10, x9 __LF                  \
+        cneg    x17, x17, lo __LF                  \
+        mul     x16, x15, x17 __LF                 \
+        umulh   x17, x15, x17 __LF                 \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x17, x17, x1 __LF                  \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adc     x14, x14, x1 __LF                  \
+        subs    x3, x5, x3 __LF                    \
+        sbcs    x4, x6, x4 __LF                    \
+        ngc     x5, xzr __LF                       \
+        cmn     x5, #1 __LF                        \
+        eor     x3, x3, x5 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        eor     x4, x4, x5 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        subs    x7, x7, x9 __LF                    \
+        sbcs    x8, x8, x10 __LF                   \
+        ngc     x9, xzr __LF                       \
+        cmn     x9, #1 __LF                        \
+        eor     x7, x7, x9 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        eor     x8, x8, x9 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        eor     x10, x5, x9 __LF                   \
+        ldp     x15, x1, [P0] __LF                 \
+        adds    x15, x11, x15 __LF                 \
+        adcs    x1, x12, x1 __LF                   \
+        ldp     x5, x9, [P0+16] __LF               \
+        adcs    x5, x13, x5 __LF                   \
+        adcs    x9, x14, x9 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x17, x12, x14 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x3, x3, x4 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        csetm   x4, lo __LF                        \
+        subs    x17, x8, x7 __LF                   \
+        cneg    x17, x17, lo __LF                  \
+        mul     x16, x3, x17 __LF                  \
+        umulh   x17, x3, x17 __LF                  \
+        cinv    x4, x4, lo __LF                    \
+        eor     x16, x16, x4 __LF                  \
+        eor     x17, x17, x4 __LF                  \
+        cmn     x4, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x17 __LF                 \
+        adc     x14, x14, x4 __LF                  \
+        cmn     x10, #1 __LF                       \
+        eor     x11, x11, x10 __LF                 \
+        adcs    x11, x11, x15 __LF                 \
+        eor     x12, x12, x10 __LF                 \
+        adcs    x12, x12, x1 __LF                  \
+        eor     x13, x13, x10 __LF                 \
+        adcs    x13, x13, x5 __LF                  \
+        eor     x14, x14, x10 __LF                 \
+        adcs    x14, x14, x9 __LF                  \
+        adcs    x3, x2, x10 __LF                   \
+        adcs    x4, x10, xzr __LF                  \
+        adc     x10, x10, xzr __LF                 \
+        adds    x13, x13, x15 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adcs    x3, x3, x5 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x10, x10, x2 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x17, x15, xzr __LF                 \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x17 __LF                 \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x17, x15, xzr __LF                 \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x17 __LF                 \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        adds    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        add     x2, x10, #1 __LF                   \
+        lsl     x15, x2, #32 __LF                  \
+        sub     x16, x15, x2 __LF                  \
+        adds    x13, x13, x2 __LF                  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, x15 __LF                   \
+        csetm   x7, lo __LF                        \
+        adds    x13, x13, x7 __LF                  \
+        and     x16, x7, #0xffffffff00000000 __LF  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, x7 __LF                    \
+        and     x15, x7, #0xfffffffeffffffff __LF  \
+        adc     x4, x4, x15 __LF                   \
+        stp     x13, x14, [P0] __LF                \
         stp     x3, x4, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2 exactly
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        ldp     x4, x5, [P1+16];                \
-        umull   x15, w2, w2;                    \
-        lsr     x11, x2, #32;                   \
-        umull   x16, w11, w11;                  \
-        umull   x11, w2, w11;                   \
-        adds    x15, x15, x11, lsl #33;         \
-        lsr     x11, x11, #31;                  \
-        adc     x16, x16, x11;                  \
-        umull   x17, w3, w3;                    \
-        lsr     x11, x3, #32;                   \
-        umull   x1, w11, w11;                   \
-        umull   x11, w3, w11;                   \
-        mul     x12, x2, x3;                    \
-        umulh   x13, x2, x3;                    \
-        adds    x17, x17, x11, lsl #33;         \
-        lsr     x11, x11, #31;                  \
-        adc     x1, x1, x11;                    \
-        adds    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x16, x12;                  \
-        adcs    x17, x17, x13;                  \
-        adc     x1, x1, xzr;                    \
-        lsl     x12, x15, #32;                  \
-        lsr     x11, x15, #32;                  \
-        subs    x14, x12, x15;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x16, x16, x14;                  \
-        sbcs    x17, x17, x13;                  \
-        sbcs    x1, x1, x12;                    \
-        sbc     x15, x15, x11;                  \
-        lsl     x12, x16, #32;                  \
-        lsr     x11, x16, #32;                  \
-        subs    x14, x12, x16;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x17, x17, x14;                  \
-        sbcs    x1, x1, x13;                    \
-        sbcs    x15, x15, x12;                  \
-        sbc     x16, x16, x11;                  \
-        mul     x6, x2, x4;                     \
-        mul     x14, x3, x5;                    \
-        umulh   x8, x2, x4;                     \
-        subs    x10, x2, x3;                    \
-        cneg    x10, x10, lo;                   \
-        csetm   x13, lo;                        \
-        subs    x12, x5, x4;                    \
-        cneg    x12, x12, lo;                   \
-        mul     x11, x10, x12;                  \
-        umulh   x12, x10, x12;                  \
-        cinv    x13, x13, lo;                   \
-        eor     x11, x11, x13;                  \
-        eor     x12, x12, x13;                  \
-        adds    x7, x6, x8;                     \
-        adc     x8, x8, xzr;                    \
-        umulh   x9, x3, x5;                     \
-        adds    x7, x7, x14;                    \
-        adcs    x8, x8, x9;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x8, x8, x14;                    \
-        adc     x9, x9, xzr;                    \
-        cmn     x13, #1;                        \
-        adcs    x7, x7, x11;                    \
-        adcs    x8, x8, x12;                    \
-        adc     x9, x9, x13;                    \
-        adds    x6, x6, x6;                     \
-        adcs    x7, x7, x7;                     \
-        adcs    x8, x8, x8;                     \
-        adcs    x9, x9, x9;                     \
-        adc     x10, xzr, xzr;                  \
-        adds    x6, x6, x17;                    \
-        adcs    x7, x7, x1;                     \
-        adcs    x8, x8, x15;                    \
-        adcs    x9, x9, x16;                    \
-        adc     x10, x10, xzr;                  \
-        lsl     x12, x6, #32;                   \
-        lsr     x11, x6, #32;                   \
-        subs    x14, x12, x6;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x7, x7, x14;                    \
-        sbcs    x8, x8, x13;                    \
-        sbcs    x9, x9, x12;                    \
-        sbc     x14, x6, x11;                   \
-        adds    x10, x10, x14;                  \
-        adc     x6, xzr, xzr;                   \
-        lsl     x12, x7, #32;                   \
-        lsr     x11, x7, #32;                   \
-        subs    x14, x12, x7;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x8, x8, x14;                    \
-        sbcs    x9, x9, x13;                    \
-        sbcs    x10, x10, x12;                  \
-        sbc     x14, x7, x11;                   \
-        adds    x6, x6, x14;                    \
-        adc     x7, xzr, xzr;                   \
-        mul     x11, x4, x4;                    \
-        adds    x8, x8, x11;                    \
-        mul     x12, x5, x5;                    \
-        umulh   x11, x4, x4;                    \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        umulh   x12, x5, x5;                    \
-        adcs    x6, x6, x12;                    \
-        adc     x7, x7, xzr;                    \
-        mul     x11, x4, x5;                    \
-        umulh   x12, x4, x5;                    \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adc     x13, xzr, xzr;                  \
-        adds    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        adcs    x6, x6, x13;                    \
-        adcs    x7, x7, xzr;                    \
-        mov     x11, #-4294967296;              \
-        adds    x5, x8, #1;                     \
-        sbcs    x11, x9, x11;                   \
-        mov     x13, #-4294967297;              \
-        adcs    x12, x10, xzr;                  \
-        sbcs    x13, x6, x13;                   \
-        sbcs    xzr, x7, xzr;                   \
-        csel    x8, x5, x8, hs;                 \
-        csel    x9, x11, x9, hs;                \
-        csel    x10, x12, x10, hs;              \
-        csel    x6, x13, x6, hs;                \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        ldp     x4, x5, [P1+16] __LF               \
+        umull   x15, w2, w2 __LF                   \
+        lsr     x11, x2, #32 __LF                  \
+        umull   x16, w11, w11 __LF                 \
+        umull   x11, w2, w11 __LF                  \
+        adds    x15, x15, x11, lsl #33 __LF        \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x16, x16, x11 __LF                 \
+        umull   x17, w3, w3 __LF                   \
+        lsr     x11, x3, #32 __LF                  \
+        umull   x1, w11, w11 __LF                  \
+        umull   x11, w3, w11 __LF                  \
+        mul     x12, x2, x3 __LF                   \
+        umulh   x13, x2, x3 __LF                   \
+        adds    x17, x17, x11, lsl #33 __LF        \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x1, x1, x11 __LF                   \
+        adds    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x16, x12 __LF                 \
+        adcs    x17, x17, x13 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        lsl     x12, x15, #32 __LF                 \
+        lsr     x11, x15, #32 __LF                 \
+        subs    x14, x12, x15 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x16, x16, x14 __LF                 \
+        sbcs    x17, x17, x13 __LF                 \
+        sbcs    x1, x1, x12 __LF                   \
+        sbc     x15, x15, x11 __LF                 \
+        lsl     x12, x16, #32 __LF                 \
+        lsr     x11, x16, #32 __LF                 \
+        subs    x14, x12, x16 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x17, x17, x14 __LF                 \
+        sbcs    x1, x1, x13 __LF                   \
+        sbcs    x15, x15, x12 __LF                 \
+        sbc     x16, x16, x11 __LF                 \
+        mul     x6, x2, x4 __LF                    \
+        mul     x14, x3, x5 __LF                   \
+        umulh   x8, x2, x4 __LF                    \
+        subs    x10, x2, x3 __LF                   \
+        cneg    x10, x10, lo __LF                  \
+        csetm   x13, lo __LF                       \
+        subs    x12, x5, x4 __LF                   \
+        cneg    x12, x12, lo __LF                  \
+        mul     x11, x10, x12 __LF                 \
+        umulh   x12, x10, x12 __LF                 \
+        cinv    x13, x13, lo __LF                  \
+        eor     x11, x11, x13 __LF                 \
+        eor     x12, x12, x13 __LF                 \
+        adds    x7, x6, x8 __LF                    \
+        adc     x8, x8, xzr __LF                   \
+        umulh   x9, x3, x5 __LF                    \
+        adds    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x9 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x8, x8, x14 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        cmn     x13, #1 __LF                       \
+        adcs    x7, x7, x11 __LF                   \
+        adcs    x8, x8, x12 __LF                   \
+        adc     x9, x9, x13 __LF                   \
+        adds    x6, x6, x6 __LF                    \
+        adcs    x7, x7, x7 __LF                    \
+        adcs    x8, x8, x8 __LF                    \
+        adcs    x9, x9, x9 __LF                    \
+        adc     x10, xzr, xzr __LF                 \
+        adds    x6, x6, x17 __LF                   \
+        adcs    x7, x7, x1 __LF                    \
+        adcs    x8, x8, x15 __LF                   \
+        adcs    x9, x9, x16 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        lsl     x12, x6, #32 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        subs    x14, x12, x6 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x7, x7, x14 __LF                   \
+        sbcs    x8, x8, x13 __LF                   \
+        sbcs    x9, x9, x12 __LF                   \
+        sbc     x14, x6, x11 __LF                  \
+        adds    x10, x10, x14 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        lsl     x12, x7, #32 __LF                  \
+        lsr     x11, x7, #32 __LF                  \
+        subs    x14, x12, x7 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x8, x8, x14 __LF                   \
+        sbcs    x9, x9, x13 __LF                   \
+        sbcs    x10, x10, x12 __LF                 \
+        sbc     x14, x7, x11 __LF                  \
+        adds    x6, x6, x14 __LF                   \
+        adc     x7, xzr, xzr __LF                  \
+        mul     x11, x4, x4 __LF                   \
+        adds    x8, x8, x11 __LF                   \
+        mul     x12, x5, x5 __LF                   \
+        umulh   x11, x4, x4 __LF                   \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        umulh   x12, x5, x5 __LF                   \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        umulh   x12, x4, x5 __LF                   \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adc     x13, xzr, xzr __LF                 \
+        adds    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        adcs    x6, x6, x13 __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x11, #-4294967296 __LF             \
+        adds    x5, x8, #1 __LF                    \
+        sbcs    x11, x9, x11 __LF                  \
+        mov     x13, #-4294967297 __LF             \
+        adcs    x12, x10, xzr __LF                 \
+        sbcs    x13, x6, x13 __LF                  \
+        sbcs    xzr, x7, xzr __LF                  \
+        csel    x8, x5, x8, hs __LF                \
+        csel    x9, x11, x9, hs __LF               \
+        csel    x10, x12, x10, hs __LF             \
+        csel    x6, x13, x6, hs __LF               \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x6, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Corresponds exactly to bignum_add_sm2
 
 #define add_sm2(P0,P1,P2)                       \
-        ldp     x4, x5, [P1];                   \
-        ldp     x8, x9, [P2];                   \
-        adds    x4, x4, x8;                     \
-        adcs    x5, x5, x9;                     \
-        ldp     x6, x7, [P1+16];                \
-        ldp     x10, x11, [P2+16];              \
-        adcs    x6, x6, x10;                    \
-        adcs    x7, x7, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        adds    x8, x4, #0x1;                   \
-        mov     x9, #0xffffffff00000000;        \
-        sbcs    x9, x5, x9;                     \
-        adcs    x10, x6, xzr;                   \
-        mov     x11, #0xfffffffeffffffff;       \
-        sbcs    x11, x7, x11;                   \
-        sbcs    x3, x3, xzr;                    \
-        csel    x4, x4, x8, cc;                 \
-        csel    x5, x5, x9, cc;                 \
-        csel    x6, x6, x10, cc;                \
-        csel    x7, x7, x11, cc;                \
-        stp     x4, x5, [P0];                   \
+        ldp     x4, x5, [P1] __LF                  \
+        ldp     x8, x9, [P2] __LF                  \
+        adds    x4, x4, x8 __LF                    \
+        adcs    x5, x5, x9 __LF                    \
+        ldp     x6, x7, [P1+16] __LF               \
+        ldp     x10, x11, [P2+16] __LF             \
+        adcs    x6, x6, x10 __LF                   \
+        adcs    x7, x7, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        adds    x8, x4, #0x1 __LF                  \
+        mov     x9, #0xffffffff00000000 __LF       \
+        sbcs    x9, x5, x9 __LF                    \
+        adcs    x10, x6, xzr __LF                  \
+        mov     x11, #0xfffffffeffffffff __LF      \
+        sbcs    x11, x7, x11 __LF                  \
+        sbcs    x3, x3, xzr __LF                   \
+        csel    x4, x4, x8, cc __LF                \
+        csel    x5, x5, x9, cc __LF                \
+        csel    x6, x6, x10, cc __LF               \
+        csel    x7, x7, x11, cc __LF               \
+        stp     x4, x5, [P0] __LF                  \
         stp     x6, x7, [P0+16]
 
 // A weak version of add that only guarantees sum in 4 digits
 
 #define weakadd_sm2(P0,P1,P2)                   \
-        ldp     x4, x5, [P1];                   \
-        ldp     x8, x9, [P2];                   \
-        adds    x4, x4, x8;                     \
-        adcs    x5, x5, x9;                     \
-        ldp     x6, x7, [P1+16];                \
-        ldp     x10, x11, [P2+16];              \
-        adcs    x6, x6, x10;                    \
-        adcs    x7, x7, x11;                    \
-        csetm   x2, cs;                         \
-        subs    x4, x4, x2;                     \
-        and     x3, x2, #0xffffffff00000000;    \
-        sbcs    x5, x5, x3;                     \
-        and     x1, x2, #0xfffffffeffffffff;    \
-        sbcs    x6, x6, x2;                     \
-        sbc     x7, x7, x1;                     \
-        stp     x4, x5, [P0];                   \
+        ldp     x4, x5, [P1] __LF                  \
+        ldp     x8, x9, [P2] __LF                  \
+        adds    x4, x4, x8 __LF                    \
+        adcs    x5, x5, x9 __LF                    \
+        ldp     x6, x7, [P1+16] __LF               \
+        ldp     x10, x11, [P2+16] __LF             \
+        adcs    x6, x6, x10 __LF                   \
+        adcs    x7, x7, x11 __LF                   \
+        csetm   x2, cs __LF                        \
+        subs    x4, x4, x2 __LF                    \
+        and     x3, x2, #0xffffffff00000000 __LF   \
+        sbcs    x5, x5, x3 __LF                    \
+        and     x1, x2, #0xfffffffeffffffff __LF   \
+        sbcs    x6, x6, x2 __LF                    \
+        sbc     x7, x7, x1 __LF                    \
+        stp     x4, x5, [P0] __LF                  \
         stp     x6, x7, [P0+16]
 
 // P0 = C * P1 - D * P2 computed as D * (p_sm2 - P2) + C * P1
@@ -437,63 +437,63 @@
 // This also applies to the other functions following.
 
 #define cmsub_sm2(P0,C,P1,D,P2)                 \
-        mov     x1, D;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x3, #0xffffffff00000000;        \
-        sbcs    x10, x3, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, x2, x11;                   \
-        mov     x4, #0xfffffffeffffffff;        \
-        sbc     x12, x4, x12;                   \
-        mul     x3, x1, x9;                     \
-        mul     x4, x1, x10;                    \
-        mul     x5, x1, x11;                    \
-        mul     x6, x1, x12;                    \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        umulh   x11, x1, x11;                   \
-        umulh   x7, x1, x12;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, xzr;                    \
-        mov     x1, C;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x7, x7, #0x1;                   \
-        lsl     x8, x7, #32;                    \
-        sub     x9, x8, x7;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, x8;                     \
-        csetm   x7, cc;                         \
-        adds    x3, x3, x7;                     \
-        and     x9, x7, #0xffffffff00000000;    \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x7;                     \
-        and     x8, x7, #0xfffffffeffffffff;    \
-        adc     x6, x6, x8;                     \
-        stp     x3, x4, [P0];                   \
+        mov     x1, D __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x3, #0xffffffff00000000 __LF       \
+        sbcs    x10, x3, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, x2, x11 __LF                  \
+        mov     x4, #0xfffffffeffffffff __LF       \
+        sbc     x12, x4, x12 __LF                  \
+        mul     x3, x1, x9 __LF                    \
+        mul     x4, x1, x10 __LF                   \
+        mul     x5, x1, x11 __LF                   \
+        mul     x6, x1, x12 __LF                   \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        umulh   x11, x1, x11 __LF                  \
+        umulh   x7, x1, x12 __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mov     x1, C __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x7, x7, #0x1 __LF                  \
+        lsl     x8, x7, #32 __LF                   \
+        sub     x9, x8, x7 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, x8 __LF                    \
+        csetm   x7, cc __LF                        \
+        adds    x3, x3, x7 __LF                    \
+        and     x9, x7, #0xffffffff00000000 __LF   \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        and     x8, x7, #0xfffffffeffffffff __LF   \
+        adc     x6, x6, x8 __LF                    \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // P0 = 4 * P1 - P2, by direct subtraction of P2; the method
@@ -502,90 +502,90 @@
 // long as it is > -p_sm2, which is the case here.
 
 #define cmsub41_sm2(P0,P1,P2)                   \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        lsr     x4, x4, #62;                    \
-        sbc     x4, x4, xzr;                    \
-        add     x4, x4, #0x1;                   \
-        lsl     x5, x4, #32;                    \
-        sub     x6, x5, x4;                     \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, x5;                     \
-        csetm   x4, cc;                         \
-        adds    x0, x0, x4;                     \
-        and     x6, x4, #0xffffffff00000000;    \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, x4;                     \
-        and     x5, x4, #0xfffffffeffffffff;    \
-        adc     x3, x3, x5;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        lsr     x4, x4, #62 __LF                   \
+        sbc     x4, x4, xzr __LF                   \
+        add     x4, x4, #0x1 __LF                  \
+        lsl     x5, x4, #32 __LF                   \
+        sub     x6, x5, x4 __LF                    \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, x5 __LF                    \
+        csetm   x4, cc __LF                        \
+        adds    x0, x0, x4 __LF                    \
+        and     x6, x4, #0xffffffff00000000 __LF   \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x4 __LF                    \
+        and     x5, x4, #0xfffffffeffffffff __LF   \
+        adc     x3, x3, x5 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2, computed as (p_sm2 - P2) << 3 + 3 * P1
 
 #define cmsub38_sm2(P0,P1,P2)                   \
-        mov     x1, 8;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x3, #0xffffffff00000000;        \
-        sbcs    x10, x3, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, x2, x11;                   \
-        mov     x4, #0xfffffffeffffffff;        \
-        sbc     x12, x4, x12;                   \
-        lsl     x3, x9, #3;                     \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        extr    x6, x12, x11, #61;              \
-        lsr     x7, x12, #61;                   \
-        mov     x1, 3;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x7, x7, #0x1;                   \
-        lsl     x8, x7, #32;                    \
-        sub     x9, x8, x7;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, x8;                     \
-        csetm   x7, cc;                         \
-        adds    x3, x3, x7;                     \
-        and     x9, x7, #0xffffffff00000000;    \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x7;                     \
-        and     x8, x7, #0xfffffffeffffffff;    \
-        adc     x6, x6, x8;                     \
-        stp     x3, x4, [P0];                   \
+        mov     x1, 8 __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x3, #0xffffffff00000000 __LF       \
+        sbcs    x10, x3, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, x2, x11 __LF                  \
+        mov     x4, #0xfffffffeffffffff __LF       \
+        sbc     x12, x4, x12 __LF                  \
+        lsl     x3, x9, #3 __LF                    \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        extr    x6, x12, x11, #61 __LF             \
+        lsr     x7, x12, #61 __LF                  \
+        mov     x1, 3 __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x7, x7, #0x1 __LF                  \
+        lsl     x8, x7, #32 __LF                   \
+        sub     x9, x8, x7 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, x8 __LF                    \
+        csetm   x7, cc __LF                        \
+        adds    x3, x3, x7 __LF                    \
+        and     x9, x7, #0xffffffff00000000 __LF   \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        and     x8, x7, #0xfffffffeffffffff __LF   \
+        adc     x6, x6, x8 __LF                    \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjdouble):

--- a/arm/sm2/sm2_montjdouble_alt.S
+++ b/arm/sm2/sm2_montjdouble_alt.S
@@ -63,289 +63,289 @@
 // Corresponds to bignum_montmul_sm2_alt except for registers
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        lsl     x11, x12, #32;                  \
-        lsr     x6, x12, #32;                   \
-        subs    x8, x11, x12;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x13, x13, x8;                   \
-        sbcs    x14, x14, x7;                   \
-        sbcs    x0, x0, x11;                    \
-        sbc     x12, x12, x6;                   \
-        lsl     x11, x13, #32;                  \
-        lsr     x6, x13, #32;                   \
-        subs    x8, x11, x13;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x14, x14, x8;                   \
-        sbcs    x0, x0, x7;                     \
-        sbcs    x12, x12, x11;                  \
-        sbc     x13, x13, x6;                   \
-        lsl     x11, x14, #32;                  \
-        lsr     x6, x14, #32;                   \
-        subs    x8, x11, x14;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x0, x0, x8;                     \
-        sbcs    x12, x12, x7;                   \
-        sbcs    x13, x13, x11;                  \
-        sbc     x14, x14, x6;                   \
-        lsl     x11, x0, #32;                   \
-        lsr     x6, x0, #32;                    \
-        subs    x8, x11, x0;                    \
-        sbc     x7, x6, xzr;                    \
-        subs    x12, x12, x8;                   \
-        sbcs    x13, x13, x7;                   \
-        sbcs    x14, x14, x11;                  \
-        sbc     x0, x0, x6;                     \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff00000000;       \
-        mov     x6, #0xfffffffeffffffff;        \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        adcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x6;                     \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        lsl     x11, x12, #32 __LF                 \
+        lsr     x6, x12, #32 __LF                  \
+        subs    x8, x11, x12 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x13, x13, x8 __LF                  \
+        sbcs    x14, x14, x7 __LF                  \
+        sbcs    x0, x0, x11 __LF                   \
+        sbc     x12, x12, x6 __LF                  \
+        lsl     x11, x13, #32 __LF                 \
+        lsr     x6, x13, #32 __LF                  \
+        subs    x8, x11, x13 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x14, x14, x8 __LF                  \
+        sbcs    x0, x0, x7 __LF                    \
+        sbcs    x12, x12, x11 __LF                 \
+        sbc     x13, x13, x6 __LF                  \
+        lsl     x11, x14, #32 __LF                 \
+        lsr     x6, x14, #32 __LF                  \
+        subs    x8, x11, x14 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x0, x0, x8 __LF                    \
+        sbcs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x11 __LF                 \
+        sbc     x14, x14, x6 __LF                  \
+        lsl     x11, x0, #32 __LF                  \
+        lsr     x6, x0, #32 __LF                   \
+        subs    x8, x11, x0 __LF                   \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x12, x12, x8 __LF                  \
+        sbcs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x11 __LF                 \
+        sbc     x0, x0, x6 __LF                    \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff00000000 __LF      \
+        mov     x6, #0xfffffffeffffffff __LF       \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        adcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x6 __LF                    \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2_alt exactly
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        lsl     x4, x8, #32;                    \
-        lsr     x5, x8, #32;                    \
-        subs    x2, x4, x8;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x9, x9, x2;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x4;                   \
-        sbc     x8, x8, x5;                     \
-        lsl     x4, x9, #32;                    \
-        lsr     x5, x9, #32;                    \
-        subs    x2, x4, x9;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x10, x10, x2;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x8, x8, x4;                     \
-        sbc     x9, x9, x5;                     \
-        lsl     x4, x10, #32;                   \
-        lsr     x5, x10, #32;                   \
-        subs    x2, x4, x10;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x11, x11, x2;                   \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x4;                     \
-        sbc     x10, x10, x5;                   \
-        lsl     x4, x11, #32;                   \
-        lsr     x5, x11, #32;                   \
-        subs    x2, x4, x11;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, x4;                   \
-        sbc     x11, x11, x5;                   \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, cs;                         \
-        mov     x3, #0xffffffff00000000;        \
-        mov     x5, #0xfffffffeffffffff;        \
-        adds    x12, x8, #0x1;                  \
-        sbcs    x13, x9, x3;                    \
-        adcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, cc;                \
-        csel    x9, x9, x13, cc;                \
-        csel    x10, x10, x14, cc;              \
-        csel    x11, x11, x7, cc;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        lsl     x4, x8, #32 __LF                   \
+        lsr     x5, x8, #32 __LF                   \
+        subs    x2, x4, x8 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x9, x9, x2 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        lsl     x4, x9, #32 __LF                   \
+        lsr     x5, x9, #32 __LF                   \
+        subs    x2, x4, x9 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x10, x10, x2 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x8, x8, x4 __LF                    \
+        sbc     x9, x9, x5 __LF                    \
+        lsl     x4, x10, #32 __LF                  \
+        lsr     x5, x10, #32 __LF                  \
+        subs    x2, x4, x10 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x11, x11, x2 __LF                  \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbc     x10, x10, x5 __LF                  \
+        lsl     x4, x11, #32 __LF                  \
+        lsr     x5, x11, #32 __LF                  \
+        subs    x2, x4, x11 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, cs __LF                        \
+        mov     x3, #0xffffffff00000000 __LF       \
+        mov     x5, #0xfffffffeffffffff __LF       \
+        adds    x12, x8, #0x1 __LF                 \
+        sbcs    x13, x9, x3 __LF                   \
+        adcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, cc __LF               \
+        csel    x9, x9, x13, cc __LF               \
+        csel    x10, x10, x14, cc __LF             \
+        csel    x11, x11, x7, cc __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 // Corresponds exactly to bignum_add_sm2
 
 #define add_sm2(P0,P1,P2)                       \
-        ldp     x4, x5, [P1];                   \
-        ldp     x8, x9, [P2];                   \
-        adds    x4, x4, x8;                     \
-        adcs    x5, x5, x9;                     \
-        ldp     x6, x7, [P1+16];                \
-        ldp     x10, x11, [P2+16];              \
-        adcs    x6, x6, x10;                    \
-        adcs    x7, x7, x11;                    \
-        adc     x3, xzr, xzr;                   \
-        adds    x8, x4, #0x1;                   \
-        mov     x9, #0xffffffff00000000;        \
-        sbcs    x9, x5, x9;                     \
-        adcs    x10, x6, xzr;                   \
-        mov     x11, #0xfffffffeffffffff;       \
-        sbcs    x11, x7, x11;                   \
-        sbcs    x3, x3, xzr;                    \
-        csel    x4, x4, x8, cc;                 \
-        csel    x5, x5, x9, cc;                 \
-        csel    x6, x6, x10, cc;                \
-        csel    x7, x7, x11, cc;                \
-        stp     x4, x5, [P0];                   \
+        ldp     x4, x5, [P1] __LF                  \
+        ldp     x8, x9, [P2] __LF                  \
+        adds    x4, x4, x8 __LF                    \
+        adcs    x5, x5, x9 __LF                    \
+        ldp     x6, x7, [P1+16] __LF               \
+        ldp     x10, x11, [P2+16] __LF             \
+        adcs    x6, x6, x10 __LF                   \
+        adcs    x7, x7, x11 __LF                   \
+        adc     x3, xzr, xzr __LF                  \
+        adds    x8, x4, #0x1 __LF                  \
+        mov     x9, #0xffffffff00000000 __LF       \
+        sbcs    x9, x5, x9 __LF                    \
+        adcs    x10, x6, xzr __LF                  \
+        mov     x11, #0xfffffffeffffffff __LF      \
+        sbcs    x11, x7, x11 __LF                  \
+        sbcs    x3, x3, xzr __LF                   \
+        csel    x4, x4, x8, cc __LF                \
+        csel    x5, x5, x9, cc __LF                \
+        csel    x6, x6, x10, cc __LF               \
+        csel    x7, x7, x11, cc __LF               \
+        stp     x4, x5, [P0] __LF                  \
         stp     x6, x7, [P0+16]
 
 // A weak version of add that only guarantees sum in 4 digits
 
 #define weakadd_sm2(P0,P1,P2)                   \
-        ldp     x4, x5, [P1];                   \
-        ldp     x8, x9, [P2];                   \
-        adds    x4, x4, x8;                     \
-        adcs    x5, x5, x9;                     \
-        ldp     x6, x7, [P1+16];                \
-        ldp     x10, x11, [P2+16];              \
-        adcs    x6, x6, x10;                    \
-        adcs    x7, x7, x11;                    \
-        csetm   x2, cs;                         \
-        subs    x4, x4, x2;                     \
-        and     x3, x2, #0xffffffff00000000;    \
-        sbcs    x5, x5, x3;                     \
-        and     x1, x2, #0xfffffffeffffffff;    \
-        sbcs    x6, x6, x2;                     \
-        sbc     x7, x7, x1;                     \
-        stp     x4, x5, [P0];                   \
+        ldp     x4, x5, [P1] __LF                  \
+        ldp     x8, x9, [P2] __LF                  \
+        adds    x4, x4, x8 __LF                    \
+        adcs    x5, x5, x9 __LF                    \
+        ldp     x6, x7, [P1+16] __LF               \
+        ldp     x10, x11, [P2+16] __LF             \
+        adcs    x6, x6, x10 __LF                   \
+        adcs    x7, x7, x11 __LF                   \
+        csetm   x2, cs __LF                        \
+        subs    x4, x4, x2 __LF                    \
+        and     x3, x2, #0xffffffff00000000 __LF   \
+        sbcs    x5, x5, x3 __LF                    \
+        and     x1, x2, #0xfffffffeffffffff __LF   \
+        sbcs    x6, x6, x2 __LF                    \
+        sbc     x7, x7, x1 __LF                    \
+        stp     x4, x5, [P0] __LF                  \
         stp     x6, x7, [P0+16]
 
 // P0 = C * P1 - D * P2 computed as D * (p_sm2 - P2) + C * P1
@@ -353,63 +353,63 @@
 // This also applies to the other functions following.
 
 #define cmsub_sm2(P0,C,P1,D,P2)                 \
-        mov     x1, D;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x3, #0xffffffff00000000;        \
-        sbcs    x10, x3, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, x2, x11;                   \
-        mov     x4, #0xfffffffeffffffff;        \
-        sbc     x12, x4, x12;                   \
-        mul     x3, x1, x9;                     \
-        mul     x4, x1, x10;                    \
-        mul     x5, x1, x11;                    \
-        mul     x6, x1, x12;                    \
-        umulh   x9, x1, x9;                     \
-        umulh   x10, x1, x10;                   \
-        umulh   x11, x1, x11;                   \
-        umulh   x7, x1, x12;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, xzr;                    \
-        mov     x1, C;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x7, x7, #0x1;                   \
-        lsl     x8, x7, #32;                    \
-        sub     x9, x8, x7;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, x8;                     \
-        csetm   x7, cc;                         \
-        adds    x3, x3, x7;                     \
-        and     x9, x7, #0xffffffff00000000;    \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x7;                     \
-        and     x8, x7, #0xfffffffeffffffff;    \
-        adc     x6, x6, x8;                     \
-        stp     x3, x4, [P0];                   \
+        mov     x1, D __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x3, #0xffffffff00000000 __LF       \
+        sbcs    x10, x3, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, x2, x11 __LF                  \
+        mov     x4, #0xfffffffeffffffff __LF       \
+        sbc     x12, x4, x12 __LF                  \
+        mul     x3, x1, x9 __LF                    \
+        mul     x4, x1, x10 __LF                   \
+        mul     x5, x1, x11 __LF                   \
+        mul     x6, x1, x12 __LF                   \
+        umulh   x9, x1, x9 __LF                    \
+        umulh   x10, x1, x10 __LF                  \
+        umulh   x11, x1, x11 __LF                  \
+        umulh   x7, x1, x12 __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mov     x1, C __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x7, x7, #0x1 __LF                  \
+        lsl     x8, x7, #32 __LF                   \
+        sub     x9, x8, x7 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, x8 __LF                    \
+        csetm   x7, cc __LF                        \
+        adds    x3, x3, x7 __LF                    \
+        and     x9, x7, #0xffffffff00000000 __LF   \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        and     x8, x7, #0xfffffffeffffffff __LF   \
+        adc     x6, x6, x8 __LF                    \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 // P0 = 4 * P1 - P2, by direct subtraction of P2; the method
@@ -418,90 +418,90 @@
 // long as it is > -p_sm2, which is the case here.
 
 #define cmsub41_sm2(P0,P1,P2)                   \
-        ldp     x1, x2, [P1];                   \
-        lsl     x0, x1, #2;                     \
-        ldp     x6, x7, [P2];                   \
-        subs    x0, x0, x6;                     \
-        extr    x1, x2, x1, #62;                \
-        sbcs    x1, x1, x7;                     \
-        ldp     x3, x4, [P1+16];                \
-        extr    x2, x3, x2, #62;                \
-        ldp     x6, x7, [P2+16];                \
-        sbcs    x2, x2, x6;                     \
-        extr    x3, x4, x3, #62;                \
-        sbcs    x3, x3, x7;                     \
-        lsr     x4, x4, #62;                    \
-        sbc     x4, x4, xzr;                    \
-        add     x4, x4, #0x1;                   \
-        lsl     x5, x4, #32;                    \
-        sub     x6, x5, x4;                     \
-        adds    x0, x0, x4;                     \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, xzr;                    \
-        adcs    x3, x3, x5;                     \
-        csetm   x4, cc;                         \
-        adds    x0, x0, x4;                     \
-        and     x6, x4, #0xffffffff00000000;    \
-        adcs    x1, x1, x6;                     \
-        adcs    x2, x2, x4;                     \
-        and     x5, x4, #0xfffffffeffffffff;    \
-        adc     x3, x3, x5;                     \
-        stp     x0, x1, [P0];                   \
+        ldp     x1, x2, [P1] __LF                  \
+        lsl     x0, x1, #2 __LF                    \
+        ldp     x6, x7, [P2] __LF                  \
+        subs    x0, x0, x6 __LF                    \
+        extr    x1, x2, x1, #62 __LF               \
+        sbcs    x1, x1, x7 __LF                    \
+        ldp     x3, x4, [P1+16] __LF               \
+        extr    x2, x3, x2, #62 __LF               \
+        ldp     x6, x7, [P2+16] __LF               \
+        sbcs    x2, x2, x6 __LF                    \
+        extr    x3, x4, x3, #62 __LF               \
+        sbcs    x3, x3, x7 __LF                    \
+        lsr     x4, x4, #62 __LF                   \
+        sbc     x4, x4, xzr __LF                   \
+        add     x4, x4, #0x1 __LF                  \
+        lsl     x5, x4, #32 __LF                   \
+        sub     x6, x5, x4 __LF                    \
+        adds    x0, x0, x4 __LF                    \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, xzr __LF                   \
+        adcs    x3, x3, x5 __LF                    \
+        csetm   x4, cc __LF                        \
+        adds    x0, x0, x4 __LF                    \
+        and     x6, x4, #0xffffffff00000000 __LF   \
+        adcs    x1, x1, x6 __LF                    \
+        adcs    x2, x2, x4 __LF                    \
+        and     x5, x4, #0xfffffffeffffffff __LF   \
+        adc     x3, x3, x5 __LF                    \
+        stp     x0, x1, [P0] __LF                  \
         stp     x2, x3, [P0+16]
 
 // P0 = 3 * P1 - 8 * P2, computed as (p_sm2 - P2) << 3 + 3 * P1
 
 #define cmsub38_sm2(P0,P1,P2)                   \
-        mov     x1, 8;                          \
-        mov     x2, #-1;                        \
-        ldp     x9, x10, [P2];                  \
-        subs    x9, x2, x9;                     \
-        mov     x3, #0xffffffff00000000;        \
-        sbcs    x10, x3, x10;                   \
-        ldp     x11, x12, [P2+16];              \
-        sbcs    x11, x2, x11;                   \
-        mov     x4, #0xfffffffeffffffff;        \
-        sbc     x12, x4, x12;                   \
-        lsl     x3, x9, #3;                     \
-        extr    x4, x10, x9, #61;               \
-        extr    x5, x11, x10, #61;              \
-        extr    x6, x12, x11, #61;              \
-        lsr     x7, x12, #61;                   \
-        mov     x1, 3;                          \
-        ldp     x9, x10, [P1];                  \
-        mul     x8, x9, x1;                     \
-        umulh   x9, x9, x1;                     \
-        adds    x3, x3, x8;                     \
-        mul     x8, x10, x1;                    \
-        umulh   x10, x10, x1;                   \
-        adcs    x4, x4, x8;                     \
-        ldp     x11, x12, [P1+16];              \
-        mul     x8, x11, x1;                    \
-        umulh   x11, x11, x1;                   \
-        adcs    x5, x5, x8;                     \
-        mul     x8, x12, x1;                    \
-        umulh   x12, x12, x1;                   \
-        adcs    x6, x6, x8;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x4, x4, x9;                     \
-        adcs    x5, x5, x10;                    \
-        adcs    x6, x6, x11;                    \
-        adc     x7, x7, x12;                    \
-        add     x7, x7, #0x1;                   \
-        lsl     x8, x7, #32;                    \
-        sub     x9, x8, x7;                     \
-        adds    x3, x3, x7;                     \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, xzr;                    \
-        adcs    x6, x6, x8;                     \
-        csetm   x7, cc;                         \
-        adds    x3, x3, x7;                     \
-        and     x9, x7, #0xffffffff00000000;    \
-        adcs    x4, x4, x9;                     \
-        adcs    x5, x5, x7;                     \
-        and     x8, x7, #0xfffffffeffffffff;    \
-        adc     x6, x6, x8;                     \
-        stp     x3, x4, [P0];                   \
+        mov     x1, 8 __LF                         \
+        mov     x2, #-1 __LF                       \
+        ldp     x9, x10, [P2] __LF                 \
+        subs    x9, x2, x9 __LF                    \
+        mov     x3, #0xffffffff00000000 __LF       \
+        sbcs    x10, x3, x10 __LF                  \
+        ldp     x11, x12, [P2+16] __LF             \
+        sbcs    x11, x2, x11 __LF                  \
+        mov     x4, #0xfffffffeffffffff __LF       \
+        sbc     x12, x4, x12 __LF                  \
+        lsl     x3, x9, #3 __LF                    \
+        extr    x4, x10, x9, #61 __LF              \
+        extr    x5, x11, x10, #61 __LF             \
+        extr    x6, x12, x11, #61 __LF             \
+        lsr     x7, x12, #61 __LF                  \
+        mov     x1, 3 __LF                         \
+        ldp     x9, x10, [P1] __LF                 \
+        mul     x8, x9, x1 __LF                    \
+        umulh   x9, x9, x1 __LF                    \
+        adds    x3, x3, x8 __LF                    \
+        mul     x8, x10, x1 __LF                   \
+        umulh   x10, x10, x1 __LF                  \
+        adcs    x4, x4, x8 __LF                    \
+        ldp     x11, x12, [P1+16] __LF             \
+        mul     x8, x11, x1 __LF                   \
+        umulh   x11, x11, x1 __LF                  \
+        adcs    x5, x5, x8 __LF                    \
+        mul     x8, x12, x1 __LF                   \
+        umulh   x12, x12, x1 __LF                  \
+        adcs    x6, x6, x8 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x10 __LF                   \
+        adcs    x6, x6, x11 __LF                   \
+        adc     x7, x7, x12 __LF                   \
+        add     x7, x7, #0x1 __LF                  \
+        lsl     x8, x7, #32 __LF                   \
+        sub     x9, x8, x7 __LF                    \
+        adds    x3, x3, x7 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, xzr __LF                   \
+        adcs    x6, x6, x8 __LF                    \
+        csetm   x7, cc __LF                        \
+        adds    x3, x3, x7 __LF                    \
+        and     x9, x7, #0xffffffff00000000 __LF   \
+        adcs    x4, x4, x9 __LF                    \
+        adcs    x5, x5, x7 __LF                    \
+        and     x8, x7, #0xfffffffeffffffff __LF   \
+        adc     x6, x6, x8 __LF                    \
+        stp     x3, x4, [P0] __LF                  \
         stp     x5, x6, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjdouble_alt):

--- a/arm/sm2/sm2_montjmixadd.S
+++ b/arm/sm2/sm2_montjmixadd.S
@@ -74,326 +74,326 @@
 // Corresponds to bignum_montmul_sm2 with x0 in place of x17
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x5, x6, [P1+16];                \
-        ldp     x7, x8, [P2];                   \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x3, x4;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x0;                   \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x0;                   \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        stp     x13, x14, [P0];                 \
-        stp     x11, x12, [P0+16];              \
-        mul     x11, x5, x9;                    \
-        mul     x13, x6, x10;                   \
-        umulh   x12, x5, x9;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x6, x10;                   \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x15, x5, x6;                    \
-        cneg    x15, x15, lo;                   \
-        csetm   x1, lo;                         \
-        subs    x0, x10, x9;                    \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x15, x0;                   \
-        umulh   x0, x15, x0;                    \
-        cinv    x1, x1, lo;                     \
-        eor     x16, x16, x1;                   \
-        eor     x0, x0, x1;                     \
-        cmn     x1, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x1;                   \
-        subs    x3, x5, x3;                     \
-        sbcs    x4, x6, x4;                     \
-        ngc     x5, xzr;                        \
-        cmn     x5, #1;                         \
-        eor     x3, x3, x5;                     \
-        adcs    x3, x3, xzr;                    \
-        eor     x4, x4, x5;                     \
-        adcs    x4, x4, xzr;                    \
-        subs    x7, x7, x9;                     \
-        sbcs    x8, x8, x10;                    \
-        ngc     x9, xzr;                        \
-        cmn     x9, #1;                         \
-        eor     x7, x7, x9;                     \
-        adcs    x7, x7, xzr;                    \
-        eor     x8, x8, x9;                     \
-        adcs    x8, x8, xzr;                    \
-        eor     x10, x5, x9;                    \
-        ldp     x15, x1, [P0];                  \
-        adds    x15, x11, x15;                  \
-        adcs    x1, x12, x1;                    \
-        ldp     x5, x9, [P0+16];                \
-        adcs    x5, x13, x5;                    \
-        adcs    x9, x14, x9;                    \
-        adc     x2, xzr, xzr;                   \
-        mul     x11, x3, x7;                    \
-        mul     x13, x4, x8;                    \
-        umulh   x12, x3, x7;                    \
-        adds    x16, x11, x13;                  \
-        umulh   x14, x4, x8;                    \
-        adcs    x0, x12, x14;                   \
-        adcs    x14, x14, xzr;                  \
-        adds    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adcs    x14, x14, xzr;                  \
-        subs    x3, x3, x4;                     \
-        cneg    x3, x3, lo;                     \
-        csetm   x4, lo;                         \
-        subs    x0, x8, x7;                     \
-        cneg    x0, x0, lo;                     \
-        mul     x16, x3, x0;                    \
-        umulh   x0, x3, x0;                     \
-        cinv    x4, x4, lo;                     \
-        eor     x16, x16, x4;                   \
-        eor     x0, x0, x4;                     \
-        cmn     x4, #1;                         \
-        adcs    x12, x12, x16;                  \
-        adcs    x13, x13, x0;                   \
-        adc     x14, x14, x4;                   \
-        cmn     x10, #1;                        \
-        eor     x11, x11, x10;                  \
-        adcs    x11, x11, x15;                  \
-        eor     x12, x12, x10;                  \
-        adcs    x12, x12, x1;                   \
-        eor     x13, x13, x10;                  \
-        adcs    x13, x13, x5;                   \
-        eor     x14, x14, x10;                  \
-        adcs    x14, x14, x9;                   \
-        adcs    x3, x2, x10;                    \
-        adcs    x4, x10, xzr;                   \
-        adc     x10, x10, xzr;                  \
-        adds    x13, x13, x15;                  \
-        adcs    x14, x14, x1;                   \
-        adcs    x3, x3, x5;                     \
-        adcs    x4, x4, x9;                     \
-        adc     x10, x10, x2;                   \
-        lsl     x16, x11, #32;                  \
-        lsr     x15, x11, #32;                  \
-        subs    x1, x16, x11;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x12, x12, x1;                   \
-        sbcs    x13, x13, x0;                   \
-        sbcs    x14, x14, x16;                  \
-        sbc     x11, x11, x15;                  \
-        lsl     x16, x12, #32;                  \
-        lsr     x15, x12, #32;                  \
-        subs    x1, x16, x12;                   \
-        sbc     x0, x15, xzr;                   \
-        subs    x13, x13, x1;                   \
-        sbcs    x14, x14, x0;                   \
-        sbcs    x11, x11, x16;                  \
-        sbc     x12, x12, x15;                  \
-        adds    x3, x3, x11;                    \
-        adcs    x4, x4, x12;                    \
-        adc     x10, x10, xzr;                  \
-        add     x2, x10, #1;                    \
-        lsl     x15, x2, #32;                   \
-        sub     x16, x15, x2;                   \
-        adds    x13, x13, x2;                   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, xzr;                    \
-        adcs    x4, x4, x15;                    \
-        csetm   x7, lo;                         \
-        adds    x13, x13, x7;                   \
-        and     x16, x7, #0xffffffff00000000;   \
-        adcs    x14, x14, x16;                  \
-        adcs    x3, x3, x7;                     \
-        and     x15, x7, #0xfffffffeffffffff;   \
-        adc     x4, x4, x15;                    \
-        stp     x13, x14, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x5, x6, [P1+16] __LF               \
+        ldp     x7, x8, [P2] __LF                  \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x3, x4 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x0 __LF                  \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x0 __LF                  \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        stp     x13, x14, [P0] __LF                \
+        stp     x11, x12, [P0+16] __LF             \
+        mul     x11, x5, x9 __LF                   \
+        mul     x13, x6, x10 __LF                  \
+        umulh   x12, x5, x9 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x6, x10 __LF                  \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x15, x5, x6 __LF                   \
+        cneg    x15, x15, lo __LF                  \
+        csetm   x1, lo __LF                        \
+        subs    x0, x10, x9 __LF                   \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x15, x0 __LF                  \
+        umulh   x0, x15, x0 __LF                   \
+        cinv    x1, x1, lo __LF                    \
+        eor     x16, x16, x1 __LF                  \
+        eor     x0, x0, x1 __LF                    \
+        cmn     x1, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x1 __LF                  \
+        subs    x3, x5, x3 __LF                    \
+        sbcs    x4, x6, x4 __LF                    \
+        ngc     x5, xzr __LF                       \
+        cmn     x5, #1 __LF                        \
+        eor     x3, x3, x5 __LF                    \
+        adcs    x3, x3, xzr __LF                   \
+        eor     x4, x4, x5 __LF                    \
+        adcs    x4, x4, xzr __LF                   \
+        subs    x7, x7, x9 __LF                    \
+        sbcs    x8, x8, x10 __LF                   \
+        ngc     x9, xzr __LF                       \
+        cmn     x9, #1 __LF                        \
+        eor     x7, x7, x9 __LF                    \
+        adcs    x7, x7, xzr __LF                   \
+        eor     x8, x8, x9 __LF                    \
+        adcs    x8, x8, xzr __LF                   \
+        eor     x10, x5, x9 __LF                   \
+        ldp     x15, x1, [P0] __LF                 \
+        adds    x15, x11, x15 __LF                 \
+        adcs    x1, x12, x1 __LF                   \
+        ldp     x5, x9, [P0+16] __LF               \
+        adcs    x5, x13, x5 __LF                   \
+        adcs    x9, x14, x9 __LF                   \
+        adc     x2, xzr, xzr __LF                  \
+        mul     x11, x3, x7 __LF                   \
+        mul     x13, x4, x8 __LF                   \
+        umulh   x12, x3, x7 __LF                   \
+        adds    x16, x11, x13 __LF                 \
+        umulh   x14, x4, x8 __LF                   \
+        adcs    x0, x12, x14 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        adds    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adcs    x14, x14, xzr __LF                 \
+        subs    x3, x3, x4 __LF                    \
+        cneg    x3, x3, lo __LF                    \
+        csetm   x4, lo __LF                        \
+        subs    x0, x8, x7 __LF                    \
+        cneg    x0, x0, lo __LF                    \
+        mul     x16, x3, x0 __LF                   \
+        umulh   x0, x3, x0 __LF                    \
+        cinv    x4, x4, lo __LF                    \
+        eor     x16, x16, x4 __LF                  \
+        eor     x0, x0, x4 __LF                    \
+        cmn     x4, #1 __LF                        \
+        adcs    x12, x12, x16 __LF                 \
+        adcs    x13, x13, x0 __LF                  \
+        adc     x14, x14, x4 __LF                  \
+        cmn     x10, #1 __LF                       \
+        eor     x11, x11, x10 __LF                 \
+        adcs    x11, x11, x15 __LF                 \
+        eor     x12, x12, x10 __LF                 \
+        adcs    x12, x12, x1 __LF                  \
+        eor     x13, x13, x10 __LF                 \
+        adcs    x13, x13, x5 __LF                  \
+        eor     x14, x14, x10 __LF                 \
+        adcs    x14, x14, x9 __LF                  \
+        adcs    x3, x2, x10 __LF                   \
+        adcs    x4, x10, xzr __LF                  \
+        adc     x10, x10, xzr __LF                 \
+        adds    x13, x13, x15 __LF                 \
+        adcs    x14, x14, x1 __LF                  \
+        adcs    x3, x3, x5 __LF                    \
+        adcs    x4, x4, x9 __LF                    \
+        adc     x10, x10, x2 __LF                  \
+        lsl     x16, x11, #32 __LF                 \
+        lsr     x15, x11, #32 __LF                 \
+        subs    x1, x16, x11 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x12, x12, x1 __LF                  \
+        sbcs    x13, x13, x0 __LF                  \
+        sbcs    x14, x14, x16 __LF                 \
+        sbc     x11, x11, x15 __LF                 \
+        lsl     x16, x12, #32 __LF                 \
+        lsr     x15, x12, #32 __LF                 \
+        subs    x1, x16, x12 __LF                  \
+        sbc     x0, x15, xzr __LF                  \
+        subs    x13, x13, x1 __LF                  \
+        sbcs    x14, x14, x0 __LF                  \
+        sbcs    x11, x11, x16 __LF                 \
+        sbc     x12, x12, x15 __LF                 \
+        adds    x3, x3, x11 __LF                   \
+        adcs    x4, x4, x12 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        add     x2, x10, #1 __LF                   \
+        lsl     x15, x2, #32 __LF                  \
+        sub     x16, x15, x2 __LF                  \
+        adds    x13, x13, x2 __LF                  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, xzr __LF                   \
+        adcs    x4, x4, x15 __LF                   \
+        csetm   x7, lo __LF                        \
+        adds    x13, x13, x7 __LF                  \
+        and     x16, x7, #0xffffffff00000000 __LF  \
+        adcs    x14, x14, x16 __LF                 \
+        adcs    x3, x3, x7 __LF                    \
+        and     x15, x7, #0xfffffffeffffffff __LF  \
+        adc     x4, x4, x15 __LF                   \
+        stp     x13, x14, [P0] __LF                \
         stp     x3, x4, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2 with x0 in place of x17
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        ldp     x4, x5, [P1+16];                \
-        umull   x15, w2, w2;                    \
-        lsr     x11, x2, #32;                   \
-        umull   x16, w11, w11;                  \
-        umull   x11, w2, w11;                   \
-        adds    x15, x15, x11, lsl #33;         \
-        lsr     x11, x11, #31;                  \
-        adc     x16, x16, x11;                  \
-        umull   x0, w3, w3;                     \
-        lsr     x11, x3, #32;                   \
-        umull   x1, w11, w11;                   \
-        umull   x11, w3, w11;                   \
-        mul     x12, x2, x3;                    \
-        umulh   x13, x2, x3;                    \
-        adds    x0, x0, x11, lsl #33;           \
-        lsr     x11, x11, #31;                  \
-        adc     x1, x1, x11;                    \
-        adds    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adc     x1, x1, xzr;                    \
-        adds    x16, x16, x12;                  \
-        adcs    x0, x0, x13;                    \
-        adc     x1, x1, xzr;                    \
-        lsl     x12, x15, #32;                  \
-        lsr     x11, x15, #32;                  \
-        subs    x14, x12, x15;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x16, x16, x14;                  \
-        sbcs    x0, x0, x13;                    \
-        sbcs    x1, x1, x12;                    \
-        sbc     x15, x15, x11;                  \
-        lsl     x12, x16, #32;                  \
-        lsr     x11, x16, #32;                  \
-        subs    x14, x12, x16;                  \
-        sbc     x13, x11, xzr;                  \
-        subs    x0, x0, x14;                    \
-        sbcs    x1, x1, x13;                    \
-        sbcs    x15, x15, x12;                  \
-        sbc     x16, x16, x11;                  \
-        mul     x6, x2, x4;                     \
-        mul     x14, x3, x5;                    \
-        umulh   x8, x2, x4;                     \
-        subs    x10, x2, x3;                    \
-        cneg    x10, x10, lo;                   \
-        csetm   x13, lo;                        \
-        subs    x12, x5, x4;                    \
-        cneg    x12, x12, lo;                   \
-        mul     x11, x10, x12;                  \
-        umulh   x12, x10, x12;                  \
-        cinv    x13, x13, lo;                   \
-        eor     x11, x11, x13;                  \
-        eor     x12, x12, x13;                  \
-        adds    x7, x6, x8;                     \
-        adc     x8, x8, xzr;                    \
-        umulh   x9, x3, x5;                     \
-        adds    x7, x7, x14;                    \
-        adcs    x8, x8, x9;                     \
-        adc     x9, x9, xzr;                    \
-        adds    x8, x8, x14;                    \
-        adc     x9, x9, xzr;                    \
-        cmn     x13, #1;                        \
-        adcs    x7, x7, x11;                    \
-        adcs    x8, x8, x12;                    \
-        adc     x9, x9, x13;                    \
-        adds    x6, x6, x6;                     \
-        adcs    x7, x7, x7;                     \
-        adcs    x8, x8, x8;                     \
-        adcs    x9, x9, x9;                     \
-        adc     x10, xzr, xzr;                  \
-        adds    x6, x6, x0;                     \
-        adcs    x7, x7, x1;                     \
-        adcs    x8, x8, x15;                    \
-        adcs    x9, x9, x16;                    \
-        adc     x10, x10, xzr;                  \
-        lsl     x12, x6, #32;                   \
-        lsr     x11, x6, #32;                   \
-        subs    x14, x12, x6;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x7, x7, x14;                    \
-        sbcs    x8, x8, x13;                    \
-        sbcs    x9, x9, x12;                    \
-        sbc     x14, x6, x11;                   \
-        adds    x10, x10, x14;                  \
-        adc     x6, xzr, xzr;                   \
-        lsl     x12, x7, #32;                   \
-        lsr     x11, x7, #32;                   \
-        subs    x14, x12, x7;                   \
-        sbc     x13, x11, xzr;                  \
-        subs    x8, x8, x14;                    \
-        sbcs    x9, x9, x13;                    \
-        sbcs    x10, x10, x12;                  \
-        sbc     x14, x7, x11;                   \
-        adds    x6, x6, x14;                    \
-        adc     x7, xzr, xzr;                   \
-        mul     x11, x4, x4;                    \
-        adds    x8, x8, x11;                    \
-        mul     x12, x5, x5;                    \
-        umulh   x11, x4, x4;                    \
-        adcs    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        umulh   x12, x5, x5;                    \
-        adcs    x6, x6, x12;                    \
-        adc     x7, x7, xzr;                    \
-        mul     x11, x4, x5;                    \
-        umulh   x12, x4, x5;                    \
-        adds    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adc     x13, xzr, xzr;                  \
-        adds    x9, x9, x11;                    \
-        adcs    x10, x10, x12;                  \
-        adcs    x6, x6, x13;                    \
-        adcs    x7, x7, xzr;                    \
-        mov     x11, #-4294967296;              \
-        adds    x5, x8, #1;                     \
-        sbcs    x11, x9, x11;                   \
-        mov     x13, #-4294967297;              \
-        adcs    x12, x10, xzr;                  \
-        sbcs    x13, x6, x13;                   \
-        sbcs    xzr, x7, xzr;                   \
-        csel    x8, x5, x8, hs;                 \
-        csel    x9, x11, x9, hs;                \
-        csel    x10, x12, x10, hs;              \
-        csel    x6, x13, x6, hs;                \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        ldp     x4, x5, [P1+16] __LF               \
+        umull   x15, w2, w2 __LF                   \
+        lsr     x11, x2, #32 __LF                  \
+        umull   x16, w11, w11 __LF                 \
+        umull   x11, w2, w11 __LF                  \
+        adds    x15, x15, x11, lsl #33 __LF        \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x16, x16, x11 __LF                 \
+        umull   x0, w3, w3 __LF                    \
+        lsr     x11, x3, #32 __LF                  \
+        umull   x1, w11, w11 __LF                  \
+        umull   x11, w3, w11 __LF                  \
+        mul     x12, x2, x3 __LF                   \
+        umulh   x13, x2, x3 __LF                   \
+        adds    x0, x0, x11, lsl #33 __LF          \
+        lsr     x11, x11, #31 __LF                 \
+        adc     x1, x1, x11 __LF                   \
+        adds    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adc     x1, x1, xzr __LF                   \
+        adds    x16, x16, x12 __LF                 \
+        adcs    x0, x0, x13 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        lsl     x12, x15, #32 __LF                 \
+        lsr     x11, x15, #32 __LF                 \
+        subs    x14, x12, x15 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x16, x16, x14 __LF                 \
+        sbcs    x0, x0, x13 __LF                   \
+        sbcs    x1, x1, x12 __LF                   \
+        sbc     x15, x15, x11 __LF                 \
+        lsl     x12, x16, #32 __LF                 \
+        lsr     x11, x16, #32 __LF                 \
+        subs    x14, x12, x16 __LF                 \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x0, x0, x14 __LF                   \
+        sbcs    x1, x1, x13 __LF                   \
+        sbcs    x15, x15, x12 __LF                 \
+        sbc     x16, x16, x11 __LF                 \
+        mul     x6, x2, x4 __LF                    \
+        mul     x14, x3, x5 __LF                   \
+        umulh   x8, x2, x4 __LF                    \
+        subs    x10, x2, x3 __LF                   \
+        cneg    x10, x10, lo __LF                  \
+        csetm   x13, lo __LF                       \
+        subs    x12, x5, x4 __LF                   \
+        cneg    x12, x12, lo __LF                  \
+        mul     x11, x10, x12 __LF                 \
+        umulh   x12, x10, x12 __LF                 \
+        cinv    x13, x13, lo __LF                  \
+        eor     x11, x11, x13 __LF                 \
+        eor     x12, x12, x13 __LF                 \
+        adds    x7, x6, x8 __LF                    \
+        adc     x8, x8, xzr __LF                   \
+        umulh   x9, x3, x5 __LF                    \
+        adds    x7, x7, x14 __LF                   \
+        adcs    x8, x8, x9 __LF                    \
+        adc     x9, x9, xzr __LF                   \
+        adds    x8, x8, x14 __LF                   \
+        adc     x9, x9, xzr __LF                   \
+        cmn     x13, #1 __LF                       \
+        adcs    x7, x7, x11 __LF                   \
+        adcs    x8, x8, x12 __LF                   \
+        adc     x9, x9, x13 __LF                   \
+        adds    x6, x6, x6 __LF                    \
+        adcs    x7, x7, x7 __LF                    \
+        adcs    x8, x8, x8 __LF                    \
+        adcs    x9, x9, x9 __LF                    \
+        adc     x10, xzr, xzr __LF                 \
+        adds    x6, x6, x0 __LF                    \
+        adcs    x7, x7, x1 __LF                    \
+        adcs    x8, x8, x15 __LF                   \
+        adcs    x9, x9, x16 __LF                   \
+        adc     x10, x10, xzr __LF                 \
+        lsl     x12, x6, #32 __LF                  \
+        lsr     x11, x6, #32 __LF                  \
+        subs    x14, x12, x6 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x7, x7, x14 __LF                   \
+        sbcs    x8, x8, x13 __LF                   \
+        sbcs    x9, x9, x12 __LF                   \
+        sbc     x14, x6, x11 __LF                  \
+        adds    x10, x10, x14 __LF                 \
+        adc     x6, xzr, xzr __LF                  \
+        lsl     x12, x7, #32 __LF                  \
+        lsr     x11, x7, #32 __LF                  \
+        subs    x14, x12, x7 __LF                  \
+        sbc     x13, x11, xzr __LF                 \
+        subs    x8, x8, x14 __LF                   \
+        sbcs    x9, x9, x13 __LF                   \
+        sbcs    x10, x10, x12 __LF                 \
+        sbc     x14, x7, x11 __LF                  \
+        adds    x6, x6, x14 __LF                   \
+        adc     x7, xzr, xzr __LF                  \
+        mul     x11, x4, x4 __LF                   \
+        adds    x8, x8, x11 __LF                   \
+        mul     x12, x5, x5 __LF                   \
+        umulh   x11, x4, x4 __LF                   \
+        adcs    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        umulh   x12, x5, x5 __LF                   \
+        adcs    x6, x6, x12 __LF                   \
+        adc     x7, x7, xzr __LF                   \
+        mul     x11, x4, x5 __LF                   \
+        umulh   x12, x4, x5 __LF                   \
+        adds    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adc     x13, xzr, xzr __LF                 \
+        adds    x9, x9, x11 __LF                   \
+        adcs    x10, x10, x12 __LF                 \
+        adcs    x6, x6, x13 __LF                   \
+        adcs    x7, x7, xzr __LF                   \
+        mov     x11, #-4294967296 __LF             \
+        adds    x5, x8, #1 __LF                    \
+        sbcs    x11, x9, x11 __LF                  \
+        mov     x13, #-4294967297 __LF             \
+        adcs    x12, x10, xzr __LF                 \
+        sbcs    x13, x6, x13 __LF                  \
+        sbcs    xzr, x7, xzr __LF                  \
+        csel    x8, x5, x8, hs __LF                \
+        csel    x9, x11, x9, hs __LF               \
+        csel    x10, x12, x10, hs __LF             \
+        csel    x6, x13, x6, hs __LF               \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x6, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjmixadd):

--- a/arm/sm2/sm2_montjmixadd_alt.S
+++ b/arm/sm2/sm2_montjmixadd_alt.S
@@ -74,337 +74,337 @@
 // Corresponds to bignum_montmul_sm2_alt except for registers
 
 #define montmul_sm2(P0,P1,P2)                   \
-        ldp     x3, x4, [P1];                   \
-        ldp     x7, x8, [P2];                   \
-        mul     x12, x3, x7;                    \
-        umulh   x13, x3, x7;                    \
-        mul     x11, x3, x8;                    \
-        umulh   x14, x3, x8;                    \
-        adds    x13, x13, x11;                  \
-        ldp     x9, x10, [P2+16];               \
-        mul     x11, x3, x9;                    \
-        umulh   x0, x3, x9;                     \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x3, x10;                   \
-        umulh   x1, x3, x10;                    \
-        adcs    x0, x0, x11;                    \
-        adc     x1, x1, xzr;                    \
-        ldp     x5, x6, [P1+16];                \
-        mul     x11, x4, x7;                    \
-        adds    x13, x13, x11;                  \
-        mul     x11, x4, x8;                    \
-        adcs    x14, x14, x11;                  \
-        mul     x11, x4, x9;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x4, x10;                   \
-        adcs    x1, x1, x11;                    \
-        umulh   x3, x4, x10;                    \
-        adc     x3, x3, xzr;                    \
-        umulh   x11, x4, x7;                    \
-        adds    x14, x14, x11;                  \
-        umulh   x11, x4, x8;                    \
-        adcs    x0, x0, x11;                    \
-        umulh   x11, x4, x9;                    \
-        adcs    x1, x1, x11;                    \
-        adc     x3, x3, xzr;                    \
-        mul     x11, x5, x7;                    \
-        adds    x14, x14, x11;                  \
-        mul     x11, x5, x8;                    \
-        adcs    x0, x0, x11;                    \
-        mul     x11, x5, x9;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x5, x10;                   \
-        adcs    x3, x3, x11;                    \
-        umulh   x4, x5, x10;                    \
-        adc     x4, x4, xzr;                    \
-        umulh   x11, x5, x7;                    \
-        adds    x0, x0, x11;                    \
-        umulh   x11, x5, x8;                    \
-        adcs    x1, x1, x11;                    \
-        umulh   x11, x5, x9;                    \
-        adcs    x3, x3, x11;                    \
-        adc     x4, x4, xzr;                    \
-        mul     x11, x6, x7;                    \
-        adds    x0, x0, x11;                    \
-        mul     x11, x6, x8;                    \
-        adcs    x1, x1, x11;                    \
-        mul     x11, x6, x9;                    \
-        adcs    x3, x3, x11;                    \
-        mul     x11, x6, x10;                   \
-        adcs    x4, x4, x11;                    \
-        umulh   x5, x6, x10;                    \
-        adc     x5, x5, xzr;                    \
-        umulh   x11, x6, x7;                    \
-        adds    x1, x1, x11;                    \
-        umulh   x11, x6, x8;                    \
-        adcs    x3, x3, x11;                    \
-        umulh   x11, x6, x9;                    \
-        adcs    x4, x4, x11;                    \
-        adc     x5, x5, xzr;                    \
-        lsl     x11, x12, #32;                  \
-        lsr     x6, x12, #32;                   \
-        subs    x8, x11, x12;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x13, x13, x8;                   \
-        sbcs    x14, x14, x7;                   \
-        sbcs    x0, x0, x11;                    \
-        sbc     x12, x12, x6;                   \
-        lsl     x11, x13, #32;                  \
-        lsr     x6, x13, #32;                   \
-        subs    x8, x11, x13;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x14, x14, x8;                   \
-        sbcs    x0, x0, x7;                     \
-        sbcs    x12, x12, x11;                  \
-        sbc     x13, x13, x6;                   \
-        lsl     x11, x14, #32;                  \
-        lsr     x6, x14, #32;                   \
-        subs    x8, x11, x14;                   \
-        sbc     x7, x6, xzr;                    \
-        subs    x0, x0, x8;                     \
-        sbcs    x12, x12, x7;                   \
-        sbcs    x13, x13, x11;                  \
-        sbc     x14, x14, x6;                   \
-        lsl     x11, x0, #32;                   \
-        lsr     x6, x0, #32;                    \
-        subs    x8, x11, x0;                    \
-        sbc     x7, x6, xzr;                    \
-        subs    x12, x12, x8;                   \
-        sbcs    x13, x13, x7;                   \
-        sbcs    x14, x14, x11;                  \
-        sbc     x0, x0, x6;                     \
-        adds    x12, x12, x1;                   \
-        adcs    x13, x13, x3;                   \
-        adcs    x14, x14, x4;                   \
-        adcs    x0, x0, x5;                     \
-        cset    x8, cs;                         \
-        mov     x11, #0xffffffff00000000;       \
-        mov     x6, #0xfffffffeffffffff;        \
-        adds    x1, x12, #0x1;                  \
-        sbcs    x3, x13, x11;                   \
-        adcs    x4, x14, xzr;                   \
-        sbcs    x5, x0, x6;                     \
-        sbcs    xzr, x8, xzr;                   \
-        csel    x12, x12, x1, cc;               \
-        csel    x13, x13, x3, cc;               \
-        csel    x14, x14, x4, cc;               \
-        csel    x0, x0, x5, cc;                 \
-        stp     x12, x13, [P0];                 \
+        ldp     x3, x4, [P1] __LF                  \
+        ldp     x7, x8, [P2] __LF                  \
+        mul     x12, x3, x7 __LF                   \
+        umulh   x13, x3, x7 __LF                   \
+        mul     x11, x3, x8 __LF                   \
+        umulh   x14, x3, x8 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        ldp     x9, x10, [P2+16] __LF              \
+        mul     x11, x3, x9 __LF                   \
+        umulh   x0, x3, x9 __LF                    \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x3, x10 __LF                  \
+        umulh   x1, x3, x10 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        adc     x1, x1, xzr __LF                   \
+        ldp     x5, x6, [P1+16] __LF               \
+        mul     x11, x4, x7 __LF                   \
+        adds    x13, x13, x11 __LF                 \
+        mul     x11, x4, x8 __LF                   \
+        adcs    x14, x14, x11 __LF                 \
+        mul     x11, x4, x9 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x4, x10 __LF                  \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x3, x4, x10 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        umulh   x11, x4, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        umulh   x11, x4, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        umulh   x11, x4, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        adc     x3, x3, xzr __LF                   \
+        mul     x11, x5, x7 __LF                   \
+        adds    x14, x14, x11 __LF                 \
+        mul     x11, x5, x8 __LF                   \
+        adcs    x0, x0, x11 __LF                   \
+        mul     x11, x5, x9 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x5, x10 __LF                  \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x4, x5, x10 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        umulh   x11, x5, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        umulh   x11, x5, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        umulh   x11, x5, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        adc     x4, x4, xzr __LF                   \
+        mul     x11, x6, x7 __LF                   \
+        adds    x0, x0, x11 __LF                   \
+        mul     x11, x6, x8 __LF                   \
+        adcs    x1, x1, x11 __LF                   \
+        mul     x11, x6, x9 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        mul     x11, x6, x10 __LF                  \
+        adcs    x4, x4, x11 __LF                   \
+        umulh   x5, x6, x10 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        umulh   x11, x6, x7 __LF                   \
+        adds    x1, x1, x11 __LF                   \
+        umulh   x11, x6, x8 __LF                   \
+        adcs    x3, x3, x11 __LF                   \
+        umulh   x11, x6, x9 __LF                   \
+        adcs    x4, x4, x11 __LF                   \
+        adc     x5, x5, xzr __LF                   \
+        lsl     x11, x12, #32 __LF                 \
+        lsr     x6, x12, #32 __LF                  \
+        subs    x8, x11, x12 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x13, x13, x8 __LF                  \
+        sbcs    x14, x14, x7 __LF                  \
+        sbcs    x0, x0, x11 __LF                   \
+        sbc     x12, x12, x6 __LF                  \
+        lsl     x11, x13, #32 __LF                 \
+        lsr     x6, x13, #32 __LF                  \
+        subs    x8, x11, x13 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x14, x14, x8 __LF                  \
+        sbcs    x0, x0, x7 __LF                    \
+        sbcs    x12, x12, x11 __LF                 \
+        sbc     x13, x13, x6 __LF                  \
+        lsl     x11, x14, #32 __LF                 \
+        lsr     x6, x14, #32 __LF                  \
+        subs    x8, x11, x14 __LF                  \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x0, x0, x8 __LF                    \
+        sbcs    x12, x12, x7 __LF                  \
+        sbcs    x13, x13, x11 __LF                 \
+        sbc     x14, x14, x6 __LF                  \
+        lsl     x11, x0, #32 __LF                  \
+        lsr     x6, x0, #32 __LF                   \
+        subs    x8, x11, x0 __LF                   \
+        sbc     x7, x6, xzr __LF                   \
+        subs    x12, x12, x8 __LF                  \
+        sbcs    x13, x13, x7 __LF                  \
+        sbcs    x14, x14, x11 __LF                 \
+        sbc     x0, x0, x6 __LF                    \
+        adds    x12, x12, x1 __LF                  \
+        adcs    x13, x13, x3 __LF                  \
+        adcs    x14, x14, x4 __LF                  \
+        adcs    x0, x0, x5 __LF                    \
+        cset    x8, cs __LF                        \
+        mov     x11, #0xffffffff00000000 __LF      \
+        mov     x6, #0xfffffffeffffffff __LF       \
+        adds    x1, x12, #0x1 __LF                 \
+        sbcs    x3, x13, x11 __LF                  \
+        adcs    x4, x14, xzr __LF                  \
+        sbcs    x5, x0, x6 __LF                    \
+        sbcs    xzr, x8, xzr __LF                  \
+        csel    x12, x12, x1, cc __LF              \
+        csel    x13, x13, x3, cc __LF              \
+        csel    x14, x14, x4, cc __LF              \
+        csel    x0, x0, x5, cc __LF                \
+        stp     x12, x13, [P0] __LF                \
         stp     x14, x0, [P0+16]
 
 // Corresponds to bignum_montsqr_sm2_alt exactly
 
 #define montsqr_sm2(P0,P1)                      \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        lsl     x4, x8, #32;                    \
-        lsr     x5, x8, #32;                    \
-        subs    x2, x4, x8;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x9, x9, x2;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x4;                   \
-        sbc     x8, x8, x5;                     \
-        lsl     x4, x9, #32;                    \
-        lsr     x5, x9, #32;                    \
-        subs    x2, x4, x9;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x10, x10, x2;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x8, x8, x4;                     \
-        sbc     x9, x9, x5;                     \
-        lsl     x4, x10, #32;                   \
-        lsr     x5, x10, #32;                   \
-        subs    x2, x4, x10;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x11, x11, x2;                   \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x4;                     \
-        sbc     x10, x10, x5;                   \
-        lsl     x4, x11, #32;                   \
-        lsr     x5, x11, #32;                   \
-        subs    x2, x4, x11;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, x4;                   \
-        sbc     x11, x11, x5;                   \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        cset    x2, cs;                         \
-        mov     x3, #0xffffffff00000000;        \
-        mov     x5, #0xfffffffeffffffff;        \
-        adds    x12, x8, #0x1;                  \
-        sbcs    x13, x9, x3;                    \
-        adcs    x14, x10, xzr;                  \
-        sbcs    x7, x11, x5;                    \
-        sbcs    xzr, x2, xzr;                   \
-        csel    x8, x8, x12, cc;                \
-        csel    x9, x9, x13, cc;                \
-        csel    x10, x10, x14, cc;              \
-        csel    x11, x11, x7, cc;               \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        lsl     x4, x8, #32 __LF                   \
+        lsr     x5, x8, #32 __LF                   \
+        subs    x2, x4, x8 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x9, x9, x2 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        lsl     x4, x9, #32 __LF                   \
+        lsr     x5, x9, #32 __LF                   \
+        subs    x2, x4, x9 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x10, x10, x2 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x8, x8, x4 __LF                    \
+        sbc     x9, x9, x5 __LF                    \
+        lsl     x4, x10, #32 __LF                  \
+        lsr     x5, x10, #32 __LF                  \
+        subs    x2, x4, x10 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x11, x11, x2 __LF                  \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbc     x10, x10, x5 __LF                  \
+        lsl     x4, x11, #32 __LF                  \
+        lsr     x5, x11, #32 __LF                  \
+        subs    x2, x4, x11 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        cset    x2, cs __LF                        \
+        mov     x3, #0xffffffff00000000 __LF       \
+        mov     x5, #0xfffffffeffffffff __LF       \
+        adds    x12, x8, #0x1 __LF                 \
+        sbcs    x13, x9, x3 __LF                   \
+        adcs    x14, x10, xzr __LF                 \
+        sbcs    x7, x11, x5 __LF                   \
+        sbcs    xzr, x2, xzr __LF                  \
+        csel    x8, x8, x12, cc __LF               \
+        csel    x9, x9, x13, cc __LF               \
+        csel    x10, x10, x14, cc __LF             \
+        csel    x11, x11, x7, cc __LF              \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Almost-Montgomery variant which we use when an input to other muls
 // with the other argument fully reduced (which is always safe).
 
 #define amontsqr_sm2(P0,P1)                     \
-        ldp     x2, x3, [P1];                   \
-        mul     x9, x2, x3;                     \
-        umulh   x10, x2, x3;                    \
-        ldp     x4, x5, [P1+16];                \
-        mul     x11, x2, x5;                    \
-        umulh   x12, x2, x5;                    \
-        mul     x6, x2, x4;                     \
-        umulh   x7, x2, x4;                     \
-        adds    x10, x10, x6;                   \
-        adcs    x11, x11, x7;                   \
-        mul     x6, x3, x4;                     \
-        umulh   x7, x3, x4;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x11, x11, x6;                   \
-        mul     x13, x4, x5;                    \
-        umulh   x14, x4, x5;                    \
-        adcs    x12, x12, x7;                   \
-        mul     x6, x3, x5;                     \
-        umulh   x7, x3, x5;                     \
-        adc     x7, x7, xzr;                    \
-        adds    x12, x12, x6;                   \
-        adcs    x13, x13, x7;                   \
-        adc     x14, x14, xzr;                  \
-        adds    x9, x9, x9;                     \
-        adcs    x10, x10, x10;                  \
-        adcs    x11, x11, x11;                  \
-        adcs    x12, x12, x12;                  \
-        adcs    x13, x13, x13;                  \
-        adcs    x14, x14, x14;                  \
-        cset    x7, cs;                         \
-        umulh   x6, x2, x2;                     \
-        mul     x8, x2, x2;                     \
-        adds    x9, x9, x6;                     \
-        mul     x6, x3, x3;                     \
-        adcs    x10, x10, x6;                   \
-        umulh   x6, x3, x3;                     \
-        adcs    x11, x11, x6;                   \
-        mul     x6, x4, x4;                     \
-        adcs    x12, x12, x6;                   \
-        umulh   x6, x4, x4;                     \
-        adcs    x13, x13, x6;                   \
-        mul     x6, x5, x5;                     \
-        adcs    x14, x14, x6;                   \
-        umulh   x6, x5, x5;                     \
-        adc     x7, x7, x6;                     \
-        lsl     x4, x8, #32;                    \
-        lsr     x5, x8, #32;                    \
-        subs    x2, x4, x8;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x9, x9, x2;                     \
-        sbcs    x10, x10, x3;                   \
-        sbcs    x11, x11, x4;                   \
-        sbc     x8, x8, x5;                     \
-        lsl     x4, x9, #32;                    \
-        lsr     x5, x9, #32;                    \
-        subs    x2, x4, x9;                     \
-        sbc     x3, x5, xzr;                    \
-        subs    x10, x10, x2;                   \
-        sbcs    x11, x11, x3;                   \
-        sbcs    x8, x8, x4;                     \
-        sbc     x9, x9, x5;                     \
-        lsl     x4, x10, #32;                   \
-        lsr     x5, x10, #32;                   \
-        subs    x2, x4, x10;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x11, x11, x2;                   \
-        sbcs    x8, x8, x3;                     \
-        sbcs    x9, x9, x4;                     \
-        sbc     x10, x10, x5;                   \
-        lsl     x4, x11, #32;                   \
-        lsr     x5, x11, #32;                   \
-        subs    x2, x4, x11;                    \
-        sbc     x3, x5, xzr;                    \
-        subs    x8, x8, x2;                     \
-        sbcs    x9, x9, x3;                     \
-        sbcs    x10, x10, x4;                   \
-        sbc     x11, x11, x5;                   \
-        adds    x8, x8, x12;                    \
-        adcs    x9, x9, x13;                    \
-        adcs    x10, x10, x14;                  \
-        adcs    x11, x11, x7;                   \
-        csetm   x2, cs;                         \
-        subs    x8, x8, x2;                     \
-        and     x3, x2, #0xffffffff00000000;    \
-        sbcs    x9, x9, x3;                     \
-        and     x5, x2, #0xfffffffeffffffff;    \
-        sbcs    x10, x10, x2;                   \
-        sbc     x11, x11, x5;                   \
-        stp     x8, x9, [P0];                   \
+        ldp     x2, x3, [P1] __LF                  \
+        mul     x9, x2, x3 __LF                    \
+        umulh   x10, x2, x3 __LF                   \
+        ldp     x4, x5, [P1+16] __LF               \
+        mul     x11, x2, x5 __LF                   \
+        umulh   x12, x2, x5 __LF                   \
+        mul     x6, x2, x4 __LF                    \
+        umulh   x7, x2, x4 __LF                    \
+        adds    x10, x10, x6 __LF                  \
+        adcs    x11, x11, x7 __LF                  \
+        mul     x6, x3, x4 __LF                    \
+        umulh   x7, x3, x4 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x11, x11, x6 __LF                  \
+        mul     x13, x4, x5 __LF                   \
+        umulh   x14, x4, x5 __LF                   \
+        adcs    x12, x12, x7 __LF                  \
+        mul     x6, x3, x5 __LF                    \
+        umulh   x7, x3, x5 __LF                    \
+        adc     x7, x7, xzr __LF                   \
+        adds    x12, x12, x6 __LF                  \
+        adcs    x13, x13, x7 __LF                  \
+        adc     x14, x14, xzr __LF                 \
+        adds    x9, x9, x9 __LF                    \
+        adcs    x10, x10, x10 __LF                 \
+        adcs    x11, x11, x11 __LF                 \
+        adcs    x12, x12, x12 __LF                 \
+        adcs    x13, x13, x13 __LF                 \
+        adcs    x14, x14, x14 __LF                 \
+        cset    x7, cs __LF                        \
+        umulh   x6, x2, x2 __LF                    \
+        mul     x8, x2, x2 __LF                    \
+        adds    x9, x9, x6 __LF                    \
+        mul     x6, x3, x3 __LF                    \
+        adcs    x10, x10, x6 __LF                  \
+        umulh   x6, x3, x3 __LF                    \
+        adcs    x11, x11, x6 __LF                  \
+        mul     x6, x4, x4 __LF                    \
+        adcs    x12, x12, x6 __LF                  \
+        umulh   x6, x4, x4 __LF                    \
+        adcs    x13, x13, x6 __LF                  \
+        mul     x6, x5, x5 __LF                    \
+        adcs    x14, x14, x6 __LF                  \
+        umulh   x6, x5, x5 __LF                    \
+        adc     x7, x7, x6 __LF                    \
+        lsl     x4, x8, #32 __LF                   \
+        lsr     x5, x8, #32 __LF                   \
+        subs    x2, x4, x8 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x9, x9, x2 __LF                    \
+        sbcs    x10, x10, x3 __LF                  \
+        sbcs    x11, x11, x4 __LF                  \
+        sbc     x8, x8, x5 __LF                    \
+        lsl     x4, x9, #32 __LF                   \
+        lsr     x5, x9, #32 __LF                   \
+        subs    x2, x4, x9 __LF                    \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x10, x10, x2 __LF                  \
+        sbcs    x11, x11, x3 __LF                  \
+        sbcs    x8, x8, x4 __LF                    \
+        sbc     x9, x9, x5 __LF                    \
+        lsl     x4, x10, #32 __LF                  \
+        lsr     x5, x10, #32 __LF                  \
+        subs    x2, x4, x10 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x11, x11, x2 __LF                  \
+        sbcs    x8, x8, x3 __LF                    \
+        sbcs    x9, x9, x4 __LF                    \
+        sbc     x10, x10, x5 __LF                  \
+        lsl     x4, x11, #32 __LF                  \
+        lsr     x5, x11, #32 __LF                  \
+        subs    x2, x4, x11 __LF                   \
+        sbc     x3, x5, xzr __LF                   \
+        subs    x8, x8, x2 __LF                    \
+        sbcs    x9, x9, x3 __LF                    \
+        sbcs    x10, x10, x4 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        adds    x8, x8, x12 __LF                   \
+        adcs    x9, x9, x13 __LF                   \
+        adcs    x10, x10, x14 __LF                 \
+        adcs    x11, x11, x7 __LF                  \
+        csetm   x2, cs __LF                        \
+        subs    x8, x8, x2 __LF                    \
+        and     x3, x2, #0xffffffff00000000 __LF   \
+        sbcs    x9, x9, x3 __LF                    \
+        and     x5, x2, #0xfffffffeffffffff __LF   \
+        sbcs    x10, x10, x2 __LF                  \
+        sbc     x11, x11, x5 __LF                  \
+        stp     x8, x9, [P0] __LF                  \
         stp     x10, x11, [P0+16]
 
 // Corresponds exactly to bignum_sub_sm2
 
 #define sub_sm2(P0,P1,P2)                       \
-        ldp     x5, x6, [P1];                   \
-        ldp     x4, x3, [P2];                   \
-        subs    x5, x5, x4;                     \
-        sbcs    x6, x6, x3;                     \
-        ldp     x7, x8, [P1+16];                \
-        ldp     x4, x3, [P2+16];                \
-        sbcs    x7, x7, x4;                     \
-        sbcs    x8, x8, x3;                     \
-        csetm   x3, cc;                         \
-        adds    x5, x5, x3;                     \
-        and     x4, x3, #0xffffffff00000000;    \
-        adcs    x6, x6, x4;                     \
-        adcs    x7, x7, x3;                     \
-        and     x4, x3, #0xfffffffeffffffff;    \
-        adc     x8, x8, x4;                     \
-        stp     x5, x6, [P0];                   \
+        ldp     x5, x6, [P1] __LF                  \
+        ldp     x4, x3, [P2] __LF                  \
+        subs    x5, x5, x4 __LF                    \
+        sbcs    x6, x6, x3 __LF                    \
+        ldp     x7, x8, [P1+16] __LF               \
+        ldp     x4, x3, [P2+16] __LF               \
+        sbcs    x7, x7, x4 __LF                    \
+        sbcs    x8, x8, x3 __LF                    \
+        csetm   x3, cc __LF                        \
+        adds    x5, x5, x3 __LF                    \
+        and     x4, x3, #0xffffffff00000000 __LF   \
+        adcs    x6, x6, x4 __LF                    \
+        adcs    x7, x7, x3 __LF                    \
+        and     x4, x3, #0xfffffffeffffffff __LF   \
+        adc     x8, x8, x4 __LF                    \
+        stp     x5, x6, [P0] __LF                  \
         stp     x7, x8, [P0+16]
 
 S2N_BN_SYMBOL(sm2_montjmixadd_alt):

--- a/arm/sm2/sm2_montjscalarmul.S
+++ b/arm/sm2/sm2_montjscalarmul.S
@@ -60,33 +60,33 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                          \
-        cmp     x14, #(1*I);                    \
-        ldp     x12, x13, [x15];                \
-        csel    x0, x12, x0, eq;                \
-        csel    x1, x13, x1, eq;                \
-        ldp     x12, x13, [x15, #16];           \
-        csel    x2, x12, x2, eq;                \
-        csel    x3, x13, x3, eq;                \
-        ldp     x12, x13, [x15, #32];           \
-        csel    x4, x12, x4, eq;                \
-        csel    x5, x13, x5, eq;                \
-        ldp     x12, x13, [x15, #48];           \
-        csel    x6, x12, x6, eq;                \
-        csel    x7, x13, x7, eq;                \
-        ldp     x12, x13, [x15, #64];           \
-        csel    x8, x12, x8, eq;                \
-        csel    x9, x13, x9, eq;                \
-        ldp     x12, x13, [x15, #80];           \
-        csel    x10, x12, x10, eq;              \
-        csel    x11, x13, x11, eq;              \
+        cmp     x14, #(1*I) __LF                   \
+        ldp     x12, x13, [x15] __LF               \
+        csel    x0, x12, x0, eq __LF               \
+        csel    x1, x13, x1, eq __LF               \
+        ldp     x12, x13, [x15, #16] __LF          \
+        csel    x2, x12, x2, eq __LF               \
+        csel    x3, x13, x3, eq __LF               \
+        ldp     x12, x13, [x15, #32] __LF          \
+        csel    x4, x12, x4, eq __LF               \
+        csel    x5, x13, x5, eq __LF               \
+        ldp     x12, x13, [x15, #48] __LF          \
+        csel    x6, x12, x6, eq __LF               \
+        csel    x7, x13, x7, eq __LF               \
+        ldp     x12, x13, [x15, #64] __LF          \
+        csel    x8, x12, x8, eq __LF               \
+        csel    x9, x13, x9, eq __LF               \
+        ldp     x12, x13, [x15, #80] __LF          \
+        csel    x10, x12, x10, eq __LF             \
+        csel    x11, x13, x11, eq __LF             \
         add     x15, x15, #96
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(sm2_montjscalarmul):

--- a/arm/sm2/sm2_montjscalarmul_alt.S
+++ b/arm/sm2/sm2_montjscalarmul_alt.S
@@ -60,33 +60,33 @@
 // which doesn't accept repetitions, assembler macros etc.
 
 #define selectblock(I)                          \
-        cmp     x14, #(1*I);                    \
-        ldp     x12, x13, [x15];                \
-        csel    x0, x12, x0, eq;                \
-        csel    x1, x13, x1, eq;                \
-        ldp     x12, x13, [x15, #16];           \
-        csel    x2, x12, x2, eq;                \
-        csel    x3, x13, x3, eq;                \
-        ldp     x12, x13, [x15, #32];           \
-        csel    x4, x12, x4, eq;                \
-        csel    x5, x13, x5, eq;                \
-        ldp     x12, x13, [x15, #48];           \
-        csel    x6, x12, x6, eq;                \
-        csel    x7, x13, x7, eq;                \
-        ldp     x12, x13, [x15, #64];           \
-        csel    x8, x12, x8, eq;                \
-        csel    x9, x13, x9, eq;                \
-        ldp     x12, x13, [x15, #80];           \
-        csel    x10, x12, x10, eq;              \
-        csel    x11, x13, x11, eq;              \
+        cmp     x14, #(1*I) __LF                   \
+        ldp     x12, x13, [x15] __LF               \
+        csel    x0, x12, x0, eq __LF               \
+        csel    x1, x13, x1, eq __LF               \
+        ldp     x12, x13, [x15, #16] __LF          \
+        csel    x2, x12, x2, eq __LF               \
+        csel    x3, x13, x3, eq __LF               \
+        ldp     x12, x13, [x15, #32] __LF          \
+        csel    x4, x12, x4, eq __LF               \
+        csel    x5, x13, x5, eq __LF               \
+        ldp     x12, x13, [x15, #48] __LF          \
+        csel    x6, x12, x6, eq __LF               \
+        csel    x7, x13, x7, eq __LF               \
+        ldp     x12, x13, [x15, #64] __LF          \
+        csel    x8, x12, x8, eq __LF               \
+        csel    x9, x13, x9, eq __LF               \
+        ldp     x12, x13, [x15, #80] __LF          \
+        csel    x10, x12, x10, eq __LF             \
+        csel    x11, x13, x11, eq __LF             \
         add     x15, x15, #96
 
 // Loading large constants
 
 #define movbig(nn,n3,n2,n1,n0)                                      \
-        movz    nn, n0;                                             \
-        movk    nn, n1, lsl #16;                                    \
-        movk    nn, n2, lsl #32;                                    \
+        movz    nn, n0 __LF                                            \
+        movk    nn, n1, lsl #16 __LF                                   \
+        movk    nn, n2, lsl #32 __LF                                   \
         movk    nn, n3, lsl #48
 
 S2N_BN_SYMBOL(sm2_montjscalarmul_alt):

--- a/include/_internal_s2n_bignum.h
+++ b/include/_internal_s2n_bignum.h
@@ -1,8 +1,14 @@
 
 #ifdef __APPLE__
 #   define S2N_BN_SYMBOL(NAME) _##NAME
+#   if defined(__AARCH64EL__) || defined(__ARMEL__)
+#     define __LF %%
+#   else
+#     define __LF ;
+#   endif
 #else
 #   define S2N_BN_SYMBOL(name) name
+#   define __LF ;
 #endif
 
 #define S2N_BN_SYM_VISIBILITY_DIRECTIVE(name) .globl S2N_BN_SYMBOL(name)


### PR DESCRIPTION
*Issue #, if available:*
* Related: https://github.com/aws/aws-lc/pull/2287
  * Note that all relevant tests are passing.

*Description of changes:*
* On MacOS/ARM64, the assembler treats the semicolon (`;`) as the beginning of a comment. For multiline macros that use the semicolon to separate lines, every line of the macro after the first is treated as being part of a comment.
* To work around this, AWS-LC has been doing custom processing of the s2n-bignum assembly files: https://github.com/aws/aws-lc/blob/main/crypto/fipsmodule/CMakeLists.txt#L329
* This change replaces the use of semicolons with a `__LF` macro that expands to an appropriate line separator depending on the platform.

*Callout*
* Changes to the assembly files were all performed by a simple CLI command executed from the `arm` directory:
```
find . -name "*.S" | xargs sed -I '' -e 's/; \(.*\\\)$/ __LF\1/g'
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
