### PR TITLE
Extend Mach-O reader to read rodata and relocation entries

### DIFF
--- a/arm/tutorial/rodata.S
+++ b/arm/tutorial/rodata.S
@@ -16,12 +16,15 @@
   }
 */
 
-.text
+#if defined(__linux__) && defined(__ELF__)
 .section  .rodata
   .global  x
-  .align  3
   .type  x, %object
   .size  x, 40
+#elif defined(__APPLE__)
+.const_data
+#endif
+  .align  3
 x:
   .word  2
   .word  4
@@ -34,10 +37,12 @@ x:
   .word  18
   .word  20
 
+#if defined(__linux__) && defined(__ELF__)
   .global  y
-  .align  3
   .type  y, %object
   .size  y, 40
+#endif
+  .align  3
 y:
   .word  1
   .word  2
@@ -50,33 +55,55 @@ y:
   .word  9
   .word  10
 
+#if defined(__linux__) && defined(__ELF__)
   .global  z
-  .align  3
   .type  z, %object
   .size  z, 4
+#endif
+  .align  3
 z:
   .word  1
 
 .text
   .align  2
+#if defined(__linux__) && defined(__ELF__)
   .type  f, %function
+#endif
+
 f:
   mov x3, x0
+#if defined(__linux__) && defined(__ELF__)
   adrp  x10, x
   add  x10, x10, :lo12:x
+#else
+  adrp  x10, x@PAGE
+  add  x10, x10, x@PAGEOFF
+#endif
   mov x1, x3
   ldr  w1, [x10, x1, lsl 2]
+#if defined(__linux__) && defined(__ELF__)
   adrp  x11, y
   add  x11, x11, :lo12:y
+#else
+  adrp  x11, y@PAGE
+  add  x11, x11, y@PAGEOFF
+#endif
   mov x2, x3
   ldr  w0, [x11, x2, lsl 2]
   add  w0, w1, w0
   ret
 
+#if defined(__linux__) && defined(__ELF__)
   .type  g, %function
+#endif
 g:
+#if defined(__linux__) && defined(__ELF__)
   adrp  x10, z
   add  x10, x10, :lo12:z
+#else
+  adrp  x10, z@PAGE
+  add  x10, x10, z@PAGEOFF
+#endif
   ldr w1, [x10]
   add x0, x1, x0
   b f


### PR DESCRIPTION
This patch extends the Mach-O reader of s2n-bignum to extract the read-only data (the `__const` section) and relocation entries for `ADRP`/`ADD` as well.

It extends the `load_macho` function in common/elf to return the new information and makes its function signature same as `load_elf`. The `arm/tutorial/rodata.{S,ml}` tutorial was updated. It should work on Mac. The new curve25519_x25519base.ml that John wrote also passed with his curve25519_x25519base.S was cross-compiled to Mach-O as well!

Materials that were useful to me were:
- OS X ABI Mach-O File Format Reference: https://github.com/aidansteele/osx-abi-macho-file-format-reference
- Relocation entry types from MachO.h of LLVM: https://github.com/llvm/llvm-project/blob/main/llvm/include/llvm/BinaryFormat/MachO.h#L451

I also found that https://github.com/horsicq/XMachOViewer was useful for its visualization.

One interesting thing from Mach-O's symbol table was that it has 'virtual' symbols whose names start with 'ltmp'. I found that other MachO dump tools ignore these symbols (one of those was https://github.com/microsoft/llvm-mctoll/blob/master/MachODump.cpp#L228 and another one was from another open source tool), so I chose to mimic their choice :)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
