### PR TITLE
Add single-register case of TBL instruction to ARM model

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -866,6 +866,11 @@ let decode = new_definition `!w:int32. decode w =
       if op then SOME(arm_ZIP2 (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
       else SOME(arm_ZIP1 (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
 
+  | [0:1; q; 0b001110000:9; Rm:5; 0b000000:6; Rn:5; Rd:5] ->
+    // TBL (single register, i.e. len = 0, only)
+    let datasize = if q then 128 else 64 in
+    SOME(arm_TBL (QREG' Rd) (QREG' Rn) (QREG' Rm) datasize)
+
   | [0b11001110000:11; Rm:5; 0:1; Ra:5; Rn:5; Rd:5] ->
     // EOR3
     SOME (arm_EOR3 (QREG' Rd) (QREG' Rn) (QREG' Rm) (QREG' Ra))

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -869,7 +869,7 @@ let decode = new_definition `!w:int32. decode w =
   | [0:1; q; 0b001110000:9; Rm:5; 0b000000:6; Rn:5; Rd:5] ->
     // TBL (single register, i.e. len = 0, only)
     let datasize = if q then 128 else 64 in
-    SOME(arm_TBL (QREG' Rd) (QREG' Rn) (QREG' Rm) datasize)
+    SOME(arm_TBL (QREG' Rd) [QREG' Rn] (QREG' Rm) datasize)
 
   | [0b11001110000:11; Rm:5; 0:1; Ra:5; Rn:5; Rd:5] ->
     // EOR3

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2178,6 +2178,19 @@ let arm_TRN2 = define
             else simd4 word_interleave_hi n m in
           (Rd := word_zx d:(128)word) s`;;
 
+let arm_TBL = define
+ `arm_TBL Rd Rn Rm datasize =
+    \s:armstate.
+        let n:int128 = read Rn s in
+        let m = read Rm s in
+        if datasize = 128 then
+          let d = usimd16 (\x. word_subword n (8 * val x,8):byte) m in
+          (Rd := d) s
+        else
+          let d =
+             usimd8 (\x. word_subword n (8 * val x,8):byte) (word_zx m:int64) in
+          (Rd := word_zx d:(128)word) s`;;
+
 (* ------------------------------------------------------------------------- *)
 (* Load and store instructions.                                              *)
 (* ------------------------------------------------------------------------- *)
@@ -3067,6 +3080,7 @@ let arm_SMULL_VEC_ALT =  EXPAND_SIMD_RULE arm_SMULL_VEC;;
 let arm_SMULL2_VEC_ALT = EXPAND_SIMD_RULE arm_SMULL2_VEC;;
 let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
+let arm_TBL_ALT =        EXPAND_SIMD_RULE arm_TBL;;
 let arm_TRN1_ALT =       EXPAND_SIMD_RULE arm_TRN1;;
 let arm_TRN2_ALT =       EXPAND_SIMD_RULE arm_TRN2;;
 let arm_UADDLP_ALT =     EXPAND_SIMD_RULE arm_UADDLP;;
@@ -3085,7 +3099,6 @@ let arm_ZIP1_ALT =       EXPAND_SIMD_RULE arm_ZIP1;;
 let arm_ZIP2_ALT =       EXPAND_SIMD_RULE arm_ZIP2;;
 let arm_LD2_ALT =        EXPAND_SIMD_RULE arm_LD2;;
 let arm_ST2_ALT =        EXPAND_SIMD_RULE arm_ST2;;
-
 
 let arm_SQDMULH_VEC_ALT =
   REWRITE_RULE[word_2smulh] (EXPAND_SIMD_RULE arm_SQDMULH_VEC);;
@@ -3148,6 +3161,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SQDMULH_VEC_ALT;
        arm_SQRDMULH_VEC_ALT;
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
+       arm_TBL_ALT;
        arm_TRN1_ALT; arm_TRN2_ALT;
        arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
        arm_UMLAL_VEC_ALT; arm_UMLAL2_VEC_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2179,7 +2179,7 @@ let arm_TRN2 = define
           (Rd := word_zx d:(128)word) s`;;
 
 let arm_TBL = define
- `arm_TBL Rd Rn Rm datasize =
+ `arm_TBL Rd [Rn] Rm datasize =
     \s:armstate.
         let n:int128 = read Rn s in
         let m = read Rm s in

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -286,6 +286,9 @@ let iclasses =
   (*** SUB ***)
   "0x101110xx1xxxxx100001xxxxxxxxxx";
 
+  (*** TBL ***)
+  "0x001110000xxxxx000000xxxxxxxxxx";
+
   (*** TRN1 and TRN2 ***)
   "0x001110xx0xxxxx0x1010xxxxxxxxxx";
 


### PR DESCRIPTION
This instruction uses the bytes in one argument as indices into the bytes in the other one. Any indexing bytes >= 16 result in a zero result for that lookup, by definition, and this is implicit in the definition of the semantics using "word_subword". Note that our cosimulation testing in "simulator.ml" with random numbers will have a strong bias towards this trivial case for each lookup. However, there's around a 50% chance that at least one of the 8 or 16 lookups per instruction (for data sizes 64 or 128) will be nontrivial, so it seems that it still gives adequate coverage.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
