### PR TITLE
Extend model of SLI to 64-bit variant

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -504,13 +504,12 @@ let decode = new_definition `!w:int32. decode w =
       let Rn = defgh in
       // if immh = 0, this is MOVI
       if bit 3 immh /\ ~q then NONE // "UNDEFINED"
-      else if ~q then NONE // 64-bit case is unsupported
       else
         let esize = 8 * 2 EXP (3 - word_clz immh) in
-        let datasize = 128 in
+        let datasize = if q then 128 else 64 in
         let elements = datasize DIV esize in
         let shift = val (word_join immh immb:(7)word) - esize in
-        SOME (arm_SLI_VEC (QREG' Rd) (QREG' Rn) shift esize)
+        SOME (arm_SLI_VEC (QREG' Rd) (QREG' Rn) shift datasize esize)
     else if cmode = (word 0b0100:(4)word) then
       // SRI (vector)
       let immb = abc in

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -271,11 +271,11 @@ let iclasses =
   "0x0011110001xxxx000001xxxxxxxxxx";
   "0x00111100001xxx000001xxxxxxxxxx";
 
-  (*** SLI ***)
-  "0110111101xxxxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
-  "01101111001xxxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
-  "011011110001xxxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
-  "0110111100001xxx010101xxxxxxxxxx"; (* q=1, immh!=0 *)
+  (*** SLI (vector) ***)
+  "0x10111101xxxxxx010101xxxxxxxxxx"; (* immh!=0 *)
+  "0x101111001xxxxx010101xxxxxxxxxx"; (* immh!=0 *)
+  "0x1011110001xxxx010101xxxxxxxxxx"; (* immh!=0 *)
+  "0x10111100001xxx010101xxxxxxxxxx"; (* immh!=0 *)
 
   (*** SRI (vector) ***)
   "0x10111101xxxxxx010001xxxxxxxxxx"; (* immh!=0 *)


### PR DESCRIPTION
Previously, the Arm64 model for the SLI (Vector) instruction only supported the 128-bit variant.

This commit extends the Arm64 model with support for the 64-bit variant of the SLI (Vector) instruction.
