### PR TITLE
Refresh assembly head comments

### DIFF
--- a/arm/curve25519/bignum_add_p25519.S
+++ b/arm/curve25519/bignum_add_p25519.S
@@ -5,8 +5,8 @@
 // Add modulo p_25519, z := (x + y) mod p_25519, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_cmul_p25519.S
+++ b/arm/curve25519/bignum_cmul_p25519.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p25519
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p25519(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_double_p25519.S
+++ b/arm/curve25519/bignum_double_p25519.S
@@ -5,8 +5,8 @@
 // Double modulo p_25519, z := (2 * x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p25519(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_inv_p25519.S
+++ b/arm/curve25519/bignum_inv_p25519.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_25519 = 2^255 - 19
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_p25519(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // Assuming the 4-digit input x is coprime to p_25519, i.e. is not divisible
 // by it, returns z < p_25519 such that x * z == 1 (mod p_25519). Note that

--- a/arm/curve25519/bignum_invsqrt_p25519.S
+++ b/arm/curve25519/bignum_invsqrt_p25519.S
@@ -5,7 +5,7 @@
 // Inverse square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_invsqrt_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_invsqrt_p25519(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular inverse square root mod p_25519,
 // i.e. a z such that x * z^2 == 1 (mod p_25519), whenever one exists. The

--- a/arm/curve25519/bignum_invsqrt_p25519_alt.S
+++ b/arm/curve25519/bignum_invsqrt_p25519_alt.S
@@ -5,7 +5,7 @@
 // Inverse square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_invsqrt_p25519_alt(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_invsqrt_p25519_alt(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular inverse square root mod p_25519,
 // i.e. a z such that x * z^2 == 1 (mod p_25519), whenever one exists. The

--- a/arm/curve25519/bignum_madd_n25519.S
+++ b/arm/curve25519/bignum_madd_n25519.S
@@ -5,9 +5,9 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4],
+//                                   const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/arm/curve25519/bignum_madd_n25519_alt.S
+++ b/arm/curve25519/bignum_madd_n25519_alt.S
@@ -5,9 +5,10 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4],
+//                                       const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/arm/curve25519/bignum_mod_m25519_4.S
+++ b/arm/curve25519/bignum_mod_m25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod m_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_m25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_m25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of curve25519/edwards25519.
 // This is the full group order, 8 * the standard basepoint order.

--- a/arm/curve25519/bignum_mod_n25519.S
+++ b/arm/curve25519/bignum_mod_n25519.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n25519
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n25519(uint64_t z[static 4], uint64_t k,
+//                                  const uint64_t *x);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint,
 // which is n_25519 = 2^252 + 27742317777372353535851937790883648493

--- a/arm/curve25519/bignum_mod_n25519_4.S
+++ b/arm/curve25519/bignum_mod_n25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint.
 //

--- a/arm/curve25519/bignum_mod_p25519_4.S
+++ b/arm/curve25519/bignum_mod_p25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_mul_p25519.S
+++ b/arm/curve25519/bignum_mul_p25519.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_mul_p25519_alt.S
+++ b/arm/curve25519/bignum_mul_p25519_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_neg_p25519.S
+++ b/arm/curve25519/bignum_neg_p25519.S
@@ -5,8 +5,7 @@
 // Negate modulo p_25519, z := (-x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_optneg_p25519.S
+++ b/arm/curve25519/bignum_optneg_p25519.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p25519
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p25519(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_sqr_p25519.S
+++ b/arm/curve25519/bignum_sqr_p25519.S
@@ -5,8 +5,7 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_sqr_p25519_alt.S
+++ b/arm/curve25519/bignum_sqr_p25519_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/bignum_sqrt_p25519.S
+++ b/arm/curve25519/bignum_sqrt_p25519.S
@@ -5,7 +5,8 @@
 // Square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_sqrt_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_sqrt_p25519(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular square root mod p_25519, i.e.
 // a z such that z^2 == x (mod p_25519), whenever one exists. The square

--- a/arm/curve25519/bignum_sqrt_p25519_alt.S
+++ b/arm/curve25519/bignum_sqrt_p25519_alt.S
@@ -5,7 +5,8 @@
 // Square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_sqrt_p25519_alt(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_sqrt_p25519_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular square root mod p_25519, i.e.
 // a z such that z^2 == x (mod p_25519), whenever one exists. The square

--- a/arm/curve25519/bignum_sub_p25519.S
+++ b/arm/curve25519/bignum_sub_p25519.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_25519, z := (x - y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/curve25519/curve25519_ladderstep.S
+++ b/arm/curve25519/curve25519_ladderstep.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint64_t rr[16],const uint64_t point[8],const uint64_t pp[16],uint64_t b);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/arm/curve25519/curve25519_ladderstep_alt.S
+++ b/arm/curve25519/curve25519_ladderstep_alt.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep_alt
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint64_t rr[16],const uint64_t point[8],const uint64_t pp[16],uint64_t b);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/arm/curve25519/curve25519_pxscalarmul.S
+++ b/arm/curve25519/curve25519_pxscalarmul.S
@@ -6,7 +6,8 @@
 // Inputs scalar[4], point[4]; output res[8]
 //
 // extern void curve25519_pxscalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/arm/curve25519/curve25519_pxscalarmul_alt.S
+++ b/arm/curve25519/curve25519_pxscalarmul_alt.S
@@ -6,7 +6,8 @@
 // Inputs scalar[4], point[4]; output res[8]
 //
 // extern void curve25519_pxscalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/arm/curve25519/curve25519_x25519.S
+++ b/arm/curve25519/curve25519_x25519.S
@@ -19,7 +19,8 @@
 // Inputs scalar[4], point[4]; output res[4]
 //
 // extern void curve25519_x25519
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 4],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519_alt.S
+++ b/arm/curve25519/curve25519_x25519_alt.S
@@ -6,7 +6,8 @@
 // Inputs scalar[4], point[4]; output res[4]
 //
 // extern void curve25519_x25519_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 4],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519_byte.S
+++ b/arm/curve25519/curve25519_x25519_byte.S
@@ -19,7 +19,8 @@
 // Inputs scalar[32] (bytes), point[32] (bytes); output res[32] (bytes)
 //
 // extern void curve25519_x25519_byte
-//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32],
+//    const uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519_byte_alt.S
@@ -6,7 +6,8 @@
 // Inputs scalar[32] (bytes), point[32] (bytes); output res[32] (bytes)
 //
 // extern void curve25519_x25519_byte_alt
-//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32],
+//    const uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/arm/curve25519/curve25519_x25519base.S
+++ b/arm/curve25519/curve25519_x25519base.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[4]
 //
 // extern void curve25519_x25519base
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint64_t res[static 4],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/curve25519_x25519base_alt.S
+++ b/arm/curve25519/curve25519_x25519base_alt.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[4]
 //
 // extern void curve25519_x25519base_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint64_t res[static 4],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/curve25519_x25519base_byte.S
+++ b/arm/curve25519/curve25519_x25519base_byte.S
@@ -6,7 +6,7 @@
 // Input scalar[32] (bytes); output res[32] (bytes)
 //
 // extern void curve25519_x25519base_byte
-//   (uint8_t res[static 32],uint8_t scalar[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/curve25519_x25519base_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519base_byte_alt.S
@@ -6,7 +6,7 @@
 // Input scalar[32] (bytes); output res[32] (bytes)
 //
 // extern void curve25519_x25519base_byte_alt
-//   (uint8_t res[static 32],uint8_t scalar[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/arm/curve25519/edwards25519_encode.S
+++ b/arm/curve25519/edwards25519_encode.S
@@ -5,8 +5,8 @@
 // Encode edwards25519 point into compressed form as 256-bit number
 // Input p[8]; output z[32] (bytes)
 //
-//    extern void edwards25519_encode
-//     (uint8_t z[static 32], uint64_t p[static 8]);
+//    extern void edwards25519_encode(uint8_t z[static 32],
+//                                    const uint64_t p[static 8]);
 //
 // This assumes that the input buffer p points to a pair of 256-bit
 // numbers x (at p) and y (at p+4) representing a point (x,y) on the

--- a/arm/curve25519/edwards25519_epadd.S
+++ b/arm/curve25519/edwards25519_epadd.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[16]; output p3[16]
 //
 // extern void edwards25519_epadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 16]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/arm/curve25519/edwards25519_epadd_alt.S
+++ b/arm/curve25519/edwards25519_epadd_alt.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[16]; output p3[16]
 //
 // extern void edwards25519_epadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 16]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/arm/curve25519/edwards25519_epdouble.S
+++ b/arm/curve25519/edwards25519_epdouble.S
@@ -6,7 +6,7 @@
 // Input p1[12]; output p3[16]
 //
 // extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/arm/curve25519/edwards25519_epdouble_alt.S
+++ b/arm/curve25519/edwards25519_epdouble_alt.S
@@ -5,8 +5,8 @@
 // Extended projective doubling for edwards25519
 // Input p1[12]; output p3[16]
 //
-// extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+// extern void edwards25519_epdouble_alt
+//   (uint64_t p3[static 16],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/arm/curve25519/edwards25519_pdouble.S
+++ b/arm/curve25519/edwards25519_pdouble.S
@@ -6,7 +6,7 @@
 // Input p1[12]; output p3[12]
 //
 // extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+//   (uint64_t p3[static 12],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/arm/curve25519/edwards25519_pdouble_alt.S
+++ b/arm/curve25519/edwards25519_pdouble_alt.S
@@ -5,8 +5,8 @@
 // Projective doubling for edwards25519
 // Input p1[12]; output p3[12]
 //
-// extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+// extern void edwards25519_pdouble_alt
+//   (uint64_t p3[static 12],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/arm/curve25519/edwards25519_pepadd.S
+++ b/arm/curve25519/edwards25519_pepadd.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[12]; output p3[16]
 //
 // extern void edwards25519_pepadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 12]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/arm/curve25519/edwards25519_pepadd_alt.S
+++ b/arm/curve25519/edwards25519_pepadd_alt.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[12]; output p3[16]
 //
 // extern void edwards25519_pepadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 12]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/arm/curve25519/edwards25519_scalarmulbase.S
+++ b/arm/curve25519/edwards25519_scalarmulbase.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmulbase
-//   (uint64_t res[static 8],uint64_t scalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns point (X,Y) = n * B where B = (...,4/5) is
 // the standard basepoint for the edwards25519 (Ed25519) curve.

--- a/arm/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/arm/curve25519/edwards25519_scalarmulbase_alt.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmulbase_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns point (X,Y) = n * B where B = (...,4/5) is
 // the standard basepoint for the edwards25519 (Ed25519) curve.

--- a/arm/curve25519/edwards25519_scalarmuldouble.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8], bscalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmuldouble
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//    uint64_t point[static 8],uint64_t bscalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 8],const uint64_t bscalar[static 4]);
 //
 // Given scalar = n, point = P and bscalar = m, returns in res
 // the point (X,Y) = n * P + m * B where B = (...,4/5) is

--- a/arm/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8], bscalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmuldouble_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//    uint64_t point[static 8],uint64_t bscalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 8],const uint64_t bscalar[static 4]);
 //
 // Given scalar = n, point = P and bscalar = m, returns in res
 // the point (X,Y) = n * P + m * B where B = (...,4/5) is

--- a/arm/fastmul/bignum_emontredc_8n.S
+++ b/arm/fastmul/bignum_emontredc_8n.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce in 8-digit blocks, results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc_8n
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc_8n(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                        uint64_t w);
 //
 // Functionally equivalent to bignum_emontredc (see that file for more detail).
 // But in general assumes that the input k is a multiple of 8.

--- a/arm/fastmul/bignum_emontredc_8n_cdiff.S
+++ b/arm/fastmul/bignum_emontredc_8n_cdiff.S
@@ -5,10 +5,10 @@
 // Extend Montgomery reduce in 8-digit blocks, uses an extra storage to
 // temporarily cache multiplied differences appearing in ADK.
 // Results are stored in input-output buffer (z).
+// k must be divisible by 8 and not smaller than 16.
 // Inputs z[2*k], m[k], w;
 // Outputs function return (extra result bit) and z[2*k]
 // Temporary buffer m_precalc[12*(k/4-1)]
-// k must be divisible by 8 and not smaller than 16.
 //
 //    extern uint64_t bignum_emontredc_8n_cdiff(uint64_t k, uint64_t *z,
 //                                              const uint64_t *m, uint64_t w,

--- a/arm/fastmul/bignum_emontredc_8n_cdiff.S
+++ b/arm/fastmul/bignum_emontredc_8n_cdiff.S
@@ -10,8 +10,9 @@
 // Temporary buffer m_precalc[12*(k/4-1)]
 // k must be divisible by 8 and not smaller than 16.
 //
-//    extern uint64_t bignum_emontredc_8n_cdiff
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w, uint64_t *m_precalc);
+//    extern uint64_t bignum_emontredc_8n_cdiff(uint64_t k, uint64_t *z,
+//                                              const uint64_t *m, uint64_t w,
+//                                              uint64_t *m_precalc);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = m, X3 = w, X4 = m_precalc
 //                   returns X0

--- a/arm/fastmul/bignum_kmul_16_32.S
+++ b/arm/fastmul/bignum_kmul_16_32.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[16], y[16]; output z[32]; temporary buffer t[>=32]
 //
-//    extern void bignum_kmul_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t y[static 16],
-//      uint64_t t[static 32])
+//    extern void bignum_kmul_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  const uint64_t y[static 16],
+//                                  uint64_t t[static 32]);
 //
 // This is a Karatsuba-style function multiplying half-sized results
 // internally and using temporary buffer t for intermediate results.

--- a/arm/fastmul/bignum_kmul_32_64.S
+++ b/arm/fastmul/bignum_kmul_32_64.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[32], y[32]; output z[64]; temporary buffer t[>=96]
 //
-//    extern void bignum_kmul_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t y[static 32],
-//      uint64_t t[static 96])
+//    extern void bignum_kmul_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  const uint64_t y[static 32],
+//                                  uint64_t t[static 96]);
 //
 // This is a Karatsuba-style function multiplying half-sized results
 // internally and using temporary buffer t for intermediate results.

--- a/arm/fastmul/bignum_ksqr_16_32.S
+++ b/arm/fastmul/bignum_ksqr_16_32.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[16]; output z[32]; temporary buffer t[>=24]
 //
-//    extern void bignum_ksqr_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t t[static 24]);
+//    extern void bignum_ksqr_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  uint64_t t[static 24]);
 //
 // This is a Karatsuba-style function squaring half-sized results
 // and using temporary buffer t for intermediate results.

--- a/arm/fastmul/bignum_ksqr_32_64.S
+++ b/arm/fastmul/bignum_ksqr_32_64.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[32]; output z[64]; temporary buffer t[>=72]
 //
-//    extern void bignum_ksqr_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t t[static 72]);
+//    extern void bignum_ksqr_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  uint64_t t[static 72]);
 //
 // This is a Karatsuba-style function squaring half-sized results
 // and using temporary buffer t for intermediate results.

--- a/arm/fastmul/bignum_mul_4_8.S
+++ b/arm/fastmul/bignum_mul_4_8.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8(uint64_t z[static 8], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_mul_4_8_alt.S
+++ b/arm/fastmul/bignum_mul_4_8_alt.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8_alt
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8_alt(uint64_t z[static 8], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_mul_6_12.S
+++ b/arm/fastmul/bignum_mul_6_12.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12(uint64_t z[static 12], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_mul_6_12_alt.S
+++ b/arm/fastmul/bignum_mul_6_12_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12_alt
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_mul_8_16.S
+++ b/arm/fastmul/bignum_mul_8_16.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16(uint64_t z[static 16], const uint64_t x[static 8],
+//                                const uint64_t y[static 8]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_mul_8_16_alt.S
+++ b/arm/fastmul/bignum_mul_8_16_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16_alt
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8],
+//                                    const uint64_t y[static 8]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_4_8.S
+++ b/arm/fastmul/bignum_sqr_4_8.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8 (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8(uint64_t z[static 8], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_4_8_alt.S
+++ b/arm/fastmul/bignum_sqr_4_8_alt.S
@@ -5,8 +5,8 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8_alt
-//     (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8_alt(uint64_t z[static 8],
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_6_12.S
+++ b/arm/fastmul/bignum_sqr_6_12.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12 (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12(uint64_t z[static 12], const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_6_12_alt.S
+++ b/arm/fastmul/bignum_sqr_6_12_alt.S
@@ -5,7 +5,8 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12_alt (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_8_16.S
+++ b/arm/fastmul/bignum_sqr_8_16.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16 (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16(uint64_t z[static 16], const uint64_t x[static 8]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/fastmul/bignum_sqr_8_16_alt.S
+++ b/arm/fastmul/bignum_sqr_8_16_alt.S
@@ -5,8 +5,8 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16_alt
-//     (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_add.S
+++ b/arm/generic/bignum_add.S
@@ -5,9 +5,8 @@
 // Add, z := x + y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_add
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_add(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x + y operation, truncating modulo p words in general and
 // returning a top carry (0 or 1) in the p'th place, only adding the input

--- a/arm/generic/bignum_amontifier.S
+++ b/arm/generic/bignum_amontifier.S
@@ -5,8 +5,8 @@
 // Compute "amontification" constant z :== 2^{128k} (congruent mod m)
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_amontifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_amontifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                  uint64_t *t);
 //
 // This is called "amontifier" because any other value x can now be mapped into
 // the almost-Montgomery domain with an almost-Montgomery multiplication by z.

--- a/arm/generic/bignum_amontmul.S
+++ b/arm/generic/bignum_amontmul.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery multiply, z :== (x * y / 2^{64k}) (congruent mod m)
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_amontmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_amontmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *y, const uint64_t *m);
 //
 // Does z :== (x * y / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/arm/generic/bignum_amontredc.S
+++ b/arm/generic/bignum_amontredc.S
@@ -5,9 +5,8 @@
 // Almost-Montgomery reduce, z :== (x' / 2^{64p}) (congruent mod m)
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_amontredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_amontredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                 const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a :== (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x. That is, p-fold almost-Montgomery reduction

--- a/arm/generic/bignum_amontsqr.S
+++ b/arm/generic/bignum_amontsqr.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery square, z :== (x^2 / 2^{64k}) (congruent mod m)
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_amontsqr
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_amontsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *m);
 //
 // Does z :== (x^2 / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/arm/generic/bignum_bitfield.S
+++ b/arm/generic/bignum_bitfield.S
@@ -5,8 +5,8 @@
 // Select bitfield starting at bit n with length l <= 64
 // Inputs x[k], n, l; output function return
 //
-//    extern uint64_t bignum_bitfield
-//     (uint64_t k, uint64_t *x, uint64_t n, uint64_t l);
+//    extern uint64_t bignum_bitfield(uint64_t k, const uint64_t *x, uint64_t n,
+//                                    uint64_t l);
 //
 // One-word bitfield from a k-digit (digit=64 bits) bignum, in constant-time
 // style. Bitfield starts at bit n and has length l, indexing from 0 (=LSB).

--- a/arm/generic/bignum_bitsize.S
+++ b/arm/generic/bignum_bitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_bitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_bitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/arm/generic/bignum_cdiv.S
+++ b/arm/generic/bignum_cdiv.S
@@ -5,8 +5,8 @@
 // Divide by a single (nonzero) word, z := x / m and return x mod m
 // Inputs x[n], m; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_cdiv
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cdiv(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits, result z is k.
 // Truncates the quotient in general, but always (for nonzero m) returns

--- a/arm/generic/bignum_cdiv_exact.S
+++ b/arm/generic/bignum_cdiv_exact.S
@@ -5,8 +5,8 @@
 // Divide by a single word, z := x / m *when known to be exact*
 // Inputs x[n], m; output z[k]
 //
-//    extern void bignum_cdiv_exact
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern void bignum_cdiv_exact(uint64_t k, uint64_t *z, uint64_t n,
+//                                  const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits and result z is k,
 // *assuming* that m is nonzero and that the input x is in fact an

--- a/arm/generic/bignum_cld.S
+++ b/arm/generic/bignum_cld.S
@@ -5,7 +5,7 @@
 // Count leading zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_cld (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_cld(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/arm/generic/bignum_clz.S
+++ b/arm/generic/bignum_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_clz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_clz(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 64 * k
 //

--- a/arm/generic/bignum_cmadd.S
+++ b/arm/generic/bignum_cmadd.S
@@ -5,8 +5,8 @@
 // Multiply-add with single-word multiplier, z := z + c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                 const uint64_t *y);
 //
 // Does the "z := z + c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/arm/generic/bignum_cmnegadd.S
+++ b/arm/generic/bignum_cmnegadd.S
@@ -5,8 +5,8 @@
 // Negated multiply-add with single-word multiplier, z := z - c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmnegadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmnegadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                    const uint64_t *y);
 //
 // Does the "z := z - c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/arm/generic/bignum_cmod.S
+++ b/arm/generic/bignum_cmod.S
@@ -5,7 +5,7 @@
 // Find bignum modulo a single word
 // Input x[k], m; output function return
 //
-//    extern uint64_t bignum_cmod (uint64_t k, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cmod(uint64_t k, const uint64_t *x, uint64_t m);
 //
 // Returns x mod m, assuming m is nonzero.
 //

--- a/arm/generic/bignum_cmul.S
+++ b/arm/generic/bignum_cmul.S
@@ -5,8 +5,8 @@
 // Multiply by a single word, z := c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmul
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmul(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                const uint64_t *y);
 //
 // Does the "z := c * y" operation where y is n digits, result z is p.
 // Truncates the result in general unless p >= n + 1.

--- a/arm/generic/bignum_coprime.S
+++ b/arm/generic/bignum_coprime.S
@@ -5,8 +5,8 @@
 // Test bignums for coprimality, gcd(x,y) = 1
 // Inputs x[m], y[n]; output function return; temporary buffer t[>=2*max(m,n)]
 //
-//    extern uint64_t bignum_coprime
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y, uint64_t *t);
+//    extern uint64_t bignum_coprime(uint64_t m, const uint64_t *x, uint64_t n,
+//                                   const uint64_t *y, uint64_t *t);
 //
 // Test for whether two bignums are coprime (no common factor besides 1).
 // This is equivalent to testing if their gcd is 1, but a bit faster than

--- a/arm/generic/bignum_copy.S
+++ b/arm/generic/bignum_copy.S
@@ -5,8 +5,7 @@
 // Copy bignum with zero-extension or truncation, z := x
 // Input x[n]; output z[k]
 //
-//    extern void bignum_copy
-//      (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_copy(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = n, X3 = x
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_copy_row_from_table.S
+++ b/arm/generic/bignum_copy_row_from_table.S
@@ -8,8 +8,8 @@
 // achieved by reading the whole table and using the bit-masking to get the
 // `idx`-th row.
 //
-//    extern void bignum_copy_from_table
-//     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t width,
+//    extern void bignum_copy_row_from_table
+//     (uint64_t *z, const uint64_t *table, uint64_t height, uint64_t width,
 //      uint64_t idx);
 //
 // Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = width, X4 = idx

--- a/arm/generic/bignum_copy_row_from_table_16.S
+++ b/arm/generic/bignum_copy_row_from_table_16.S
@@ -8,8 +8,8 @@
 // achieved by reading the whole table and using the bit-masking to get the
 // `idx`-th row.
 //
-//    extern void bignum_copy_from_table_16
-//     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t idx);
+//    extern void bignum_copy_row_from_table_16
+//     (uint64_t *z, const uint64_t *table, uint64_t height, uint64_t idx);
 //
 // Initial version written by Hanno Becker
 // Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = idx

--- a/arm/generic/bignum_copy_row_from_table_32.S
+++ b/arm/generic/bignum_copy_row_from_table_32.S
@@ -8,8 +8,8 @@
 // achieved by reading the whole table and using the bit-masking to get the
 // `idx`-th row.
 //
-//    extern void bignum_copy_from_table_32
-//     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t idx);
+//    extern void bignum_copy_row_from_table_32
+//     (uint64_t *z, const uint64_t *table, uint64_t height, uint64_t idx);
 //
 // Initial version written by Hanno Becker
 // Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = idx

--- a/arm/generic/bignum_copy_row_from_table_8n.S
+++ b/arm/generic/bignum_copy_row_from_table_8n.S
@@ -8,8 +8,8 @@
 // achieved by reading the whole table and using the bit-masking to get the
 // `idx`-th row.
 //
-//    extern void bignum_copy_from_table_8n
-//     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t width, uint64_t idx);
+//    extern void bignum_copy_row_from_table_8n
+//     (uint64_t *z, const uint64_t *table, uint64_t height, uint64_t width, uint64_t idx);
 //
 // Standard ARM ABI: X0 = z, X1 = table, X2 = height, X3 = width, X4 = idx
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_ctd.S
+++ b/arm/generic/bignum_ctd.S
@@ -5,7 +5,7 @@
 // Count trailing zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctd(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/arm/generic/bignum_ctz.S
+++ b/arm/generic/bignum_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctz(uint64_t k, const uint64_t *x);
 //
 //
 // In the case of a zero bignum as input the result is 64 * k

--- a/arm/generic/bignum_demont.S
+++ b/arm/generic/bignum_demont.S
@@ -5,8 +5,8 @@
 // Convert from (almost-)Montgomery form z := (x / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_demont
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_demont(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *m);
 //
 // Does z := (x / 2^{64k}) mod m, hence mapping out of Montgomery domain.
 // In other words, this is a k-fold Montgomery reduction with same-size input.

--- a/arm/generic/bignum_digit.S
+++ b/arm/generic/bignum_digit.S
@@ -5,7 +5,7 @@
 // Select digit x[n]
 // Inputs x[k], n; output function return
 //
-//    extern uint64_t bignum_digit (uint64_t k, uint64_t *x, uint64_t n);
+//    extern uint64_t bignum_digit(uint64_t k, const uint64_t *x, uint64_t n);
 //
 // n'th digit of a k-digit (digit=64 bits) bignum, in constant-time style.
 // Indexing starts at 0, which is the least significant digit (little-endian).

--- a/arm/generic/bignum_digitsize.S
+++ b/arm/generic/bignum_digitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in digits (64-bit word)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_digitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_digitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/arm/generic/bignum_divmod10.S
+++ b/arm/generic/bignum_divmod10.S
@@ -5,7 +5,7 @@
 // Divide bignum by 10, returning remainder: z' := z div 10, return = z mod 10
 // Inputs z[k]; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_divmod10 (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_divmod10(uint64_t k, uint64_t *z);
 //
 // Standard ARM ABI: X0 = k, X1 = z, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_emontredc.S
+++ b/arm/generic/bignum_emontredc.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce, returning results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                     uint64_t w);
 //
 // Assumes that z initially holds a 2k-digit bignum z_0, m is a k-digit odd
 // bignum and m * w == -1 (mod 2^64). This function also uses z for the output

--- a/arm/generic/bignum_eq.S
+++ b/arm/generic/bignum_eq.S
@@ -5,8 +5,8 @@
 // Test bignums for equality, x = y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_eq
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_eq(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard ARM ABI: X0 = m, X1 = x, X2 = n, X3 = y, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_even.S
+++ b/arm/generic/bignum_even.S
@@ -5,7 +5,7 @@
 // Test bignum for even-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_even (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_even(uint64_t k, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = k, X1 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_ge.S
+++ b/arm/generic/bignum_ge.S
@@ -5,8 +5,8 @@
 // Compare bignums, x >= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_ge
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_ge(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard ARM ABI: X0 = m, X1 = x, X2 = n, X3 = y, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_gt.S
+++ b/arm/generic/bignum_gt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x > y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_gt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_gt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard ARM ABI: X0 = m, X1 = x, X2 = n, X3 = y, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_iszero.S
+++ b/arm/generic/bignum_iszero.S
@@ -5,7 +5,7 @@
 // Test bignum for zero-ness, x = 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_iszero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_iszero(uint64_t k, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = k, X1 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_le.S
+++ b/arm/generic/bignum_le.S
@@ -5,8 +5,8 @@
 // Compare bignums, x <= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_le
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_le(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard ARM ABI: X0 = m, X1 = x, X2 = n, X3 = y, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_lt.S
+++ b/arm/generic/bignum_lt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x < y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_lt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_lt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard ARM ABI: X0 = m, X1 = x, X2 = n, X3 = y, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_madd.S
+++ b/arm/generic/bignum_madd.S
@@ -5,9 +5,8 @@
 // Multiply-add, z := z + x * y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_madd
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_madd(uint64_t k, uint64_t *z, uint64_t m,
+//                                const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y + z" operation, while also returning a "next" or
 // "carry" word. In the case where m + n <= p (i.e. the pure product would

--- a/arm/generic/bignum_modadd.S
+++ b/arm/generic/bignum_modadd.S
@@ -5,8 +5,8 @@
 // Add modulo m, z := (x + y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = x, X3 = y, X4 = m
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_moddouble.S
+++ b/arm/generic/bignum_moddouble.S
@@ -5,8 +5,8 @@
 // Double modulo m, z := (2 * x) mod m, assuming x reduced
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_moddouble
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_moddouble(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                 const uint64_t *m);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = x, X3 = m
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_modexp.S
+++ b/arm/generic/bignum_modexp.S
@@ -6,7 +6,8 @@
 // Inputs a[k], p[k], m[k]; output z[k], temporary buffer t[>=3*k]
 //
 //   extern void bignum_modexp
-//    (uint64_t k,uint64_t *z, uint64_t *a,uint64_t *p,uint64_t *m,uint64_t *t);
+//    (uint64_t k,uint64_t *z, const uint64_t *a,const uint64_t *p,
+//     const uint64_t *m,uint64_t *t);
 //
 // Does z := (a^p) mod m where all numbers are k-digit and m is odd
 //

--- a/arm/generic/bignum_modifier.S
+++ b/arm/generic/bignum_modifier.S
@@ -5,8 +5,8 @@
 // Compute "modification" constant z := 2^{64k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_modifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_modifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "mod-ifier" because given any other k-digit number x we can

--- a/arm/generic/bignum_modinv.S
+++ b/arm/generic/bignum_modinv.S
@@ -5,8 +5,8 @@
 // Invert modulo m, z = (1/a) mod b, assuming b is an odd number > 1, coprime a
 // Inputs a[k], b[k]; output z[k]; temporary buffer t[>=3*k]
 //
-//    extern void bignum_modinv
-//     (uint64_t k, uint64_t *z, uint64_t *a, uint64_t *b, uint64_t *t);
+//    extern void bignum_modinv(uint64_t k, uint64_t *z, const uint64_t *a,
+//                              const uint64_t *b, uint64_t *t);
 //
 // k-digit (digit=64 bits) "z := a^-1 mod b" (modular inverse of a modulo b)
 // using t as a temporary buffer (t at least 3*k words = 24*k bytes), and

--- a/arm/generic/bignum_modoptneg.S
+++ b/arm/generic/bignum_modoptneg.S
@@ -6,8 +6,8 @@
 // (if p zero), assuming x reduced
 // Inputs p, x[k], m[k]; output z[k]
 //
-//    extern void bignum_modoptneg
-//      (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x, uint64_t *m);
+//    extern void bignum_modoptneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                 const uint64_t *x, const uint64_t *m);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = p, X3 = x, X4 = m
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_modsub.S
+++ b/arm/generic/bignum_modsub.S
@@ -5,8 +5,8 @@
 // Subtract modulo m, z := (x - y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard ARM ABI: X0 = k, X1 = z, X2 = x, X3 = y, X4 = m
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_montifier.S
+++ b/arm/generic/bignum_montifier.S
@@ -5,8 +5,8 @@
 // Compute "montification" constant z := 2^{128k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_montifier
-//      (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_montifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                 uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "montifier" because given any other k-digit number x,

--- a/arm/generic/bignum_montmul.S
+++ b/arm/generic/bignum_montmul.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^{64k}) mod m
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_montmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_montmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *y, const uint64_t *m);
 //
 // Does z := (x * y / 2^{64k}) mod m, assuming x * y <= 2^{64k} * m, which is
 // guaranteed in particular if x < m, y < m initially (the "intended" case).

--- a/arm/generic/bignum_montredc.S
+++ b/arm/generic/bignum_montredc.S
@@ -5,9 +5,8 @@
 // Montgomery reduce, z := (x' / 2^{64p}) MOD m
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_montredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_montredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a := (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x, assuming x' <= 2^{64p} * m. That is,

--- a/arm/generic/bignum_montsqr.S
+++ b/arm/generic/bignum_montsqr.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_montsqr
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_montsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *m);
 //
 // Does z := (x^2 / 2^{64k}) mod m, assuming x^2 <= 2^{64k} * m, which is
 // guaranteed in particular if x < m initially (the "intended" case).

--- a/arm/generic/bignum_mul.S
+++ b/arm/generic/bignum_mul.S
@@ -5,9 +5,8 @@
 // Multiply z := x * y
 // Inputs x[m], y[n]; output z[k]
 //
-//    extern void bignum_mul
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern void bignum_mul(uint64_t k, uint64_t *z, uint64_t m, const uint64_t *x,
+//                           uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y" operation where x is m digits, y is n, result z is k.
 // Truncates the result in general unless k >= m + n

--- a/arm/generic/bignum_muladd10.S
+++ b/arm/generic/bignum_muladd10.S
@@ -5,7 +5,7 @@
 // Multiply bignum by 10 and add word: z := 10 * z + d
 // Inputs z[k], d; outputs function return (carry) and z[k]
 //
-//    extern uint64_t bignum_muladd10 (uint64_t k, uint64_t *z, uint64_t d);
+//    extern uint64_t bignum_muladd10(uint64_t k, uint64_t *z, uint64_t d);
 //
 // Although typically the input d < 10, this is not actually required.
 //

--- a/arm/generic/bignum_mux.S
+++ b/arm/generic/bignum_mux.S
@@ -5,8 +5,8 @@
 // Multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[k], y[k]; output z[k]
 //
-//    extern void bignum_mux
-//     (uint64_t p, uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+//    extern void bignum_mux(uint64_t p, uint64_t k, uint64_t *z, const uint64_t *x,
+//                           const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 //

--- a/arm/generic/bignum_mux16.S
+++ b/arm/generic/bignum_mux16.S
@@ -5,8 +5,8 @@
 // Select element from 16-element table, z := xs[k*i]
 // Inputs xs[16*k], i; output z[k]
 //
-//    extern void bignum_mux16
-//     (uint64_t k, uint64_t *z, uint64_t *xs, uint64_t i);
+//    extern void bignum_mux16(uint64_t k, uint64_t *z, const uint64_t *xs,
+//                             uint64_t i);
 //
 // It is assumed that all numbers xs[16] and the target z have the same size k
 // The pointer xs is to a contiguous array of size 16, elements size-k bignums

--- a/arm/generic/bignum_negmodinv.S
+++ b/arm/generic/bignum_negmodinv.S
@@ -5,8 +5,7 @@
 // Negated modular inverse, z := (-1/x) mod 2^{64k}
 // Input x[k]; output z[k]
 //
-//    extern void bignum_negmodinv
-//     (uint64_t k, uint64_t *z, uint64_t *x);
+//    extern void bignum_negmodinv(uint64_t k, uint64_t *z, const uint64_t *x);
 //
 // Assuming x is odd (otherwise nothing makes sense) the result satisfies
 //

--- a/arm/generic/bignum_nonzero.S
+++ b/arm/generic/bignum_nonzero.S
@@ -5,7 +5,7 @@
 // Test bignum for nonzero-ness x =/= 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_nonzero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_nonzero(uint64_t k, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = k, X1 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_normalize.S
+++ b/arm/generic/bignum_normalize.S
@@ -5,7 +5,7 @@
 // Normalize bignum in-place by shifting left till top bit is 1
 // Input z[k]; outputs function return (bits shifted left) and z[k]
 //
-//    extern uint64_t bignum_normalize (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_normalize(uint64_t k, uint64_t *z);
 //
 // Given a k-digit bignum z, this function shifts it left by its number of
 // leading zero bits, to give result with top bit 1, unless the input number

--- a/arm/generic/bignum_odd.S
+++ b/arm/generic/bignum_odd.S
@@ -5,7 +5,7 @@
 // Test bignum for odd-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_odd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_odd(uint64_t k, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = k, X1 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/bignum_of_word.S
+++ b/arm/generic/bignum_of_word.S
@@ -5,7 +5,7 @@
 // Convert single digit to bignum, z := n
 // Input n; output z[k]
 //
-//    extern void bignum_of_word (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_of_word(uint64_t k, uint64_t *z, uint64_t n);
 //
 // Create a k-digit (digit=64 bits) bignum at z with value n (mod 2^k)
 // where n is a word. The "mod 2^k" only matters in the degenerate k = 0 case.

--- a/arm/generic/bignum_optadd.S
+++ b/arm/generic/bignum_optadd.S
@@ -5,8 +5,8 @@
 // Optionally add, z := x + y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual addition, always 0 if p was zero.

--- a/arm/generic/bignum_optneg.S
+++ b/arm/generic/bignum_optneg.S
@@ -5,8 +5,8 @@
 // Optionally negate, z := -x (if p nonzero) or z := x (if p zero)
 // Inputs p, x[k]; outputs function return (nonzero input) and z[k]
 //
-//    extern uint64_t bignum_optneg
-//     (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x);
+//    extern uint64_t bignum_optneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                  const uint64_t *x);
 //
 // It is assumed that both numbers x and z have the same size k digits.
 // Returns a carry, which is equivalent to "x is nonzero".

--- a/arm/generic/bignum_optsub.S
+++ b/arm/generic/bignum_optsub.S
@@ -5,8 +5,8 @@
 // Optionally subtract, z := x - y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual subtraction, always 0 if p was zero.

--- a/arm/generic/bignum_optsubadd.S
+++ b/arm/generic/bignum_optsubadd.S
@@ -5,8 +5,8 @@
 // Optionally subtract or add, z := x + sgn(p) * y interpreting p as signed
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsubadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsubadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                     uint64_t p, const uint64_t *y);
 //
 // If p has top bit set (i.e. is negative as a signed int) return z := x - y
 // Else if p is nonzero (i.e. is positive as a signed int) return z := x + y

--- a/arm/generic/bignum_pow2.S
+++ b/arm/generic/bignum_pow2.S
@@ -5,7 +5,7 @@
 // Return bignum of power of 2, z := 2^n
 // Input n; output z[k]
 //
-//    extern void bignum_pow2 (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_pow2(uint64_t k, uint64_t *z, uint64_t n);
 //
 // The result is as usual mod 2^{64*k}, so will be zero if n >= 64*k.
 //

--- a/arm/generic/bignum_shl_small.S
+++ b/arm/generic/bignum_shl_small.S
@@ -5,8 +5,8 @@
 // Shift bignum left by c < 64 bits z := x * 2^c
 // Inputs x[n], c; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_shl_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shl_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x << c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/arm/generic/bignum_shr_small.S
+++ b/arm/generic/bignum_shr_small.S
@@ -5,8 +5,8 @@
 // Shift bignum right by c < 64 bits z := floor(x / 2^c)
 // Inputs x[n], c; outputs function return (bits shifted out) and z[k]
 //
-//    extern uint64_t bignum_shr_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shr_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x >> c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/arm/generic/bignum_sqr.S
+++ b/arm/generic/bignum_sqr.S
@@ -5,8 +5,7 @@
 // Square z := x^2
 // Input x[n]; output z[k]
 //
-//    extern void bignum_sqr
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_sqr(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Does the "z := x^2" operation where x is n digits and result z is k.
 // Truncates the result in general unless k >= 2 * n

--- a/arm/generic/bignum_sub.S
+++ b/arm/generic/bignum_sub.S
@@ -5,9 +5,8 @@
 // Subtract, z := x - y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_sub
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_sub(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x - y operation, truncating modulo p words in general and
 // returning a top borrow (0 or 1) in the p'th place, only subtracting input

--- a/arm/generic/word_bytereverse.S
+++ b/arm/generic/word_bytereverse.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Reverse the order of bytes in a 64-bit word
 //
-//    extern uint64_t word_bytereverse (uint64_t a);
+//    extern uint64_t word_bytereverse(uint64_t a);
 //
 // Standard ARM ABI: X0 = a, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_clz.S
+++ b/arm/generic/word_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_clz (uint64_t a);
+//    extern uint64_t word_clz(uint64_t a);
 //
 // Standard ARM ABI: X0 = a, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_ctz.S
+++ b/arm/generic/word_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_ctz (uint64_t a);
+//    extern uint64_t word_ctz(uint64_t a);
 //
 // Standard ARM ABI: X0 = a, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_max.S
+++ b/arm/generic/word_max.S
@@ -5,7 +5,7 @@
 // Return maximum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_max (uint64_t a, uint64_t b);
+//    extern uint64_t word_max(uint64_t a, uint64_t b);
 //
 // Standard ARM ABI: X0 = a, X1 = b, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_min.S
+++ b/arm/generic/word_min.S
@@ -5,7 +5,7 @@
 // Return minimum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_min (uint64_t a, uint64_t b);
+//    extern uint64_t word_min(uint64_t a, uint64_t b);
 //
 // Standard ARM ABI: X0 = a, X1 = b, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_negmodinv.S
+++ b/arm/generic/word_negmodinv.S
@@ -5,7 +5,7 @@
 // Single-word negated modular inverse (-1/a) mod 2^64
 // Input a; output function return
 //
-//    extern uint64_t word_negmodinv (uint64_t a);
+//    extern uint64_t word_negmodinv(uint64_t a);
 //
 // A 64-bit function that returns a negated multiplicative inverse mod 2^64
 // of its input, assuming that input is odd. Given odd input a, the result z

--- a/arm/generic/word_popcount.S
+++ b/arm/generic/word_popcount.S
@@ -5,7 +5,7 @@
 // Count number of set bits in a single 64-bit word (population count)
 // Input a; output function return
 //
-//    extern uint64_t word_popcount (uint64_t a);
+//    extern uint64_t word_popcount(uint64_t a);
 //
 // Standard ARM ABI: X0 = a, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/generic/word_recip.S
+++ b/arm/generic/word_recip.S
@@ -5,7 +5,7 @@
 // Single-word reciprocal, underestimate of floor(2^128 / a) - 2^64
 // Input a; output function return
 //
-//    extern uint64_t word_recip (uint64_t a);
+//    extern uint64_t word_recip(uint64_t a);
 //
 // Given an input word "a" with its top bit set (i.e. 2^63 <= a < 2^64), the
 // result "x" is implicitly augmented with a leading 1 giving x' = 2^64 + x.

--- a/arm/p256/bignum_add_p256.S
+++ b/arm/p256/bignum_add_p256.S
@@ -5,8 +5,8 @@
 // Add modulo p_256, z := (x + y) mod p_256, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_bigendian_4.S
+++ b/arm/p256/bignum_bigendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from big-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_bigendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_bigendian_4(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_frombebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tobebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tobebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // The implementation works by loading in bytes and storing in words (i.e.
 // stylistically it is "frombebytes"); in the more common little-endian

--- a/arm/p256/bignum_cmul_p256.S
+++ b/arm/p256/bignum_cmul_p256.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256(uint64_t z[static 4], uint64_t c,
+//                                 const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_deamont_p256.S
+++ b/arm/p256/bignum_deamont_p256.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/arm/p256/bignum_demont_p256.S
+++ b/arm/p256/bignum_demont_p256.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p256" instead.

--- a/arm/p256/bignum_double_p256.S
+++ b/arm/p256/bignum_double_p256.S
@@ -5,8 +5,8 @@
 // Double modulo p_256, z := (2 * x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_half_p256.S
+++ b/arm/p256/bignum_half_p256.S
@@ -5,8 +5,7 @@
 // Halve modulo p_256, z := (x / 2) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_inv_p256.S
+++ b/arm/p256/bignum_inv_p256.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_256 = 2^256 - 2^224 + 2^192 + 2^96 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_p256(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_p256(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_256, i.e. is not divisible
 // by it, returns z < p_256 such that x * z == 1 (mod p_256). Note that

--- a/arm/p256/bignum_littleendian_4.S
+++ b/arm/p256/bignum_littleendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from little-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_littleendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_littleendian_4(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_fromlebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tolebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tolebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // The implementation works by loading in bytes and storing in words (i.e.
 // stylistically it is "fromlebytes"); in the more common little-endian

--- a/arm/p256/bignum_mod_n256.S
+++ b/arm/p256/bignum_mod_n256.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/arm/p256/bignum_mod_n256_4.S
+++ b/arm/p256/bignum_mod_n256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/arm/p256/bignum_mod_p256.S
+++ b/arm/p256/bignum_mod_p256.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_p256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_mod_p256_4.S
+++ b/arm/p256/bignum_mod_p256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_montinv_p256.S
+++ b/arm/p256/bignum_montinv_p256.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_256 = 2^256 - 2^224 + 2^192 + 2^96 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_montinv_p256(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_montinv_p256(uint64_t z[static 4],
+//                                 const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_256, i.e. is not divisible
 // by it, returns z < p_256 such that x * z == 2^512 (mod p_256). This

--- a/arm/p256/bignum_montmul_p256.S
+++ b/arm/p256/bignum_montmul_p256.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4],
+//                                    const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/arm/p256/bignum_montmul_p256_alt.S
+++ b/arm/p256/bignum_montmul_p256_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4],
+//                                        const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/arm/p256/bignum_montsqr_p256.S
+++ b/arm/p256/bignum_montsqr_p256.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/arm/p256/bignum_montsqr_p256_alt.S
+++ b/arm/p256/bignum_montsqr_p256_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/arm/p256/bignum_mux_4.S
+++ b/arm/p256/bignum_mux_4.S
@@ -5,9 +5,9 @@
 // 256-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[4], y[4]; output z[4]
 //
-//    extern void bignum_mux_4
-//     (uint64_t p, uint64_t z[static 4],
-//      uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mux_4(uint64_t p, uint64_t z[static 4],
+//                             const uint64_t x[static 4],
+//                             const uint64_t y[static 4]);
 //
 // It is assumed that all numbers x, y and z have the same size 4 digits.
 //

--- a/arm/p256/bignum_neg_p256.S
+++ b/arm/p256/bignum_neg_p256.S
@@ -5,7 +5,7 @@
 // Negate modulo p_256, z := (-x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_nonzero_4.S
+++ b/arm/p256/bignum_nonzero_4.S
@@ -5,7 +5,7 @@
 // 256-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[4]; output function return
 //
-//    extern uint64_t bignum_nonzero_4(uint64_t x[static 4]);
+//    extern uint64_t bignum_nonzero_4(const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_optneg_p256.S
+++ b/arm/p256/bignum_optneg_p256.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256(uint64_t z[static 4], uint64_t p,
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_sub_p256.S
+++ b/arm/p256/bignum_sub_p256.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256, z := (x - y) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_tomont_p256.S
+++ b/arm/p256/bignum_tomont_p256.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p256/bignum_triple_p256.S
+++ b/arm/p256/bignum_triple_p256.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_256,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_256.

--- a/arm/p256/p256_montjadd.S
+++ b/arm/p256/p256_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                              const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjadd_alt.S
+++ b/arm/p256/p256_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd_alt(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjdouble.S
+++ b/arm/p256/p256_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjdouble_alt.S
+++ b/arm/p256/p256_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjmixadd.S
+++ b/arm/p256/p256_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjmixadd_alt.S
+++ b/arm/p256/p256_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12],
+//                                     const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/arm/p256/p256_montjscalarmul.S
+++ b/arm/p256/p256_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_montjscalarmul
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version p256_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/p256/p256_montjscalarmul_alt.S
+++ b/arm/p256/p256_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_montjscalarmul_alt
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version p256_scalarmul_alt.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/p256/p256_scalarmul.S
+++ b/arm/p256/p256_scalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_scalarmul
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 8]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 8]);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, returns the point (X,Y) = n * P. The input and output

--- a/arm/p256/p256_scalarmul_alt.S
+++ b/arm/p256/p256_scalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_scalarmul_alt
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 8]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 8]);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, returns the point (X,Y) = n * P. The input and output

--- a/arm/p256/p256_scalarmulbase.S
+++ b/arm/p256/p256_scalarmulbase.S
@@ -7,9 +7,9 @@
 //
 // extern void p256_scalarmulbase
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
+//    const uint64_t scalar[static 4],
 //    uint64_t blocksize,
-//    uint64_t *table);
+//    const uint64_t *table);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, the input argument "table" is expected to be a table of

--- a/arm/p256/p256_scalarmulbase_alt.S
+++ b/arm/p256/p256_scalarmulbase_alt.S
@@ -7,9 +7,9 @@
 //
 // extern void p256_scalarmulbase_alt
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
+//    const uint64_t scalar[static 4],
 //    uint64_t blocksize,
-//    uint64_t *table);
+//    const uint64_t *table);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, the input argument "table" is expected to be a table of

--- a/arm/p384/bignum_add_p384.S
+++ b/arm/p384/bignum_add_p384.S
@@ -5,8 +5,8 @@
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_add_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_add_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_bigendian_6.S
+++ b/arm/p384/bignum_bigendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from big-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_bigendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_bigendian_6(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_frombebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tobebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tobebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // The implementation works by loading in bytes and storing in words (i.e.
 // stylistically it is "frombebytes"); in the more common little-endian

--- a/arm/p384/bignum_cmul_p384.S
+++ b/arm/p384/bignum_cmul_p384.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[6]; output z[6]
 //
-//    extern void bignum_cmul_p384
-//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//    extern void bignum_cmul_p384(uint64_t z[static 6], uint64_t c,
+//                                 const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_deamont_p384.S
+++ b/arm/p384/bignum_deamont_p384.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_deamont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_deamont_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 6-digit input will work, with no range restriction.

--- a/arm/p384/bignum_demont_p384.S
+++ b/arm/p384/bignum_demont_p384.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_demont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_demont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // This assumes the input is < p_384 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p384" instead.

--- a/arm/p384/bignum_double_p384.S
+++ b/arm/p384/bignum_double_p384.S
@@ -5,8 +5,8 @@
 // Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_double_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_double_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_half_p384.S
+++ b/arm/p384/bignum_half_p384.S
@@ -5,8 +5,7 @@
 // Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_half_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_half_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_inv_p384.S
+++ b/arm/p384/bignum_inv_p384.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_384 = 2^384 - 2^128 - 2^96 + 2^32 - 1
 // Input x[6]; output z[6]
 //
-// extern void bignum_inv_p384(uint64_t z[static 6],uint64_t x[static 6]);
+// extern void bignum_inv_p384(uint64_t z[static 6],const uint64_t x[static 6]);
 //
 // If the 6-digit input x is coprime to p_384, i.e. is not divisible
 // by it, returns z < p_384 such that x * z == 1 (mod p_384). Note that

--- a/arm/p384/bignum_littleendian_6.S
+++ b/arm/p384/bignum_littleendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from little-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_littleendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_littleendian_6(uint64_t z[static 6],
+//                                      const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_fromlebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tolebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tolebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // The implementation works by loading in bytes and storing in words (i.e.
 // stylistically it is "fromlebytes"); in the more common little-endian

--- a/arm/p384/bignum_mod_n384.S
+++ b/arm/p384/bignum_mod_n384.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_n384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/arm/p384/bignum_mod_n384_6.S
+++ b/arm/p384/bignum_mod_n384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_n384_6
-//      (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_n384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/arm/p384/bignum_mod_p384.S
+++ b/arm/p384/bignum_mod_p384.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_p384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_mod_p384_6.S
+++ b/arm/p384/bignum_mod_p384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_p384_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_p384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_montinv_p384.S
+++ b/arm/p384/bignum_montinv_p384.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_384 = 2^384 - 2^128 - 2^96 + 2^32 - 1
 // Input x[6]; output z[6]
 //
-// extern void bignum_montinv_p384(uint64_t z[static 6],uint64_t x[static 6]);
+// extern void bignum_montinv_p384(uint64_t z[static 6],
+//                                 const uint64_t x[static 6]);
 //
 // If the 6-digit input x is coprime to p_384, i.e. is not divisible
 // by it, returns z < p_384 such that x * z == 2^768 (mod p_384). This

--- a/arm/p384/bignum_montmul_p384.S
+++ b/arm/p384/bignum_montmul_p384.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/arm/p384/bignum_montmul_p384_alt.S
+++ b/arm/p384/bignum_montmul_p384_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6],
+//                                        const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/arm/p384/bignum_montsqr_p384.S
+++ b/arm/p384/bignum_montsqr_p384.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/arm/p384/bignum_montsqr_p384_alt.S
+++ b/arm/p384/bignum_montsqr_p384_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/arm/p384/bignum_mux_6.S
+++ b/arm/p384/bignum_mux_6.S
@@ -5,9 +5,9 @@
 // 384-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[6], y[6]; output z[6]
 //
-//    extern void bignum_mux_6
-//     (uint64_t p, uint64_t z[static 6],
-//      uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mux_6(uint64_t p, uint64_t z[static 6],
+//                             const uint64_t x[static 6],
+//                             const uint64_t y[static 6]);
 //
 // It is assumed that all numbers x, y and z have the same size 6 digits.
 //

--- a/arm/p384/bignum_neg_p384.S
+++ b/arm/p384/bignum_neg_p384.S
@@ -5,7 +5,7 @@
 // Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_neg_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_nonzero_6.S
+++ b/arm/p384/bignum_nonzero_6.S
@@ -5,7 +5,7 @@
 // 384-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[6]; output function return
 //
-//    extern uint64_t bignum_nonzero_6(uint64_t x[static 6]);
+//    extern uint64_t bignum_nonzero_6(const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = x, returns X0
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_optneg_p384.S
+++ b/arm/p384/bignum_optneg_p384.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[6]; output z[6]
 //
-//    extern void bignum_optneg_p384
-//      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+//    extern void bignum_optneg_p384(uint64_t z[static 6], uint64_t p,
+//                                   const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_sub_p384.S
+++ b/arm/p384/bignum_sub_p384.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_384, z := (x - y) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_sub_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_sub_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_tomont_p384.S
+++ b/arm/p384/bignum_tomont_p384.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_tomont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_tomont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p384/bignum_triple_p384.S
+++ b/arm/p384/bignum_triple_p384.S
@@ -5,8 +5,8 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_triple_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.

--- a/arm/p384/p384_montjadd.S
+++ b/arm/p384/p384_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd(uint64_t p3[static 18], const uint64_t p1[static 18],
+//                              const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjadd_alt.S
+++ b/arm/p384/p384_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd_alt(uint64_t p3[static 18],
+//                                  const uint64_t p1[static 18],
+//                                  const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjdouble.S
+++ b/arm/p384/p384_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjdouble_alt.S
+++ b/arm/p384/p384_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjmixadd.S
+++ b/arm/p384/p384_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjmixadd_alt.S
+++ b/arm/p384/p384_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18],
+//                                     const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/arm/p384/p384_montjscalarmul.S
+++ b/arm/p384/p384_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p384_montjscalarmul
 //   (uint64_t res[static 18],
-//    uint64_t scalar[static 6],
-//    uint64_t point[static 18]);
+//    const uint64_t scalar[static 6],
+//    const uint64_t point[static 18]);
 //
 // This function is a variant of its affine point version p384_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/p384/p384_montjscalarmul_alt.S
+++ b/arm/p384/p384_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p384_montjscalarmul_alt
 //   (uint64_t res[static 18],
-//    uint64_t scalar[static 6],
-//    uint64_t point[static 18]);
+//    const uint64_t scalar[static 6],
+//    const uint64_t point[static 18]);
 //
 // This function is a variant of its affine point version p384_scalarmul_alt.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/p521/bignum_add_p521.S
+++ b/arm/p521/bignum_add_p521.S
@@ -5,8 +5,8 @@
 // Add modulo p_521, z := (x + y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_add_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_add_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_cmul_p521.S
+++ b/arm/p521/bignum_cmul_p521.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[9]; output z[9]
 //
-//    extern void bignum_cmul_p521
-//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//    extern void bignum_cmul_p521(uint64_t z[static 9], uint64_t c,
+//                                 const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_deamont_p521.S
+++ b/arm/p521/bignum_deamont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_deamont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_deamont_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Convert a 9-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 9-digit input will work, with no range restriction.

--- a/arm/p521/bignum_demont_p521.S
+++ b/arm/p521/bignum_demont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_demont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_demont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // This assumes the input is < p_521 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p521" instead.

--- a/arm/p521/bignum_double_p521.S
+++ b/arm/p521/bignum_double_p521.S
@@ -5,8 +5,8 @@
 // Double modulo p_521, z := (2 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_double_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_double_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_fromlebytes_p521.S
+++ b/arm/p521/bignum_fromlebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert little-endian bytes to 9-digit 528-bit bignum
 //
-//    extern void bignum_fromlebytes_p521
-//     (uint64_t z[static 9],uint8_t x[static 66])
+//    extern void bignum_fromlebytes_p521(uint64_t z[static 9],
+//                                        const uint8_t x[static 66]);
 //
 // The result will be < 2^528 since it is translated from 66 bytes.
 // It is mainly intended for inputs x < p_521 < 2^521 < 2^528.

--- a/arm/p521/bignum_half_p521.S
+++ b/arm/p521/bignum_half_p521.S
@@ -5,8 +5,7 @@
 // Halve modulo p_521, z := (x / 2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_half_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_half_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_inv_p521.S
+++ b/arm/p521/bignum_inv_p521.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_521 =  2^521 - 1
 // Input x[9]; output z[9]
 //
-// extern void bignum_inv_p521(uint64_t z[static 9],uint64_t x[static 9]);
+// extern void bignum_inv_p521(uint64_t z[static 9],const uint64_t x[static 9]);
 //
 // Assuming the 9-digit input x is coprime to p_521, i.e. is not divisible
 // by it, returns z < p_521 such that x * z == 1 (mod p_521). Note that

--- a/arm/p521/bignum_mod_n521_9.S
+++ b/arm/p521/bignum_mod_n521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_n521_9
-//      (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_n521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Reduction is modulo the group order of the NIST curve P-521.
 //

--- a/arm/p521/bignum_mod_p521_9.S
+++ b/arm/p521/bignum_mod_p521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_p521_9
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_p521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_montmul_p521.S
+++ b/arm/p521/bignum_montmul_p521.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/arm/p521/bignum_montmul_p521_alt.S
+++ b/arm/p521/bignum_montmul_p521_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9],
+//                                        const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/arm/p521/bignum_montsqr_p521.S
+++ b/arm/p521/bignum_montsqr_p521.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/arm/p521/bignum_montsqr_p521_alt.S
+++ b/arm/p521/bignum_montsqr_p521_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/arm/p521/bignum_mul_p521.S
+++ b/arm/p521/bignum_mul_p521.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_mul_p521_alt.S
+++ b/arm/p521/bignum_mul_p521_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_neg_p521.S
+++ b/arm/p521/bignum_neg_p521.S
@@ -5,7 +5,7 @@
 // Negate modulo p_521, z := (-x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_neg_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_optneg_p521.S
+++ b/arm/p521/bignum_optneg_p521.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[9]; output z[9]
 //
-//    extern void bignum_optneg_p521
-//      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
+//    extern void bignum_optneg_p521(uint64_t z[static 9], uint64_t p,
+//                                   const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_sqr_p521.S
+++ b/arm/p521/bignum_sqr_p521.S
@@ -5,8 +5,7 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521 (uint64_t z[static 9],
-//                                      uint64_t x[static 9]);
+//    extern void bignum_sqr_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_sqr_p521_alt.S
+++ b/arm/p521/bignum_sqr_p521_alt.S
@@ -5,7 +5,8 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_sqr_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_sub_p521.S
+++ b/arm/p521/bignum_sub_p521.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_521, z := (x - y) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_sub_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_sub_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_tolebytes_p521.S
+++ b/arm/p521/bignum_tolebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert 9-digit 528-bit bignum to little-endian bytes
 //
-//    extern void bignum_tolebytes_p521
-//     (uint8_t z[static 66], uint64_t x[static 9]);
+//    extern void bignum_tolebytes_p521(uint8_t z[static 66],
+//                                      const uint64_t x[static 9]);
 //
 // This is assuming the input x is < 2^528 so that it fits in 66 bytes.
 // In particular this holds if x < p_521 < 2^521 < 2^528.

--- a/arm/p521/bignum_tomont_p521.S
+++ b/arm/p521/bignum_tomont_p521.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^576 * x) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_tomont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_tomont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/bignum_triple_p521.S
+++ b/arm/p521/bignum_triple_p521.S
@@ -5,8 +5,8 @@
 // Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_triple_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_triple_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/p521/p521_jadd.S
+++ b/arm/p521/p521_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                          const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jadd_alt.S
+++ b/arm/p521/p521_jadd_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd_alt(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                              const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jdouble.S
+++ b/arm/p521/p521_jdouble.S
@@ -4,8 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble(uint64_t p3[static 27], const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jdouble_alt.S
+++ b/arm/p521/p521_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jmixadd.S
+++ b/arm/p521/p521_jmixadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                             const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jmixadd_alt.S
+++ b/arm/p521/p521_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27],
+//                                 const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/p521/p521_jscalarmul.S
+++ b/arm/p521/p521_jscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p521_jscalarmul
 //   (uint64_t res[static 27],
-//    uint64_t scalar[static 9],
-//    uint64_t point[static 27]);
+//    const uint64_t scalar[static 9],
+//    const uint64_t point[static 27]);
 //
 // This function is a variant of its affine point version p521_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/p521/p521_jscalarmul_alt.S
+++ b/arm/p521/p521_jscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p521_jscalarmul_alt
 //   (uint64_t res[static 27],
-//    uint64_t scalar[static 9],
-//    uint64_t point[static 27]);
+//    const uint64_t scalar[static 9],
+//    const uint64_t point[static 27]);
 //
 // This function is a variant of its affine point version p521_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/secp256k1/bignum_add_p256k1.S
+++ b/arm/secp256k1/bignum_add_p256k1.S
@@ -5,8 +5,8 @@
 // Add modulo p_256k1, z := (x + y) mod p_256k1, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_cmul_p256k1.S
+++ b/arm/secp256k1/bignum_cmul_p256k1.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256k1
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256k1(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_deamont_p256k1.S
+++ b/arm/secp256k1/bignum_deamont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256k1,
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/arm/secp256k1/bignum_demont_p256k1.S
+++ b/arm/secp256k1/bignum_demont_p256k1.S
@@ -6,8 +6,8 @@
 // assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256k1 for correctness. If this is not the
 // case, use the variant "bignum_deamont_p256k1" instead.

--- a/arm/secp256k1/bignum_double_p256k1.S
+++ b/arm/secp256k1/bignum_double_p256k1.S
@@ -5,8 +5,8 @@
 // Double modulo p_256k1, z := (2 * x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_half_p256k1.S
+++ b/arm/secp256k1/bignum_half_p256k1.S
@@ -5,8 +5,8 @@
 // Halve modulo p_256k1, z := (x / 2) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256k1(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_mod_n256k1_4.S
+++ b/arm/secp256k1/bignum_mod_n256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the secp256k1 curve.
 //

--- a/arm/secp256k1/bignum_mod_p256k1_4.S
+++ b/arm/secp256k1/bignum_mod_p256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_montmul_p256k1.S
+++ b/arm/secp256k1/bignum_montmul_p256k1.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k1 (in particular this is true if we are in

--- a/arm/secp256k1/bignum_montmul_p256k1_alt.S
+++ b/arm/secp256k1/bignum_montmul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4],
+//                                          const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k1 (in particular this is true if we are in

--- a/arm/secp256k1/bignum_montsqr_p256k1.S
+++ b/arm/secp256k1/bignum_montsqr_p256k1.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/arm/secp256k1/bignum_montsqr_p256k1_alt.S
+++ b/arm/secp256k1/bignum_montsqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/arm/secp256k1/bignum_mul_p256k1.S
+++ b/arm/secp256k1/bignum_mul_p256k1.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_mul_p256k1_alt.S
+++ b/arm/secp256k1/bignum_mul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_neg_p256k1.S
+++ b/arm/secp256k1/bignum_neg_p256k1.S
@@ -5,8 +5,7 @@
 // Negate modulo p_256k1, z := (-x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_optneg_p256k1.S
+++ b/arm/secp256k1/bignum_optneg_p256k1.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256k1
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256k1(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_sqr_p256k1.S
+++ b/arm/secp256k1/bignum_sqr_p256k1.S
@@ -5,8 +5,7 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_sqr_p256k1_alt.S
+++ b/arm/secp256k1/bignum_sqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_sub_p256k1.S
+++ b/arm/secp256k1/bignum_sub_p256k1.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256k1, z := (x - y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_tomont_p256k1.S
+++ b/arm/secp256k1/bignum_tomont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/secp256k1/bignum_triple_p256k1.S
+++ b/arm/secp256k1/bignum_triple_p256k1.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256k1, z := (3 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256k1
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo
 // p_256k1, and the result is always fully reduced, z = (3 * x) mod p_256k1.

--- a/arm/secp256k1/secp256k1_jadd.S
+++ b/arm/secp256k1/secp256k1_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                               const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/secp256k1/secp256k1_jadd_alt.S
+++ b/arm/secp256k1/secp256k1_jadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd_alt(uint64_t p3[static 12],
+//                                   const uint64_t p1[static 12],
+//                                   const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/secp256k1/secp256k1_jdouble.S
+++ b/arm/secp256k1/secp256k1_jdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/secp256k1/secp256k1_jdouble_alt.S
+++ b/arm/secp256k1/secp256k1_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/secp256k1/secp256k1_jmixadd.S
+++ b/arm/secp256k1/secp256k1_jmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/secp256k1/secp256k1_jmixadd_alt.S
+++ b/arm/secp256k1/secp256k1_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12],
+//                                      const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/arm/sm2/bignum_add_sm2.S
+++ b/arm/sm2/bignum_add_sm2.S
@@ -5,8 +5,8 @@
 // Add modulo p_sm2, z := (x + y) mod p_sm2, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_cmul_sm2.S
+++ b/arm/sm2/bignum_cmul_sm2.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_sm2
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_sm2(uint64_t z[static 4], uint64_t c,
+//                                const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = c, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_deamont_sm2.S
+++ b/arm/sm2/bignum_deamont_sm2.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/arm/sm2/bignum_demont_sm2.S
+++ b/arm/sm2/bignum_demont_sm2.S
@@ -5,8 +5,7 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // This assumes the input is < p_sm2 for correctness. If this is not the case,
 // use the variant "bignum_deamont_sm2" instead.

--- a/arm/sm2/bignum_double_sm2.S
+++ b/arm/sm2/bignum_double_sm2.S
@@ -5,8 +5,7 @@
 // Double modulo p_sm2, z := (2 * x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_half_sm2.S
+++ b/arm/sm2/bignum_half_sm2.S
@@ -5,8 +5,7 @@
 // Halve modulo p_sm2, z := (x / 2) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_inv_sm2.S
+++ b/arm/sm2/bignum_inv_sm2.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_sm2 = 2^256 - 2^224 - 2^96 + 2^64 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_sm2(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_sm2(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_sm2, i.e. is not divisible
 // by it, returns z < p_sm2 such that x * z == 1 (mod p_sm2). Note that

--- a/arm/sm2/bignum_mod_nsm2.S
+++ b/arm/sm2/bignum_mod_nsm2.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_nsm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_nsm2(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/arm/sm2/bignum_mod_nsm2_4.S
+++ b/arm/sm2/bignum_mod_nsm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_nsm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_nsm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/arm/sm2/bignum_mod_sm2.S
+++ b/arm/sm2/bignum_mod_sm2.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_sm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_sm2(uint64_t z[static 4], uint64_t k, const uint64_t *x);
 //
 // Standard ARM ABI: X0 = z, X1 = k, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_mod_sm2_4.S
+++ b/arm/sm2/bignum_mod_sm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_sm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_sm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_montinv_sm2.S
+++ b/arm/sm2/bignum_montinv_sm2.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_sm2 = 2^256 - 2^224 - 2^96 + 2^64 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_montinv_sm2(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_montinv_sm2(uint64_t z[static 4],
+//                                const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_sm2, i.e. is not divisible
 // by it, returns z < p_sm2 such that x * z == 2^512 (mod p_sm2). This

--- a/arm/sm2/bignum_montmul_sm2.S
+++ b/arm/sm2/bignum_montmul_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/arm/sm2/bignum_montmul_sm2_alt.S
+++ b/arm/sm2/bignum_montmul_sm2_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/arm/sm2/bignum_montsqr_sm2.S
+++ b/arm/sm2/bignum_montsqr_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/arm/sm2/bignum_montsqr_sm2_alt.S
+++ b/arm/sm2/bignum_montsqr_sm2_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/arm/sm2/bignum_neg_sm2.S
+++ b/arm/sm2/bignum_neg_sm2.S
@@ -5,7 +5,7 @@
 // Negate modulo p_sm2, z := (-x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_sm2 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_optneg_sm2.S
+++ b/arm/sm2/bignum_optneg_sm2.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_sm2
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_sm2(uint64_t z[static 4], uint64_t p,
+//                                  const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = p, X2 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_sub_sm2.S
+++ b/arm/sm2/bignum_sub_sm2.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_sm2, z := (x - y) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x, X2 = y
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_tomont_sm2.S
+++ b/arm/sm2/bignum_tomont_sm2.S
@@ -5,8 +5,7 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard ARM ABI: X0 = z, X1 = x
 // ----------------------------------------------------------------------------

--- a/arm/sm2/bignum_triple_sm2.S
+++ b/arm/sm2/bignum_triple_sm2.S
@@ -5,8 +5,7 @@
 // Triple modulo p_sm2, z := (3 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_sm2
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_sm2,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjadd.S
+++ b/arm/sm2/sm2_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                             const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjadd_alt.S
+++ b/arm/sm2/sm2_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd_alt(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjdouble.S
+++ b/arm/sm2/sm2_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjdouble_alt.S
+++ b/arm/sm2/sm2_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjmixadd.S
+++ b/arm/sm2/sm2_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12],
+//                                const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjmixadd_alt.S
+++ b/arm/sm2/sm2_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12],
+//                                    const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/arm/sm2/sm2_montjscalarmul.S
+++ b/arm/sm2/sm2_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void sm2_montjscalarmul
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version sm2_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/arm/sm2/sm2_montjscalarmul_alt.S
+++ b/arm/sm2/sm2_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void sm2_montjscalarmul_alt
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version sm2_scalarmul_alt.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/curve25519/bignum_add_p25519.S
+++ b/x86/curve25519/bignum_add_p25519.S
@@ -5,8 +5,8 @@
 // Add modulo p_25519, z := (x + y) mod p_25519, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/curve25519/bignum_cmul_p25519.S
+++ b/x86/curve25519/bignum_cmul_p25519.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p25519
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p25519(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/curve25519/bignum_cmul_p25519_alt.S
+++ b/x86/curve25519/bignum_cmul_p25519_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p25519_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p25519_alt(uint64_t z[static 4], uint64_t c,
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/curve25519/bignum_double_p25519.S
+++ b/x86/curve25519/bignum_double_p25519.S
@@ -5,8 +5,8 @@
 // Double modulo p_25519, z := (2 * x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p25519(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/curve25519/bignum_inv_p25519.S
+++ b/x86/curve25519/bignum_inv_p25519.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_25519 = 2^255 - 19
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_p25519(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // Assuming the 4-digit input x is coprime to p_25519, i.e. is not divisible
 // by it, returns z < p_25519 such that x * z == 1 (mod p_25519). The input

--- a/x86/curve25519/bignum_invsqrt_p25519.S
+++ b/x86/curve25519/bignum_invsqrt_p25519.S
@@ -5,7 +5,8 @@
 // Inverse square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_invsqrt_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_invsqrt_p25519(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular inverse square root mod p_25519,
 // i.e. a z such that x * z^2 == 1 (mod p_25519), whenever one exists. The

--- a/x86/curve25519/bignum_invsqrt_p25519_alt.S
+++ b/x86/curve25519/bignum_invsqrt_p25519_alt.S
@@ -5,7 +5,8 @@
 // Inverse square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_invsqrt_p25519_alt(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_invsqrt_p25519_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular inverse square root mod p_25519,
 // i.e. a z such that x * z^2 == 1 (mod p_25519), whenever one exists. The

--- a/x86/curve25519/bignum_madd_n25519.S
+++ b/x86/curve25519/bignum_madd_n25519.S
@@ -5,9 +5,9 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4],
+//                                   const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/x86/curve25519/bignum_madd_n25519_alt.S
+++ b/x86/curve25519/bignum_madd_n25519_alt.S
@@ -5,9 +5,10 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4],
+//                                       const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/x86/curve25519/bignum_mod_m25519_4.S
+++ b/x86/curve25519/bignum_mod_m25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod m_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_m25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_m25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of curve25519/edwards25519.
 // This is the full group order, 8 * the standard basepoint order.

--- a/x86/curve25519/bignum_mod_n25519.S
+++ b/x86/curve25519/bignum_mod_n25519.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n25519
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n25519(uint64_t z[static 4], uint64_t k,
+//                                  const uint64_t *x);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint,
 // which is n_25519 = 2^252 + 27742317777372353535851937790883648493

--- a/x86/curve25519/bignum_mod_n25519_4.S
+++ b/x86/curve25519/bignum_mod_n25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint.
 //

--- a/x86/curve25519/bignum_mod_p25519_4.S
+++ b/x86/curve25519/bignum_mod_p25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/curve25519/bignum_mul_p25519.S
+++ b/x86/curve25519/bignum_mul_p25519.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/curve25519/bignum_mul_p25519_alt.S
+++ b/x86/curve25519/bignum_mul_p25519_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/curve25519/bignum_neg_p25519.S
+++ b/x86/curve25519/bignum_neg_p25519.S
@@ -5,8 +5,7 @@
 // Negate modulo p_25519, z := (-x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/curve25519/bignum_optneg_p25519.S
+++ b/x86/curve25519/bignum_optneg_p25519.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p25519
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p25519(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/curve25519/bignum_sqr_p25519.S
+++ b/x86/curve25519/bignum_sqr_p25519.S
@@ -5,8 +5,7 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/curve25519/bignum_sqr_p25519_alt.S
+++ b/x86/curve25519/bignum_sqr_p25519_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/curve25519/bignum_sqrt_p25519.S
+++ b/x86/curve25519/bignum_sqrt_p25519.S
@@ -5,7 +5,8 @@
 // Square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_sqrt_p25519(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_sqrt_p25519(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular square root mod p_25519, i.e.
 // a z such that z^2 == x (mod p_25519), whenever one exists. The square

--- a/x86/curve25519/bignum_sqrt_p25519_alt.S
+++ b/x86/curve25519/bignum_sqrt_p25519_alt.S
@@ -5,7 +5,8 @@
 // Square root modulo p_25519 = 2^255 - 19
 // Input x[4]; output function return (Legendre symbol) and z[4]
 //
-// extern int64_t bignum_sqrt_p25519_alt(uint64_t z[static 4],uint64_t x[static 4]);
+// extern int64_t bignum_sqrt_p25519_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Given a 4-digit input x, returns a modular square root mod p_25519, i.e.
 // a z such that z^2 == x (mod p_25519), whenever one exists. The square

--- a/x86/curve25519/bignum_sub_p25519.S
+++ b/x86/curve25519/bignum_sub_p25519.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_25519, z := (x - y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/curve25519/curve25519_ladderstep.S
+++ b/x86/curve25519/curve25519_ladderstep.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint64_t rr[16],const uint64_t point[8],const uint64_t pp[16],uint64_t b);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86/curve25519/curve25519_ladderstep_alt.S
+++ b/x86/curve25519/curve25519_ladderstep_alt.S
@@ -5,7 +5,7 @@
 // Montgomery ladder step on pairs of (X,Z)-projective curve25519 points
 //
 // extern void curve25519_ladderstep_alt
-//   (uint64_t rr[16],uint64_t point[8],uint64_t pp[16],uint64_t b)
+//   (uint64_t rr[16],const uint64_t point[8],const uint64_t pp[16],uint64_t b);
 //
 // If point = (X,1) and pp = (n * (X,1),[n+1] * (X,1)) then the output
 // rr = (n' * (X,1),[n'+1] * (X,1)) where n' = 2 * n + b, with input

--- a/x86/curve25519/curve25519_pxscalarmul.S
+++ b/x86/curve25519/curve25519_pxscalarmul.S
@@ -6,7 +6,8 @@
 // Inputs scalar[4], point[4]; output res[8]
 //
 // extern void curve25519_pxscalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86/curve25519/curve25519_pxscalarmul_alt.S
+++ b/x86/curve25519/curve25519_pxscalarmul_alt.S
@@ -6,7 +6,8 @@
 // Inputs scalar[4], point[4]; output res[8]
 //
 // extern void curve25519_pxscalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // Given the X coordinate of an input point = (X,Y) on curve25519, which
 // could also be part of a projective representation (X,Y,1) of the same

--- a/x86/curve25519/curve25519_x25519.S
+++ b/x86/curve25519/curve25519_x25519.S
@@ -6,14 +6,16 @@
 // Inputs scalar[4], point[4]; output res[4]
 //
 // extern void curve25519_x25519
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 4],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // The function has a second prototype considering the arguments as arrays
 // of bytes rather than 64-bit words. The underlying code is the same, since
 // the x86 platform is little-endian.
 //
 // extern void curve25519_x25519_byte
-//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32],
+//    const uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86/curve25519/curve25519_x25519_alt.S
+++ b/x86/curve25519/curve25519_x25519_alt.S
@@ -6,14 +6,16 @@
 // Inputs scalar[4], point[4]; output res[4]
 //
 // extern void curve25519_x25519_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4],uint64_t point[static 4])
+//   (uint64_t res[static 4],const uint64_t scalar[static 4],
+//    const uint64_t point[static 4]);
 //
 // The function has a second prototype considering the arguments as arrays
 // of bytes rather than 64-bit words. The underlying code is the same, since
 // the x86 platform is little-endian.
 //
 // extern void curve25519_x25519_byte_alt
-//   (uint8_t res[static 32],uint8_t scalar[static 32],uint8_t point[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32],
+//    const uint8_t point[static 32]);
 //
 // Given a scalar n and the X coordinate of an input point P = (X,Y) on
 // curve25519 (Y can live in any extension field of characteristic 2^255-19),

--- a/x86/curve25519/curve25519_x25519base.S
+++ b/x86/curve25519/curve25519_x25519base.S
@@ -6,14 +6,14 @@
 // Input scalar[4]; output res[4]
 //
 // extern void curve25519_x25519base
-//   (uint64_t res[static 4],uint64_t scalar[static 4])
+//   (uint64_t res[static 4], const uint64_t scalar[static 4]);
 //
 // The function has a second prototype considering the arguments as arrays
 // of bytes rather than 64-bit words. The underlying code is the same, since
 // the x86 platform is little-endian.
 //
 // extern void curve25519_x25519base_byte
-//   (uint8_t res[static 32],uint8_t scalar[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86/curve25519/curve25519_x25519base_alt.S
+++ b/x86/curve25519/curve25519_x25519base_alt.S
@@ -6,14 +6,14 @@
 // Input scalar[4]; output res[4]
 //
 // extern void curve25519_x25519base_alt
-//   (uint64_t res[static 4],uint64_t scalar[static 4]);
+//   (uint64_t res[static 4],const uint64_t scalar[static 4]);
 //
 // The function has a second prototype considering the arguments as arrays
 // of bytes rather than 64-bit words. The underlying code is the same, since
 // the x86 platform is little-endian.
 //
 // extern void curve25519_x25519base_byte_alt
-//   (uint8_t res[static 32],uint8_t scalar[static 32])
+//   (uint8_t res[static 32],const uint8_t scalar[static 32]);
 //
 // Given a scalar n, returns the X coordinate of n * G where G = (9,...) is
 // the standard generator. The scalar is first slightly modified/mangled

--- a/x86/curve25519/edwards25519_encode.S
+++ b/x86/curve25519/edwards25519_encode.S
@@ -5,8 +5,8 @@
 // Encode edwards25519 point into compressed form as 256-bit number
 // Input p[8]; output z[32] (bytes)
 //
-//    extern void edwards25519_encode
-//     (uint8_t z[static 32], uint64_t p[static 8]);
+//    extern void edwards25519_encode(uint8_t z[static 32],
+//                                    const uint64_t p[static 8]);
 //
 // This assumes that the input buffer p points to a pair of 256-bit
 // numbers x (at p) and y (at p+4) representing a point (x,y) on the

--- a/x86/curve25519/edwards25519_epadd.S
+++ b/x86/curve25519/edwards25519_epadd.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[16]; output p3[16]
 //
 // extern void edwards25519_epadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 16]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86/curve25519/edwards25519_epadd_alt.S
+++ b/x86/curve25519/edwards25519_epadd_alt.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[16]; output p3[16]
 //
 // extern void edwards25519_epadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 16])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 16]);
 //
 // The output p3 and both inputs p1 and p2 are points (x,y) on
 // edwards25519 represented in extended projective quadruples (X,Y,Z,T)

--- a/x86/curve25519/edwards25519_epdouble.S
+++ b/x86/curve25519/edwards25519_epdouble.S
@@ -6,7 +6,7 @@
 // Input p1[12]; output p3[16]
 //
 // extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86/curve25519/edwards25519_epdouble_alt.S
+++ b/x86/curve25519/edwards25519_epdouble_alt.S
@@ -5,8 +5,8 @@
 // Extended projective doubling for edwards25519
 // Input p1[12]; output p3[16]
 //
-// extern void edwards25519_epdouble
-//   (uint64_t p3[static 16],uint64_t p1[static 12])
+// extern void edwards25519_epdouble_alt
+//   (uint64_t p3[static 16],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // The output p3 is in extended projective coordinates, representing

--- a/x86/curve25519/edwards25519_pdouble.S
+++ b/x86/curve25519/edwards25519_pdouble.S
@@ -6,7 +6,7 @@
 // Input p1[12]; output p3[12]
 //
 // extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+//   (uint64_t p3[static 12],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86/curve25519/edwards25519_pdouble_alt.S
+++ b/x86/curve25519/edwards25519_pdouble_alt.S
@@ -5,8 +5,8 @@
 // Projective doubling for edwards25519
 // Input p1[12]; output p3[12]
 //
-// extern void edwards25519_pdouble
-//   (uint64_t p3[static 12],uint64_t p1[static 12])
+// extern void edwards25519_pdouble_alt
+//   (uint64_t p3[static 12],const uint64_t p1[static 12]);
 //
 // If p1 is a point on edwards25519, returns its double p3 = 2 * p1.
 // Input and output are in pure projective coordinates, representing

--- a/x86/curve25519/edwards25519_pepadd.S
+++ b/x86/curve25519/edwards25519_pepadd.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[12]; output p3[16]
 //
 // extern void edwards25519_pepadd
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 12]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/x86/curve25519/edwards25519_pepadd_alt.S
+++ b/x86/curve25519/edwards25519_pepadd_alt.S
@@ -6,7 +6,8 @@
 // Inputs p1[16], p2[12]; output p3[16]
 //
 // extern void edwards25519_pepadd_alt
-//   (uint64_t p3[static 16],uint64_t p1[static 16],uint64_t p2[static 12])
+//   (uint64_t p3[static 16],const uint64_t p1[static 16],
+//    const uint64_t p2[static 12]);
 //
 // The output p3 and the first input p1 are points (x,y) on edwards25519
 // represented in extended projective quadruples (X,Y,Z,T) where

--- a/x86/curve25519/edwards25519_scalarmulbase.S
+++ b/x86/curve25519/edwards25519_scalarmulbase.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmulbase
-//   (uint64_t res[static 8],uint64_t scalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns point (X,Y) = n * B where B = (...,4/5) is
 // the standard basepoint for the edwards25519 (Ed25519) curve.

--- a/x86/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/x86/curve25519/edwards25519_scalarmulbase_alt.S
@@ -6,7 +6,7 @@
 // Input scalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmulbase_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4]);
 //
 // Given a scalar n, returns point (X,Y) = n * B where B = (...,4/5) is
 // the standard basepoint for the edwards25519 (Ed25519) curve.

--- a/x86/curve25519/edwards25519_scalarmuldouble.S
+++ b/x86/curve25519/edwards25519_scalarmuldouble.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8], bscalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmuldouble
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//    uint64_t point[static 8],uint64_t bscalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 8],const uint64_t bscalar[static 4]);
 //
 // Given scalar = n, point = P and bscalar = m, returns in res
 // the point (X,Y) = n * P + m * B where B = (...,4/5) is

--- a/x86/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/x86/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8], bscalar[4]; output res[8]
 //
 // extern void edwards25519_scalarmuldouble_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//    uint64_t point[static 8],uint64_t bscalar[static 4]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//    const uint64_t point[static 8],const uint64_t bscalar[static 4]);
 //
 // Given scalar = n, point = P and bscalar = m, returns in res
 // the point (X,Y) = n * P + m * B where B = (...,4/5) is

--- a/x86/fastmul/bignum_emontredc_8n.S
+++ b/x86/fastmul/bignum_emontredc_8n.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce in 8-digit blocks, results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc_8n
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc_8n(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                        uint64_t w);
 //
 // Functionally equivalent to bignum_emontredc (see that file for more detail).
 // But in general assumes that the input k is a multiple of 8.

--- a/x86/fastmul/bignum_kmul_16_32.S
+++ b/x86/fastmul/bignum_kmul_16_32.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[16], y[16]; output z[32]; temporary buffer t[>=32]
 //
-//    extern void bignum_kmul_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t y[static 16],
-//      uint64_t t[static 32])
+//    extern void bignum_kmul_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  const uint64_t y[static 16],
+//                                  uint64_t t[static 32]);
 //
 // In this x86 code the final temporary space argument t is unused, but
 // it is retained in the prototype above for API consistency with ARM.

--- a/x86/fastmul/bignum_kmul_32_64.S
+++ b/x86/fastmul/bignum_kmul_32_64.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[32], y[32]; output z[64]; temporary buffer t[>=96]
 //
-//    extern void bignum_kmul_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t y[static 32],
-//      uint64_t t[static 96])
+//    extern void bignum_kmul_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  const uint64_t y[static 32],
+//                                  uint64_t t[static 96]);
 //
 // This is a Karatsuba-style function multiplying half-sized results
 // internally and using temporary buffer t for intermediate results. The size

--- a/x86/fastmul/bignum_ksqr_16_32.S
+++ b/x86/fastmul/bignum_ksqr_16_32.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[16]; output z[32]; temporary buffer t[>=24]
 //
-//    extern void bignum_ksqr_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t t[static 24]);
+//    extern void bignum_ksqr_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  uint64_t t[static 24]);
 //
 // In this x86 code the final temporary space argument t is unused, but
 // it is retained in the prototype above for API consistency with ARM.

--- a/x86/fastmul/bignum_ksqr_32_64.S
+++ b/x86/fastmul/bignum_ksqr_32_64.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[32]; output z[64]; temporary buffer t[>=72]
 //
-//    extern void bignum_ksqr_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t t[static 72]);
+//    extern void bignum_ksqr_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  uint64_t t[static 72]);
 //
 // This is a Karatsuba-style function squaring half-sized results
 // and using temporary buffer t for intermediate results. The size of 72

--- a/x86/fastmul/bignum_mul_4_8.S
+++ b/x86/fastmul/bignum_mul_4_8.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8(uint64_t z[static 8], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_mul_4_8_alt.S
+++ b/x86/fastmul/bignum_mul_4_8_alt.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8_alt
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8_alt(uint64_t z[static 8], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_mul_6_12.S
+++ b/x86/fastmul/bignum_mul_6_12.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12(uint64_t z[static 12], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_mul_6_12_alt.S
+++ b/x86/fastmul/bignum_mul_6_12_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12_alt
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_mul_8_16.S
+++ b/x86/fastmul/bignum_mul_8_16.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16(uint64_t z[static 16], const uint64_t x[static 8],
+//                                const uint64_t y[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_mul_8_16_alt.S
+++ b/x86/fastmul/bignum_mul_8_16_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16_alt
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8],
+//                                    const uint64_t y[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/fastmul/bignum_sqr_4_8.S
+++ b/x86/fastmul/bignum_sqr_4_8.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8 (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8(uint64_t z[static 8], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/fastmul/bignum_sqr_4_8_alt.S
+++ b/x86/fastmul/bignum_sqr_4_8_alt.S
@@ -5,8 +5,8 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8_alt
-//      (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8_alt(uint64_t z[static 8],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/fastmul/bignum_sqr_6_12.S
+++ b/x86/fastmul/bignum_sqr_6_12.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12 (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12(uint64_t z[static 12], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/fastmul/bignum_sqr_6_12_alt.S
+++ b/x86/fastmul/bignum_sqr_6_12_alt.S
@@ -5,7 +5,8 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12_alt (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/fastmul/bignum_sqr_8_16.S
+++ b/x86/fastmul/bignum_sqr_8_16.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16 (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16(uint64_t z[static 16], const uint64_t x[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/fastmul/bignum_sqr_8_16_alt.S
+++ b/x86/fastmul/bignum_sqr_8_16_alt.S
@@ -5,7 +5,8 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16_alt (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/generic/bignum_add.S
+++ b/x86/generic/bignum_add.S
@@ -5,9 +5,8 @@
 // Add, z := x + y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_add
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_add(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x + y operation, truncating modulo p words in general and
 // returning a top carry (0 or 1) in the p'th place, only adding the input

--- a/x86/generic/bignum_amontifier.S
+++ b/x86/generic/bignum_amontifier.S
@@ -5,8 +5,8 @@
 // Compute "amontification" constant z :== 2^{128k} (congruent mod m)
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_amontifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_amontifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                  uint64_t *t);
 //
 // This is called "amontifier" because any other value x can now be mapped into
 // the almost-Montgomery domain with an almost-Montgomery multiplication by z.

--- a/x86/generic/bignum_amontmul.S
+++ b/x86/generic/bignum_amontmul.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery multiply, z :== (x * y / 2^{64k}) (congruent mod m)
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_amontmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_amontmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *y, const uint64_t *m);
 //
 // Does z :== (x * y / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/x86/generic/bignum_amontredc.S
+++ b/x86/generic/bignum_amontredc.S
@@ -5,9 +5,8 @@
 // Almost-Montgomery reduce, z :== (x' / 2^{64p}) (congruent mod m)
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_amontredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_amontredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                 const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a :== (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x. That is, p-fold almost-Montgomery reduction

--- a/x86/generic/bignum_amontsqr.S
+++ b/x86/generic/bignum_amontsqr.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery square, z :== (x^2 / 2^{64k}) (congruent mod m)
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_amontsqr
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_amontsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *m);
 //
 // Does z :== (x^2 / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/x86/generic/bignum_bitfield.S
+++ b/x86/generic/bignum_bitfield.S
@@ -5,8 +5,8 @@
 // Select bitfield starting at bit n with length l <= 64
 // Inputs x[k], n, l; output function return
 //
-//    extern uint64_t bignum_bitfield
-//     (uint64_t k, uint64_t *x, uint64_t n, uint64_t l);
+//    extern uint64_t bignum_bitfield(uint64_t k, const uint64_t *x, uint64_t n,
+//                                    uint64_t l);
 //
 // One-word bitfield from a k-digit (digit=64 bits) bignum, in constant-time
 // style. Bitfield starts at bit n and has length l, indexing from 0 (=LSB).

--- a/x86/generic/bignum_bitsize.S
+++ b/x86/generic/bignum_bitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_bitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_bitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/x86/generic/bignum_cdiv.S
+++ b/x86/generic/bignum_cdiv.S
@@ -5,8 +5,8 @@
 // Divide by a single (nonzero) word, z := x / m and return x mod m
 // Inputs x[n], m; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_cdiv
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cdiv(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits, result z is k.
 // Truncates the quotient in general, but always (for nonzero m) returns

--- a/x86/generic/bignum_cdiv_exact.S
+++ b/x86/generic/bignum_cdiv_exact.S
@@ -5,8 +5,8 @@
 // Divide by a single word, z := x / m *when known to be exact*
 // Inputs x[n], m; output z[k]
 //
-//    extern void bignum_cdiv_exact
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern void bignum_cdiv_exact(uint64_t k, uint64_t *z, uint64_t n,
+//                                  const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits and result z is k,
 // *assuming* that m is nonzero and that the input x is in fact an

--- a/x86/generic/bignum_cld.S
+++ b/x86/generic/bignum_cld.S
@@ -5,7 +5,7 @@
 // Count leading zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_cld (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_cld(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/x86/generic/bignum_clz.S
+++ b/x86/generic/bignum_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_clz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_clz(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 64 * k
 //

--- a/x86/generic/bignum_cmadd.S
+++ b/x86/generic/bignum_cmadd.S
@@ -5,8 +5,8 @@
 // Multiply-add with single-word multiplier, z := z + c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                 const uint64_t *y);
 //
 // Does the "z := z + c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/x86/generic/bignum_cmnegadd.S
+++ b/x86/generic/bignum_cmnegadd.S
@@ -5,8 +5,8 @@
 // Negated multiply-add with single-word multiplier, z := z - c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmnegadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmnegadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                    const uint64_t *y);
 //
 // Does the "z := z - c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/x86/generic/bignum_cmod.S
+++ b/x86/generic/bignum_cmod.S
@@ -5,7 +5,7 @@
 // Find bignum modulo a single word
 // Input x[k], m; output function return
 //
-//    extern uint64_t bignum_cmod (uint64_t k, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cmod(uint64_t k, const uint64_t *x, uint64_t m);
 //
 // Returns x mod m, assuming m is nonzero.
 //

--- a/x86/generic/bignum_cmul.S
+++ b/x86/generic/bignum_cmul.S
@@ -5,8 +5,8 @@
 // Multiply by a single word, z := c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmul
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmul(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                const uint64_t *y);
 //
 // Does the "z := c * y" operation where y is n digits, result z is p.
 // Truncates the result in general unless p >= n + 1.

--- a/x86/generic/bignum_coprime.S
+++ b/x86/generic/bignum_coprime.S
@@ -5,8 +5,8 @@
 // Test bignums for coprimality, gcd(x,y) = 1
 // Inputs x[m], y[n]; output function return; temporary buffer t[>=2*max(m,n)]
 //
-//    extern uint64_t bignum_coprime
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y, uint64_t *t);
+//    extern uint64_t bignum_coprime(uint64_t m, const uint64_t *x, uint64_t n,
+//                                   const uint64_t *y, uint64_t *t);
 //
 // Test for whether two bignums are coprime (no common factor besides 1).
 // This is equivalent to testing if their gcd is 1, but a bit faster than

--- a/x86/generic/bignum_copy.S
+++ b/x86/generic/bignum_copy.S
@@ -5,8 +5,7 @@
 // Copy bignum with zero-extension or truncation, z := x
 // Input x[n]; output z[k]
 //
-//    extern void bignum_copy
-//      (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_copy(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = n, RCX = x
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = n, R9 = x

--- a/x86/generic/bignum_copy_row_from_table.S
+++ b/x86/generic/bignum_copy_row_from_table.S
@@ -6,8 +6,8 @@
 // Given table: uint64_t[height*width], copy table[idx*width...(idx+1)*width-1]
 // into z[0..width-1].
 //
-//    extern void bignum_copy_from_table
-//     (uint64_t *z, uint64_t *table, uint64_t height, uint64_t width,
+//    extern void bignum_copy_row_from_table
+//     (uint64_t *z, const uint64_t *table, uint64_t height, uint64_t width,
 //      uint64_t idx);
 //
 // Standard x86-64 ABI: RDI = z, RSI = table, RDX = height, RCX = width,

--- a/x86/generic/bignum_ctd.S
+++ b/x86/generic/bignum_ctd.S
@@ -5,7 +5,7 @@
 // Count trailing zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctd(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/x86/generic/bignum_ctz.S
+++ b/x86/generic/bignum_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctz(uint64_t k, const uint64_t *x);
 //
 //
 // In the case of a zero bignum as input the result is 64 * k

--- a/x86/generic/bignum_demont.S
+++ b/x86/generic/bignum_demont.S
@@ -5,8 +5,8 @@
 // Convert from (almost-)Montgomery form z := (x / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_demont
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_demont(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *m);
 //
 // Does z := (x / 2^{64k}) mod m, hence mapping out of Montgomery domain.
 // In other words, this is a k-fold Montgomery reduction with same-size input.

--- a/x86/generic/bignum_digit.S
+++ b/x86/generic/bignum_digit.S
@@ -5,7 +5,7 @@
 // Select digit x[n]
 // Inputs x[k], n; output function return
 //
-//    extern uint64_t bignum_digit (uint64_t k, uint64_t *x, uint64_t n);
+//    extern uint64_t bignum_digit(uint64_t k, const uint64_t *x, uint64_t n);
 //
 // n'th digit of a k-digit (digit=64 bits) bignum, in constant-time style.
 // Indexing starts at 0, which is the least significant digit (little-endian).

--- a/x86/generic/bignum_digitsize.S
+++ b/x86/generic/bignum_digitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in digits (64-bit word)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_digitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_digitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/x86/generic/bignum_divmod10.S
+++ b/x86/generic/bignum_divmod10.S
@@ -5,7 +5,7 @@
 // Divide bignum by 10: z' := z div 10, returning remainder z mod 10
 // Inputs z[k]; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_divmod10 (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_divmod10(uint64_t k, uint64_t *z);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = z, returns RAX

--- a/x86/generic/bignum_emontredc.S
+++ b/x86/generic/bignum_emontredc.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce, returning results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                     uint64_t w);
 //
 // Assumes that z initially holds a 2k-digit bignum z_0, m is a k-digit odd
 // bignum and m * w == -1 (mod 2^64). This function also uses z for the output

--- a/x86/generic/bignum_eq.S
+++ b/x86/generic/bignum_eq.S
@@ -5,8 +5,8 @@
 // Test bignums for equality, x = y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_eq
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_eq(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86/generic/bignum_even.S
+++ b/x86/generic/bignum_even.S
@@ -5,7 +5,7 @@
 // Test bignum for even-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_even (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_even(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86/generic/bignum_ge.S
+++ b/x86/generic/bignum_ge.S
@@ -5,8 +5,8 @@
 // Compare bignums, x >= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_ge
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_ge(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86/generic/bignum_gt.S
+++ b/x86/generic/bignum_gt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x > y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_gt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_gt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86/generic/bignum_iszero.S
+++ b/x86/generic/bignum_iszero.S
@@ -5,7 +5,7 @@
 // Test bignum for zero-ness, x = 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_iszero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_iszero(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86/generic/bignum_le.S
+++ b/x86/generic/bignum_le.S
@@ -5,8 +5,8 @@
 // Compare bignums, x <= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_le
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_le(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86/generic/bignum_lt.S
+++ b/x86/generic/bignum_lt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x < y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_lt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_lt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86/generic/bignum_madd.S
+++ b/x86/generic/bignum_madd.S
@@ -5,9 +5,8 @@
 // Multiply-add, z := z + x * y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_madd
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_madd(uint64_t k, uint64_t *z, uint64_t m,
+//                                const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y + z" operation, while also returning a "next" or
 // "carry" word. In the case where m + n <= p (i.e. the pure product would

--- a/x86/generic/bignum_modadd.S
+++ b/x86/generic/bignum_modadd.S
@@ -5,8 +5,8 @@
 // Add modulo m, z := (x + y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = y, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = y, [RSP+40] = m

--- a/x86/generic/bignum_moddouble.S
+++ b/x86/generic/bignum_moddouble.S
@@ -5,8 +5,8 @@
 // Double modulo m, z := (2 * x) mod m, assuming x reduced
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_moddouble
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_moddouble(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                 const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = m

--- a/x86/generic/bignum_modexp.S
+++ b/x86/generic/bignum_modexp.S
@@ -6,7 +6,8 @@
 // Inputs a[k], p[k], m[k]; output z[k], temporary buffer t[>=3*k]
 //
 //   extern void bignum_modexp
-//    (uint64_t k,uint64_t *z, uint64_t *a,uint64_t *p,uint64_t *m,uint64_t *t);
+//    (uint64_t k,uint64_t *z, const uint64_t *a,const uint64_t *p,
+//     const uint64_t *m,uint64_t *t);
 //
 // Does z := (a^p) mod m where all numbers are k-digit and m is odd
 //

--- a/x86/generic/bignum_modifier.S
+++ b/x86/generic/bignum_modifier.S
@@ -5,8 +5,8 @@
 // Compute "modification" constant z := 2^{64k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_modifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_modifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "mod-ifier" because given any other k-digit number x we can

--- a/x86/generic/bignum_modinv.S
+++ b/x86/generic/bignum_modinv.S
@@ -5,8 +5,8 @@
 // Invert modulo m, z = (1/a) mod b, assuming b is an odd number > 1, coprime a
 // Inputs a[k], b[k]; output z[k]; temporary buffer t[>=3*k]
 //
-//    extern void bignum_modinv
-//     (uint64_t k, uint64_t *z, uint64_t *a, uint64_t *b, uint64_t *t);
+//    extern void bignum_modinv(uint64_t k, uint64_t *z, const uint64_t *a,
+//                              const uint64_t *b, uint64_t *t);
 //
 // k-digit (digit=64 bits) "z := a^-1 mod b" (modular inverse of a modulo b)
 // using t as a temporary buffer (t at least 3*k words = 24*k bytes), and

--- a/x86/generic/bignum_modoptneg.S
+++ b/x86/generic/bignum_modoptneg.S
@@ -6,8 +6,8 @@
 // (if p zero), assuming x reduced
 // Inputs p, x[k], m[k]; output z[k]
 //
-//    extern void bignum_modoptneg
-//      (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x, uint64_t *m);
+//    extern void bignum_modoptneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                 const uint64_t *x, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = p, RCX = x, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = p, R9 = x, [RSP+40] = m

--- a/x86/generic/bignum_modsub.S
+++ b/x86/generic/bignum_modsub.S
@@ -5,8 +5,8 @@
 // Subtract modulo m, z := (x - y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = y, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = y, [RSP+40] = m

--- a/x86/generic/bignum_montifier.S
+++ b/x86/generic/bignum_montifier.S
@@ -5,8 +5,8 @@
 // Compute "montification" constant z := 2^{128k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_montifier
-//      (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_montifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                 uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "montifier" because given any other k-digit number x,

--- a/x86/generic/bignum_montmul.S
+++ b/x86/generic/bignum_montmul.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^{64k}) mod m
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_montmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_montmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *y, const uint64_t *m);
 //
 // Does z := (x * y / 2^{64k}) mod m, assuming x * y <= 2^{64k} * m, which is
 // guaranteed in particular if x < m, y < m initially (the "intended" case).

--- a/x86/generic/bignum_montredc.S
+++ b/x86/generic/bignum_montredc.S
@@ -5,9 +5,8 @@
 // Montgomery reduce, z := (x' / 2^{64p}) MOD m
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_montredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_montredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a := (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x, assuming x' <= 2^{64p} * m. That is,

--- a/x86/generic/bignum_montsqr.S
+++ b/x86/generic/bignum_montsqr.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_montsqr
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_montsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *m);
 //
 // Does z := (x^2 / 2^{64k}) mod m, assuming x^2 <= 2^{64k} * m, which is
 // guaranteed in particular if x < m initially (the "intended" case).

--- a/x86/generic/bignum_mul.S
+++ b/x86/generic/bignum_mul.S
@@ -5,9 +5,8 @@
 // Multiply z := x * y
 // Inputs x[m], y[n]; output z[k]
 //
-//    extern void bignum_mul
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern void bignum_mul(uint64_t k, uint64_t *z, uint64_t m, const uint64_t *x,
+//                           uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y" operation where x is m digits, y is n, result z is k.
 // Truncates the result in general unless k >= m + n

--- a/x86/generic/bignum_muladd10.S
+++ b/x86/generic/bignum_muladd10.S
@@ -5,7 +5,7 @@
 // Multiply bignum by 10 and add word: z := 10 * z + d
 // Inputs z[k], d; outputs function return (carry) and z[k]
 //
-//    extern uint64_t bignum_muladd10 (uint64_t k, uint64_t *z, uint64_t d);
+//    extern uint64_t bignum_muladd10(uint64_t k, uint64_t *z, uint64_t d);
 //
 // Although typically the input d < 10, this is not actually required.
 //

--- a/x86/generic/bignum_mux.S
+++ b/x86/generic/bignum_mux.S
@@ -5,8 +5,8 @@
 // Multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[k], y[k]; output z[k]
 //
-//    extern void bignum_mux
-//     (uint64_t p, uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+//    extern void bignum_mux(uint64_t p, uint64_t k, uint64_t *z, const uint64_t *x,
+//                           const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 //

--- a/x86/generic/bignum_mux16.S
+++ b/x86/generic/bignum_mux16.S
@@ -5,8 +5,8 @@
 // Select element from 16-element table, z := xs[k*i]
 // Inputs xs[16*k], i; output z[k]
 //
-//    extern void bignum_mux16
-//     (uint64_t k, uint64_t *z, uint64_t *xs, uint64_t i);
+//    extern void bignum_mux16(uint64_t k, uint64_t *z, const uint64_t *xs,
+//                             uint64_t i);
 //
 // It is assumed that all numbers xs[16] and the target z have the same size k
 // The pointer xs is to a contiguous array of size 16, elements size-k bignums

--- a/x86/generic/bignum_negmodinv.S
+++ b/x86/generic/bignum_negmodinv.S
@@ -5,8 +5,7 @@
 // Negated modular inverse, z := (-1/x) mod 2^{64k}
 // Input x[k]; output z[k]
 //
-//    extern void bignum_negmodinv
-//     (uint64_t k, uint64_t *z, uint64_t *x);
+//    extern void bignum_negmodinv(uint64_t k, uint64_t *z, const uint64_t *x);
 //
 // Assuming x is odd (otherwise nothing makes sense) the result satisfies
 //

--- a/x86/generic/bignum_nonzero.S
+++ b/x86/generic/bignum_nonzero.S
@@ -5,7 +5,7 @@
 // Test bignum for nonzero-ness x =/= 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_nonzero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_nonzero(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86/generic/bignum_normalize.S
+++ b/x86/generic/bignum_normalize.S
@@ -5,7 +5,7 @@
 // Normalize bignum in-place by shifting left till top bit is 1
 // Input z[k]; outputs function return (bits shifted left) and z[k]
 //
-//    extern uint64_t bignum_normalize (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_normalize(uint64_t k, uint64_t *z);
 //
 // Given a k-digit bignum z, this function shifts it left by its number of
 // leading zero bits, to give result with top bit 1, unless the input number

--- a/x86/generic/bignum_odd.S
+++ b/x86/generic/bignum_odd.S
@@ -5,7 +5,7 @@
 // Test bignum for odd-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_odd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_odd(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86/generic/bignum_of_word.S
+++ b/x86/generic/bignum_of_word.S
@@ -5,7 +5,7 @@
 // Convert single digit to bignum, z := n
 // Input n; output z[k]
 //
-//    extern void bignum_of_word (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_of_word(uint64_t k, uint64_t *z, uint64_t n);
 //
 // Create a k-digit (digit=64 bits) bignum at z with value n (mod 2^k)
 // where n is a word. The "mod 2^k" only matters in the degenerate k = 0 case.

--- a/x86/generic/bignum_optadd.S
+++ b/x86/generic/bignum_optadd.S
@@ -5,8 +5,8 @@
 // Optionally add, z := x + y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual addition, always 0 if p was zero.

--- a/x86/generic/bignum_optneg.S
+++ b/x86/generic/bignum_optneg.S
@@ -5,8 +5,8 @@
 // Optionally negate, z := -x (if p nonzero) or z := x (if p zero)
 // Inputs p, x[k]; outputs function return (nonzero input) and z[k]
 //
-//    extern uint64_t bignum_optneg
-//     (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x);
+//    extern uint64_t bignum_optneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                  const uint64_t *x);
 //
 // It is assumed that both numbers x and z have the same size k digits.
 // Returns a carry, which is equivalent to "x is nonzero".

--- a/x86/generic/bignum_optsub.S
+++ b/x86/generic/bignum_optsub.S
@@ -5,8 +5,8 @@
 // Optionally subtract, z := x - y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual subtraction, always 0 if p was zero.

--- a/x86/generic/bignum_optsubadd.S
+++ b/x86/generic/bignum_optsubadd.S
@@ -5,8 +5,8 @@
 // Optionally subtract or add, z := x + sgn(p) * y interpreting p as signed
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsubadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsubadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                     uint64_t p, const uint64_t *y);
 //
 // If p has top bit set (i.e. is negative as a signed int) return z := x - y
 // Else if p is nonzero (i.e. is positive as a signed int) return z := x + y

--- a/x86/generic/bignum_pow2.S
+++ b/x86/generic/bignum_pow2.S
@@ -5,7 +5,7 @@
 // Return bignum of power of 2, z := 2^n
 // Input n; output z[k]
 //
-//    extern void bignum_pow2 (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_pow2(uint64_t k, uint64_t *z, uint64_t n);
 //
 // The result is as usual mod 2^{64*k}, so will be zero if n >= 64*k.
 //

--- a/x86/generic/bignum_shl_small.S
+++ b/x86/generic/bignum_shl_small.S
@@ -5,8 +5,8 @@
 // Shift bignum left by c < 64 bits z := x * 2^c
 // Inputs x[n], c; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_shl_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shl_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x << c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/x86/generic/bignum_shr_small.S
+++ b/x86/generic/bignum_shr_small.S
@@ -5,8 +5,8 @@
 // Shift bignum right by c < 64 bits z := floor(x / 2^c)
 // Inputs x[n], c; outputs function return (bits shifted out) and z[k]
 //
-//    extern uint64_t bignum_shr_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shr_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x >> c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/x86/generic/bignum_sqr.S
+++ b/x86/generic/bignum_sqr.S
@@ -5,8 +5,7 @@
 // Square z := x^2
 // Input x[n]; output z[k]
 //
-//    extern void bignum_sqr
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_sqr(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Does the "z := x^2" operation where x is n digits and result z is k.
 // Truncates the result in general unless k >= 2 * n

--- a/x86/generic/bignum_sub.S
+++ b/x86/generic/bignum_sub.S
@@ -5,9 +5,8 @@
 // Subtract, z := x - y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_sub
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_sub(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x - y operation, truncating modulo p words in general and
 // returning a top borrow (0 or 1) in the p'th place, only subtracting input

--- a/x86/generic/word_bytereverse.S
+++ b/x86/generic/word_bytereverse.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Reverse the order of bytes in a 64-bit word
 //
-//    extern uint64_t word_bytereverse (uint64_t a);
+//    extern uint64_t word_bytereverse(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86/generic/word_clz.S
+++ b/x86/generic/word_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_clz (uint64_t a);
+//    extern uint64_t word_clz(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86/generic/word_ctz.S
+++ b/x86/generic/word_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_ctz (uint64_t a);
+//    extern uint64_t word_ctz(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86/generic/word_max.S
+++ b/x86/generic/word_max.S
@@ -5,7 +5,7 @@
 // Return maximum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_max (uint64_t a, uint64_t b);
+//    extern uint64_t word_max(uint64_t a, uint64_t b);
 //
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX

--- a/x86/generic/word_min.S
+++ b/x86/generic/word_min.S
@@ -5,7 +5,7 @@
 // Return minimum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_min (uint64_t a, uint64_t b);
+//    extern uint64_t word_min(uint64_t a, uint64_t b);
 //
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX

--- a/x86/generic/word_negmodinv.S
+++ b/x86/generic/word_negmodinv.S
@@ -5,7 +5,7 @@
 // Single-word negated modular inverse (-1/a) mod 2^64
 // Input a; output function return
 //
-//    extern uint64_t word_negmodinv (uint64_t a);
+//    extern uint64_t word_negmodinv(uint64_t a);
 //
 // A 64-bit function that returns a negated multiplicative inverse mod 2^64
 // of its input, assuming that input is odd. Given odd input a, the result z

--- a/x86/generic/word_popcount.S
+++ b/x86/generic/word_popcount.S
@@ -5,7 +5,7 @@
 // Count number of set bits in a single 64-bit word (population count)
 // Input a; output function return
 //
-//    extern uint64_t word_popcount (uint64_t a);
+//    extern uint64_t word_popcount(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86/generic/word_recip.S
+++ b/x86/generic/word_recip.S
@@ -5,7 +5,7 @@
 // Single-word reciprocal, underestimate of 2^128 / a with implicit 1 added
 // Input a; output function return
 //
-//    extern uint64_t word_recip (uint64_t a);
+//    extern uint64_t word_recip(uint64_t a);
 //
 // Given an input word "a" with its top bit set (i.e. 2^63 <= a < 2^64), the
 // result "x" is implicitly augmented with a leading 1 giving x' = 2^64 + x.

--- a/x86/p256/bignum_add_p256.S
+++ b/x86/p256/bignum_add_p256.S
@@ -5,8 +5,8 @@
 // Add modulo p_256, z := (x + y) mod p_256, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p256/bignum_bigendian_4.S
+++ b/x86/p256/bignum_bigendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from big-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_bigendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_bigendian_4(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_frombebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tobebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tobebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // Since x86 is little-endian, and bignums are stored with little-endian
 // word order, this is simply byte reversal and is implemented as such.

--- a/x86/p256/bignum_cmul_p256.S
+++ b/x86/p256/bignum_cmul_p256.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256(uint64_t z[static 4], uint64_t c,
+//                                 const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p256/bignum_cmul_p256_alt.S
+++ b/x86/p256/bignum_cmul_p256_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256_alt(uint64_t z[static 4], uint64_t c,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p256/bignum_deamont_p256.S
+++ b/x86/p256/bignum_deamont_p256.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86/p256/bignum_deamont_p256_alt.S
+++ b/x86/p256/bignum_deamont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86/p256/bignum_demont_p256.S
+++ b/x86/p256/bignum_demont_p256.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p256" instead.

--- a/x86/p256/bignum_demont_p256_alt.S
+++ b/x86/p256/bignum_demont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p256" instead.

--- a/x86/p256/bignum_double_p256.S
+++ b/x86/p256/bignum_double_p256.S
@@ -5,8 +5,8 @@
 // Double modulo p_256, z := (2 * x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_half_p256.S
+++ b/x86/p256/bignum_half_p256.S
@@ -5,8 +5,7 @@
 // Halve modulo p_256, z := (x / 2) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_inv_p256.S
+++ b/x86/p256/bignum_inv_p256.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_256 = 2^256 - 2^224 + 2^192 + 2^96 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_p256(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_p256(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_256, i.e. is not divisible
 // by it, returns z < p_256 such that x * z == 1 (mod p_256). Note that

--- a/x86/p256/bignum_littleendian_4.S
+++ b/x86/p256/bignum_littleendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from little-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_littleendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_littleendian_4(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_fromlebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tolebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tolebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // Since x86 is little-endian, this is just copying.
 //

--- a/x86/p256/bignum_mod_n256.S
+++ b/x86/p256/bignum_mod_n256.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86/p256/bignum_mod_n256_4.S
+++ b/x86/p256/bignum_mod_n256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86/p256/bignum_mod_n256_alt.S
+++ b/x86/p256/bignum_mod_n256_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n256_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n256_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86/p256/bignum_mod_p256.S
+++ b/x86/p256/bignum_mod_p256.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_p256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86/p256/bignum_mod_p256_4.S
+++ b/x86/p256/bignum_mod_p256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_mod_p256_alt.S
+++ b/x86/p256/bignum_mod_p256_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_p256_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p256_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86/p256/bignum_montinv_p256.S
+++ b/x86/p256/bignum_montinv_p256.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_256 = 2^256 - 2^224 + 2^192 + 2^96 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_montinv_p256(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_montinv_p256(uint64_t z[static 4],
+//                                 const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_256, i.e. is not divisible
 // by it, returns z < p_256 such that x * z == 2^512 (mod p_256). This

--- a/x86/p256/bignum_montmul_p256.S
+++ b/x86/p256/bignum_montmul_p256.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4],
+//                                    const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/x86/p256/bignum_montmul_p256_alt.S
+++ b/x86/p256/bignum_montmul_p256_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4],
+//                                        const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/x86/p256/bignum_montsqr_p256.S
+++ b/x86/p256/bignum_montsqr_p256.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/x86/p256/bignum_montsqr_p256_alt.S
+++ b/x86/p256/bignum_montsqr_p256_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/x86/p256/bignum_mux_4.S
+++ b/x86/p256/bignum_mux_4.S
@@ -5,9 +5,9 @@
 // 256-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[4], y[4]; output z[4]
 //
-//    extern void bignum_mux_4
-//     (uint64_t p, uint64_t z[static 4],
-//      uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mux_4(uint64_t p, uint64_t z[static 4],
+//                             const uint64_t x[static 4],
+//                             const uint64_t y[static 4]);
 //
 // It is assumed that all numbers x, y and z have the same size 4 digits.
 //

--- a/x86/p256/bignum_neg_p256.S
+++ b/x86/p256/bignum_neg_p256.S
@@ -5,7 +5,7 @@
 // Negate modulo p_256, z := (-x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_nonzero_4.S
+++ b/x86/p256/bignum_nonzero_4.S
@@ -5,7 +5,7 @@
 // 256-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[4]; output function return
 //
-//    extern uint64_t bignum_nonzero_4(uint64_t x[static 4]);
+//    extern uint64_t bignum_nonzero_4(const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // Microsoft x64 ABI:   RCX = x, returns RAX

--- a/x86/p256/bignum_optneg_p256.S
+++ b/x86/p256/bignum_optneg_p256.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256(uint64_t z[static 4], uint64_t p,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/p256/bignum_sub_p256.S
+++ b/x86/p256/bignum_sub_p256.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256, z := (x - y) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p256/bignum_tomont_p256.S
+++ b/x86/p256/bignum_tomont_p256.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_tomont_p256_alt.S
+++ b/x86/p256/bignum_tomont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p256/bignum_triple_p256.S
+++ b/x86/p256/bignum_triple_p256.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_256,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_256.

--- a/x86/p256/bignum_triple_p256_alt.S
+++ b/x86/p256/bignum_triple_p256_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_256,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_256.

--- a/x86/p256/p256_montjadd.S
+++ b/x86/p256/p256_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                              const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjadd_alt.S
+++ b/x86/p256/p256_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd_alt(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjdouble.S
+++ b/x86/p256/p256_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjdouble_alt.S
+++ b/x86/p256/p256_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjmixadd.S
+++ b/x86/p256/p256_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjmixadd_alt.S
+++ b/x86/p256/p256_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12],
+//                                     const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86/p256/p256_montjscalarmul.S
+++ b/x86/p256/p256_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_montjscalarmul
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version p256_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/p256/p256_montjscalarmul_alt.S
+++ b/x86/p256/p256_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p256_montjscalarmul_alt
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version p256_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/p256/p256_scalarmul.S
+++ b/x86/p256/p256_scalarmul.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8]; output res[8]
 //
 // extern void p256_scalarmul
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//     uint64_t point[static 8]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//     const uint64_t point[static 8]);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, returns the point (X,Y) = n * P. The input and output

--- a/x86/p256/p256_scalarmul_alt.S
+++ b/x86/p256/p256_scalarmul_alt.S
@@ -6,8 +6,8 @@
 // Input scalar[4], point[8]; output res[8]
 //
 // extern void p256_scalarmul_alt
-//   (uint64_t res[static 8],uint64_t scalar[static 4],
-//     uint64_t point[static 8]);
+//   (uint64_t res[static 8],const uint64_t scalar[static 4],
+//     const uint64_t point[static 8]);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, returns the point (X,Y) = n * P. The input and output

--- a/x86/p256/p256_scalarmulbase.S
+++ b/x86/p256/p256_scalarmulbase.S
@@ -7,9 +7,9 @@
 //
 // extern void p256_scalarmulbase
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
+//    const uint64_t scalar[static 4],
 //    uint64_t blocksize,
-//    uint64_t *table);
+//    const uint64_t *table);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, the input argument "table" is expected to be a table of

--- a/x86/p256/p256_scalarmulbase_alt.S
+++ b/x86/p256/p256_scalarmulbase_alt.S
@@ -7,9 +7,9 @@
 //
 // extern void p256_scalarmulbase_alt
 //   (uint64_t res[static 8],
-//    uint64_t scalar[static 4],
+//    const uint64_t scalar[static 4],
 //    uint64_t blocksize,
-//    uint64_t *table);
+//    const uint64_t *table);
 //
 // Given scalar = n and point = P, assumed to be on the NIST elliptic
 // curve P-256, the input argument "table" is expected to be a table of

--- a/x86/p384/bignum_add_p384.S
+++ b/x86/p384/bignum_add_p384.S
@@ -5,8 +5,8 @@
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_add_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_add_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p384/bignum_bigendian_6.S
+++ b/x86/p384/bignum_bigendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from big-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_bigendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_bigendian_6(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_frombebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tobebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tobebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // Since x86 is little-endian, and bignums are stored with little-endian
 // word order, this is simply byte reversal and is implemented as such.

--- a/x86/p384/bignum_cmul_p384.S
+++ b/x86/p384/bignum_cmul_p384.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[6]; output z[6]
 //
-//    extern void bignum_cmul_p384
-//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//    extern void bignum_cmul_p384(uint64_t z[static 6], uint64_t c,
+//                                 const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p384/bignum_cmul_p384_alt.S
+++ b/x86/p384/bignum_cmul_p384_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[6]; output z[6]
 //
-//    extern void bignum_cmul_p384_alt
-//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//    extern void bignum_cmul_p384_alt(uint64_t z[static 6], uint64_t c,
+//                                     const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p384/bignum_deamont_p384.S
+++ b/x86/p384/bignum_deamont_p384.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_deamont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_deamont_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 6-digit input will work, with no range restriction.

--- a/x86/p384/bignum_deamont_p384_alt.S
+++ b/x86/p384/bignum_deamont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_deamont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_deamont_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6]);
 //
 // Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 6-digit input will work, with no range restriction.

--- a/x86/p384/bignum_demont_p384.S
+++ b/x86/p384/bignum_demont_p384.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_demont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_demont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // This assumes the input is < p_384 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p384" instead.

--- a/x86/p384/bignum_demont_p384_alt.S
+++ b/x86/p384/bignum_demont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_demont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_demont_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // This assumes the input is < p_384 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p384" instead.

--- a/x86/p384/bignum_double_p384.S
+++ b/x86/p384/bignum_double_p384.S
@@ -5,8 +5,8 @@
 // Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_double_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_double_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_half_p384.S
+++ b/x86/p384/bignum_half_p384.S
@@ -5,8 +5,7 @@
 // Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_half_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_half_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_inv_p384.S
+++ b/x86/p384/bignum_inv_p384.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_384 = 2^384 - 2^128 - 2^96 + 2^32 - 1
 // Input x[6]; output z[6]
 //
-// extern void bignum_inv_p384(uint64_t z[static 6],uint64_t x[static 6]);
+// extern void bignum_inv_p384(uint64_t z[static 6],const uint64_t x[static 6]);
 //
 // If the 6-digit input x is coprime to p_384, i.e. is not divisible
 // by it, returns z < p_384 such that x * z == 1 (mod p_384). Note that

--- a/x86/p384/bignum_littleendian_6.S
+++ b/x86/p384/bignum_littleendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from little-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_littleendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_littleendian_6(uint64_t z[static 6],
+//                                      const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_fromlebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tolebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tolebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // Since x86 is little-endian, this is just copying.
 //

--- a/x86/p384/bignum_mod_n384.S
+++ b/x86/p384/bignum_mod_n384.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_n384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86/p384/bignum_mod_n384_6.S
+++ b/x86/p384/bignum_mod_n384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_n384_6
-//      (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_n384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86/p384/bignum_mod_n384_alt.S
+++ b/x86/p384/bignum_mod_n384_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_n384_alt
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n384_alt(uint64_t z[static 6], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86/p384/bignum_mod_p384.S
+++ b/x86/p384/bignum_mod_p384.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_p384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86/p384/bignum_mod_p384_6.S
+++ b/x86/p384/bignum_mod_p384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_p384_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_p384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_mod_p384_alt.S
+++ b/x86/p384/bignum_mod_p384_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_p384_alt
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p384_alt(uint64_t z[static 6], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86/p384/bignum_montinv_p384.S
+++ b/x86/p384/bignum_montinv_p384.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_384 = 2^384 - 2^128 - 2^96 + 2^32 - 1
 // Input x[6]; output z[6]
 //
-// extern void bignum_montinv_p384(uint64_t z[static 6],uint64_t x[static 6]);
+// extern void bignum_montinv_p384(uint64_t z[static 6],
+//                                 const uint64_t x[static 6]);
 //
 // If the 6-digit input x is coprime to p_384, i.e. is not divisible
 // by it, returns z < p_384 such that x * z == 2^768 (mod p_384). This

--- a/x86/p384/bignum_montmul_p384.S
+++ b/x86/p384/bignum_montmul_p384.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/x86/p384/bignum_montmul_p384_alt.S
+++ b/x86/p384/bignum_montmul_p384_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6],
+//                                        const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/x86/p384/bignum_montsqr_p384.S
+++ b/x86/p384/bignum_montsqr_p384.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/x86/p384/bignum_montsqr_p384_alt.S
+++ b/x86/p384/bignum_montsqr_p384_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/x86/p384/bignum_mux_6.S
+++ b/x86/p384/bignum_mux_6.S
@@ -5,9 +5,9 @@
 // 384-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[6], y[6]; output z[6]
 //
-//    extern void bignum_mux_6
-//     (uint64_t p, uint64_t z[static 6],
-//      uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mux_6(uint64_t p, uint64_t z[static 6],
+//                             const uint64_t x[static 6],
+//                             const uint64_t y[static 6]);
 //
 // It is assumed that all numbers x, y and z have the same size 6 digits.
 //

--- a/x86/p384/bignum_neg_p384.S
+++ b/x86/p384/bignum_neg_p384.S
@@ -5,7 +5,7 @@
 // Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_neg_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_nonzero_6.S
+++ b/x86/p384/bignum_nonzero_6.S
@@ -5,7 +5,7 @@
 // 384-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[6]; output function return
 //
-//    extern uint64_t bignum_nonzero_6(uint64_t x[static 6]);
+//    extern uint64_t bignum_nonzero_6(const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // Microsoft x64 ABI:   RCX = x, returns RAX

--- a/x86/p384/bignum_optneg_p384.S
+++ b/x86/p384/bignum_optneg_p384.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[6]; output z[6]
 //
-//    extern void bignum_optneg_p384
-//      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+//    extern void bignum_optneg_p384(uint64_t z[static 6], uint64_t p,
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/p384/bignum_sub_p384.S
+++ b/x86/p384/bignum_sub_p384.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_384, z := (x - y) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_sub_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_sub_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p384/bignum_tomont_p384.S
+++ b/x86/p384/bignum_tomont_p384.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_tomont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_tomont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_tomont_p384_alt.S
+++ b/x86/p384/bignum_tomont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_tomont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_tomont_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p384/bignum_triple_p384.S
+++ b/x86/p384/bignum_triple_p384.S
@@ -5,8 +5,8 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_triple_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.

--- a/x86/p384/bignum_triple_p384_alt.S
+++ b/x86/p384/bignum_triple_p384_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_triple_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.

--- a/x86/p384/p384_montjadd.S
+++ b/x86/p384/p384_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd(uint64_t p3[static 18], const uint64_t p1[static 18],
+//                              const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjadd_alt.S
+++ b/x86/p384/p384_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd_alt(uint64_t p3[static 18],
+//                                  const uint64_t p1[static 18],
+//                                  const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjdouble.S
+++ b/x86/p384/p384_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjdouble_alt.S
+++ b/x86/p384/p384_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjmixadd.S
+++ b/x86/p384/p384_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjmixadd_alt.S
+++ b/x86/p384/p384_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18],
+//                                     const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86/p384/p384_montjscalarmul.S
+++ b/x86/p384/p384_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p384_montjscalarmul
 //   (uint64_t res[static 18],
-//    uint64_t scalar[static 6],
-//    uint64_t point[static 18]);
+//    const uint64_t scalar[static 6],
+//    const uint64_t point[static 18]);
 //
 // This function is a variant of its affine point version p384_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/p384/p384_montjscalarmul_alt.S
+++ b/x86/p384/p384_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p384_montjscalarmul_alt
 //   (uint64_t res[static 18],
-//    uint64_t scalar[static 6],
-//    uint64_t point[static 18]);
+//    const uint64_t scalar[static 6],
+//    const uint64_t point[static 18]);
 //
 // This function is a variant of its affine point version p384_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/p521/bignum_add_p521.S
+++ b/x86/p521/bignum_add_p521.S
@@ -5,8 +5,8 @@
 // Add modulo p_521, z := (x + y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_add_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_add_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p521/bignum_cmul_p521.S
+++ b/x86/p521/bignum_cmul_p521.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[9]; output z[9]
 //
-//    extern void bignum_cmul_p521
-//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//    extern void bignum_cmul_p521(uint64_t z[static 9], uint64_t c,
+//                                 const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p521/bignum_cmul_p521_alt.S
+++ b/x86/p521/bignum_cmul_p521_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[9]; output z[9]
 //
-//    extern void bignum_cmul_p521_alt
-//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//    extern void bignum_cmul_p521_alt(uint64_t z[static 9], uint64_t c,
+//                                     const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/p521/bignum_deamont_p521.S
+++ b/x86/p521/bignum_deamont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_deamont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_deamont_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Convert a 9-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 9-digit input will work, with no range restriction.

--- a/x86/p521/bignum_demont_p521.S
+++ b/x86/p521/bignum_demont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_demont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_demont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // This assumes the input is < p_521 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p521" instead.

--- a/x86/p521/bignum_double_p521.S
+++ b/x86/p521/bignum_double_p521.S
@@ -5,8 +5,8 @@
 // Double modulo p_521, z := (2 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_double_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_double_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_fromlebytes_p521.S
+++ b/x86/p521/bignum_fromlebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert little-endian bytes to 9-digit 528-bit bignum
 //
-//    extern void bignum_fromlebytes_p521
-//     (uint64_t z[static 9],uint8_t x[static 66])
+//    extern void bignum_fromlebytes_p521(uint64_t z[static 9],
+//                                        const uint8_t x[static 66]);
 //
 // The result will be < 2^528 since it is translated from 66 bytes.
 // It is mainly intended for inputs x < p_521 < 2^521 < 2^528.

--- a/x86/p521/bignum_half_p521.S
+++ b/x86/p521/bignum_half_p521.S
@@ -5,8 +5,7 @@
 // Halve modulo p_521, z := (x / 2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_half_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_half_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_inv_p521.S
+++ b/x86/p521/bignum_inv_p521.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_521 =  2^521 - 1
 // Input x[9]; output z[9]
 //
-// extern void bignum_inv_p521(uint64_t z[static 9],uint64_t x[static 9]);
+// extern void bignum_inv_p521(uint64_t z[static 9],const uint64_t x[static 9]);
 //
 // Assuming the 9-digit input x is coprime to p_521, i.e. is not divisible
 // by it, returns z < p_521 such that x * z == 1 (mod p_521). Note that

--- a/x86/p521/bignum_mod_n521_9.S
+++ b/x86/p521/bignum_mod_n521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_n521_9
-//      (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_n521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Reduction is modulo the group order of the NIST curve P-521.
 //

--- a/x86/p521/bignum_mod_n521_9_alt.S
+++ b/x86/p521/bignum_mod_n521_9_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_n521_9_alt
-//      (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_n521_9_alt(uint64_t z[static 9],
+//                                      const uint64_t x[static 9]);
 //
 // Reduction is modulo the group order of the NIST curve P-521.
 //

--- a/x86/p521/bignum_mod_p521_9.S
+++ b/x86/p521/bignum_mod_p521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_p521_9
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_p521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_montmul_p521.S
+++ b/x86/p521/bignum_montmul_p521.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/x86/p521/bignum_montmul_p521_alt.S
+++ b/x86/p521/bignum_montmul_p521_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9],
+//                                        const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/x86/p521/bignum_montsqr_p521.S
+++ b/x86/p521/bignum_montsqr_p521.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/x86/p521/bignum_montsqr_p521_alt.S
+++ b/x86/p521/bignum_montsqr_p521_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/x86/p521/bignum_mul_p521.S
+++ b/x86/p521/bignum_mul_p521.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p521/bignum_mul_p521_alt.S
+++ b/x86/p521/bignum_mul_p521_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p521/bignum_neg_p521.S
+++ b/x86/p521/bignum_neg_p521.S
@@ -5,7 +5,7 @@
 // Negate modulo p_521, z := (-x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_neg_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_optneg_p521.S
+++ b/x86/p521/bignum_optneg_p521.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[9]; output z[9]
 //
-//    extern void bignum_optneg_p521
-//      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
+//    extern void bignum_optneg_p521(uint64_t z[static 9], uint64_t p,
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/p521/bignum_sqr_p521.S
+++ b/x86/p521/bignum_sqr_p521.S
@@ -5,7 +5,7 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_sqr_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_sqr_p521_alt.S
+++ b/x86/p521/bignum_sqr_p521_alt.S
@@ -5,7 +5,8 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_sqr_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_sub_p521.S
+++ b/x86/p521/bignum_sub_p521.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_521, z := (x - y) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_sub_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_sub_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/p521/bignum_tolebytes_p521.S
+++ b/x86/p521/bignum_tolebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert 9-digit 528-bit bignum to little-endian bytes
 //
-//    extern void bignum_tolebytes_p521
-//     (uint8_t z[static 66], uint64_t x[static 9]);
+//    extern void bignum_tolebytes_p521(uint8_t z[static 66],
+//                                      const uint64_t x[static 9]);
 //
 // This is assuming the input x is < 2^528 so that it fits in 66 bytes.
 // In particular this holds if x < p_521 < 2^521 < 2^528.

--- a/x86/p521/bignum_tomont_p521.S
+++ b/x86/p521/bignum_tomont_p521.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^576 * x) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_tomont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_tomont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_triple_p521.S
+++ b/x86/p521/bignum_triple_p521.S
@@ -5,8 +5,8 @@
 // Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_triple_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_triple_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/bignum_triple_p521_alt.S
+++ b/x86/p521/bignum_triple_p521_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_triple_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_triple_p521_alt(uint64_t z[static 9],
+//                                       const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/p521/p521_jadd.S
+++ b/x86/p521/p521_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                          const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jadd_alt.S
+++ b/x86/p521/p521_jadd_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd_alt(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                              const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jdouble.S
+++ b/x86/p521/p521_jdouble.S
@@ -4,8 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble(uint64_t p3[static 27], const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jdouble_alt.S
+++ b/x86/p521/p521_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jmixadd.S
+++ b/x86/p521/p521_jmixadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                             const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jmixadd_alt.S
+++ b/x86/p521/p521_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27],
+//                                 const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/p521/p521_jscalarmul.S
+++ b/x86/p521/p521_jscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void p521_jscalarmul
 //   (uint64_t res[static 27],
-//    uint64_t scalar[static 9],
-//    uint64_t point[static 27]);
+//    const uint64_t scalar[static 9],
+//    const uint64_t point[static 27]);
 //
 // This function is a variant of its affine point version p521_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/p521/p521_jscalarmul_alt.S
+++ b/x86/p521/p521_jscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void p521_jscalarmul_alt
 //   (uint64_t res[static 27],
-//    uint64_t scalar[static 9],
-//    uint64_t point[static 27]);
+//    const uint64_t scalar[static 9],
+//    const uint64_t point[static 27]);
 //
 // This function is a variant of its affine point version p521_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/secp256k1/bignum_add_p256k1.S
+++ b/x86/secp256k1/bignum_add_p256k1.S
@@ -5,8 +5,8 @@
 // Add modulo p_256k1, z := (x + y) mod p_256k1, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/secp256k1/bignum_cmul_p256k1.S
+++ b/x86/secp256k1/bignum_cmul_p256k1.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256k1
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256k1(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/secp256k1/bignum_cmul_p256k1_alt.S
+++ b/x86/secp256k1/bignum_cmul_p256k1_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256k1_alt(uint64_t z[static 4], uint64_t c,
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/secp256k1/bignum_deamont_p256k1.S
+++ b/x86/secp256k1/bignum_deamont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256k1,
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86/secp256k1/bignum_demont_p256k1.S
+++ b/x86/secp256k1/bignum_demont_p256k1.S
@@ -6,8 +6,8 @@
 // assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256k1 for correctness. If this is not the
 // case, use the variant "bignum_deamont_p256k1" instead.

--- a/x86/secp256k1/bignum_double_p256k1.S
+++ b/x86/secp256k1/bignum_double_p256k1.S
@@ -5,8 +5,8 @@
 // Double modulo p_256k1, z := (2 * x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_half_p256k1.S
+++ b/x86/secp256k1/bignum_half_p256k1.S
@@ -5,8 +5,8 @@
 // Halve modulo p_256k1, z := (x / 2) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256k1(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_mod_n256k1_4.S
+++ b/x86/secp256k1/bignum_mod_n256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the secp256k1 curve.
 //

--- a/x86/secp256k1/bignum_mod_p256k1_4.S
+++ b/x86/secp256k1/bignum_mod_p256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_montmul_p256k1.S
+++ b/x86/secp256k1/bignum_montmul_p256k1.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k2 (in particular this is true if we are in

--- a/x86/secp256k1/bignum_montmul_p256k1_alt.S
+++ b/x86/secp256k1/bignum_montmul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4],
+//                                          const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k2 (in particular this is true if we are in

--- a/x86/secp256k1/bignum_montsqr_p256k1.S
+++ b/x86/secp256k1/bignum_montsqr_p256k1.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/x86/secp256k1/bignum_montsqr_p256k1_alt.S
+++ b/x86/secp256k1/bignum_montsqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/x86/secp256k1/bignum_mul_p256k1.S
+++ b/x86/secp256k1/bignum_mul_p256k1.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/secp256k1/bignum_mul_p256k1_alt.S
+++ b/x86/secp256k1/bignum_mul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/secp256k1/bignum_neg_p256k1.S
+++ b/x86/secp256k1/bignum_neg_p256k1.S
@@ -5,8 +5,7 @@
 // Negate modulo p_256k1, z := (-x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_optneg_p256k1.S
+++ b/x86/secp256k1/bignum_optneg_p256k1.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256k1
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256k1(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/secp256k1/bignum_sqr_p256k1.S
+++ b/x86/secp256k1/bignum_sqr_p256k1.S
@@ -5,8 +5,7 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_sqr_p256k1_alt.S
+++ b/x86/secp256k1/bignum_sqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_sub_p256k1.S
+++ b/x86/secp256k1/bignum_sub_p256k1.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256k1, z := (x - y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/secp256k1/bignum_tomont_p256k1.S
+++ b/x86/secp256k1/bignum_tomont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_tomont_p256k1_alt.S
+++ b/x86/secp256k1/bignum_tomont_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256k1_alt(uint64_t z[static 4],
+//                                         const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/secp256k1/bignum_triple_p256k1.S
+++ b/x86/secp256k1/bignum_triple_p256k1.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256k1, z := (3 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256k1
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo
 // p_256k1, and the result is always fully reduced, z = (3 * x) mod p_256k1.

--- a/x86/secp256k1/bignum_triple_p256k1_alt.S
+++ b/x86/secp256k1/bignum_triple_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256k1, z := (3 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256k1_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256k1_alt(uint64_t z[static 4],
+//                                         const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo
 // p_256k1, and the result is always fully reduced, z = (3 * x) mod p_256k1.

--- a/x86/secp256k1/secp256k1_jadd.S
+++ b/x86/secp256k1/secp256k1_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                               const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/secp256k1/secp256k1_jadd_alt.S
+++ b/x86/secp256k1/secp256k1_jadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd_alt(uint64_t p3[static 12],
+//                                   const uint64_t p1[static 12],
+//                                   const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/secp256k1/secp256k1_jdouble.S
+++ b/x86/secp256k1/secp256k1_jdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/secp256k1/secp256k1_jdouble.S
+++ b/x86/secp256k1/secp256k1_jdouble.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_montjdouble
+//    extern void secp256k1_jdouble
 //      (uint64_t p3[static 12],uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.

--- a/x86/secp256k1/secp256k1_jdouble_alt.S
+++ b/x86/secp256k1/secp256k1_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/secp256k1/secp256k1_jdouble_alt.S
+++ b/x86/secp256k1/secp256k1_jdouble_alt.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_montjdouble_alt
+//    extern void secp256k1_jdouble_alt
 //      (uint64_t p3[static 12],uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.

--- a/x86/secp256k1/secp256k1_jmixadd.S
+++ b/x86/secp256k1/secp256k1_jmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/secp256k1/secp256k1_jmixadd_alt.S
+++ b/x86/secp256k1/secp256k1_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12],
+//                                      const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86/sm2/bignum_add_sm2.S
+++ b/x86/sm2/bignum_add_sm2.S
@@ -5,8 +5,8 @@
 // Add modulo p_sm2, z := (x + y) mod p_sm2, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/sm2/bignum_cmul_sm2.S
+++ b/x86/sm2/bignum_cmul_sm2.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_sm2
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_sm2(uint64_t z[static 4], uint64_t c,
+//                                const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/sm2/bignum_cmul_sm2_alt.S
+++ b/x86/sm2/bignum_cmul_sm2_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_sm2_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_sm2_alt(uint64_t z[static 4], uint64_t c,
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86/sm2/bignum_deamont_sm2.S
+++ b/x86/sm2/bignum_deamont_sm2.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86/sm2/bignum_demont_sm2.S
+++ b/x86/sm2/bignum_demont_sm2.S
@@ -5,8 +5,7 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // This assumes the input is < p_sm2 for correctness. If this is not the case,
 // use the variant "bignum_deamont_sm2" instead.

--- a/x86/sm2/bignum_double_sm2.S
+++ b/x86/sm2/bignum_double_sm2.S
@@ -5,8 +5,7 @@
 // Double modulo p_sm2, z := (2 * x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/sm2/bignum_half_sm2.S
+++ b/x86/sm2/bignum_half_sm2.S
@@ -5,8 +5,7 @@
 // Halve modulo p_sm2, z := (x / 2) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/sm2/bignum_inv_sm2.S
+++ b/x86/sm2/bignum_inv_sm2.S
@@ -5,7 +5,7 @@
 // Modular inverse modulo p_sm2 = 2^256 - 2^224 - 2^96 + 2^64 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_inv_sm2(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_inv_sm2(uint64_t z[static 4],const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_sm2, i.e. is not divisible
 // by it, returns z < p_sm2 such that x * z == 1 (mod p_sm2). Note that

--- a/x86/sm2/bignum_mod_nsm2.S
+++ b/x86/sm2/bignum_mod_nsm2.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_nsm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_nsm2(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86/sm2/bignum_mod_nsm2_4.S
+++ b/x86/sm2/bignum_mod_nsm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_nsm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_nsm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86/sm2/bignum_mod_nsm2_alt.S
+++ b/x86/sm2/bignum_mod_nsm2_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_nsm2_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_nsm2_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86/sm2/bignum_mod_sm2.S
+++ b/x86/sm2/bignum_mod_sm2.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_sm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_sm2(uint64_t z[static 4], uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86/sm2/bignum_mod_sm2_4.S
+++ b/x86/sm2/bignum_mod_sm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_sm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_sm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/sm2/bignum_montinv_sm2.S
+++ b/x86/sm2/bignum_montinv_sm2.S
@@ -5,7 +5,8 @@
 // Montgomery inverse modulo p_sm2 = 2^256 - 2^224 - 2^96 + 2^64 - 1
 // Input x[4]; output z[4]
 //
-// extern void bignum_montinv_sm2(uint64_t z[static 4],uint64_t x[static 4]);
+// extern void bignum_montinv_sm2(uint64_t z[static 4],
+//                                const uint64_t x[static 4]);
 //
 // If the 4-digit input x is coprime to p_sm2, i.e. is not divisible
 // by it, returns z < p_sm2 such that x * z == 2^512 (mod p_sm2). This

--- a/x86/sm2/bignum_montmul_sm2.S
+++ b/x86/sm2/bignum_montmul_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/x86/sm2/bignum_montmul_sm2_alt.S
+++ b/x86/sm2/bignum_montmul_sm2_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/x86/sm2/bignum_montsqr_sm2.S
+++ b/x86/sm2/bignum_montsqr_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/x86/sm2/bignum_montsqr_sm2_alt.S
+++ b/x86/sm2/bignum_montsqr_sm2_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/x86/sm2/bignum_neg_sm2.S
+++ b/x86/sm2/bignum_neg_sm2.S
@@ -5,7 +5,7 @@
 // Negate modulo p_sm2, z := (-x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_sm2 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/sm2/bignum_optneg_sm2.S
+++ b/x86/sm2/bignum_optneg_sm2.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_sm2
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_sm2(uint64_t z[static 4], uint64_t p,
+//                                  const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86/sm2/bignum_sub_sm2.S
+++ b/x86/sm2/bignum_sub_sm2.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_sm2, z := (x - y) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86/sm2/bignum_tomont_sm2.S
+++ b/x86/sm2/bignum_tomont_sm2.S
@@ -5,8 +5,7 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86/sm2/bignum_triple_sm2.S
+++ b/x86/sm2/bignum_triple_sm2.S
@@ -5,8 +5,7 @@
 // Triple modulo p_sm2, z := (3 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_sm2
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_sm2,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_sm2.

--- a/x86/sm2/bignum_triple_sm2_alt.S
+++ b/x86/sm2/bignum_triple_sm2_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_sm2, z := (3 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_sm2_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_sm2_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_sm2,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjadd.S
+++ b/x86/sm2/sm2_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                             const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjadd_alt.S
+++ b/x86/sm2/sm2_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd_alt(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjdouble.S
+++ b/x86/sm2/sm2_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjdouble_alt.S
+++ b/x86/sm2/sm2_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjmixadd.S
+++ b/x86/sm2/sm2_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12],
+//                                const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjmixadd_alt.S
+++ b/x86/sm2/sm2_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12],
+//                                    const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86/sm2/sm2_montjscalarmul.S
+++ b/x86/sm2/sm2_montjscalarmul.S
@@ -7,8 +7,8 @@
 //
 // extern void sm2_montjscalarmul
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version sm2_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86/sm2/sm2_montjscalarmul_alt.S
+++ b/x86/sm2/sm2_montjscalarmul_alt.S
@@ -7,8 +7,8 @@
 //
 // extern void sm2_montjscalarmul_alt
 //   (uint64_t res[static 12],
-//    uint64_t scalar[static 4],
-//    uint64_t point[static 12]);
+//    const uint64_t scalar[static 4],
+//    const uint64_t point[static 12]);
 //
 // This function is a variant of its affine point version sm2_scalarmul.
 // Here, input and output points are assumed to be in Jacobian form with

--- a/x86_att/curve25519/bignum_add_p25519.S
+++ b/x86_att/curve25519/bignum_add_p25519.S
@@ -5,8 +5,8 @@
 // Add modulo p_25519, z := (x + y) mod p_25519, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/curve25519/bignum_cmul_p25519.S
+++ b/x86_att/curve25519/bignum_cmul_p25519.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p25519
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p25519(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/curve25519/bignum_cmul_p25519_alt.S
+++ b/x86_att/curve25519/bignum_cmul_p25519_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p25519_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p25519_alt(uint64_t z[static 4], uint64_t c,
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/curve25519/bignum_double_p25519.S
+++ b/x86_att/curve25519/bignum_double_p25519.S
@@ -5,8 +5,8 @@
 // Double modulo p_25519, z := (2 * x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p25519(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/curve25519/bignum_madd_n25519.S
+++ b/x86_att/curve25519/bignum_madd_n25519.S
@@ -5,9 +5,9 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4],
+//                                   const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/x86_att/curve25519/bignum_madd_n25519_alt.S
+++ b/x86_att/curve25519/bignum_madd_n25519_alt.S
@@ -5,9 +5,10 @@
 // Multiply-add modulo the order of the curve25519/edwards25519 basepoint
 // Inputs x[4], y[4], c[4]; output z[4]
 //
-//    extern void bignum_madd_n25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4],
-//      uint64_t y[static 4], uint64_t c[static 4]);
+//    extern void bignum_madd_n25519_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4],
+//                                       const uint64_t c[static 4]);
 //
 // Performs z := (x * y + c) mod n_25519, where the modulus is
 // n_25519 = 2^252 + 27742317777372353535851937790883648493, the

--- a/x86_att/curve25519/bignum_mod_m25519_4.S
+++ b/x86_att/curve25519/bignum_mod_m25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod m_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_m25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_m25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of curve25519/edwards25519.
 // This is the full group order, 8 * the standard basepoint order.

--- a/x86_att/curve25519/bignum_mod_n25519.S
+++ b/x86_att/curve25519/bignum_mod_n25519.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n25519
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n25519(uint64_t z[static 4], uint64_t k,
+//                                  const uint64_t *x);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint,
 // which is n_25519 = 2^252 + 27742317777372353535851937790883648493

--- a/x86_att/curve25519/bignum_mod_n25519_4.S
+++ b/x86_att/curve25519/bignum_mod_n25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo basepoint order, z := x mod n_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the order of the curve25519/edwards25519 basepoint.
 //

--- a/x86_att/curve25519/bignum_mod_p25519_4.S
+++ b/x86_att/curve25519/bignum_mod_p25519_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p25519_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p25519_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/curve25519/bignum_mul_p25519.S
+++ b/x86_att/curve25519/bignum_mul_p25519.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/curve25519/bignum_mul_p25519_alt.S
+++ b/x86_att/curve25519/bignum_mul_p25519_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_25519, z := (x * y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/curve25519/bignum_neg_p25519.S
+++ b/x86_att/curve25519/bignum_neg_p25519.S
@@ -5,8 +5,7 @@
 // Negate modulo p_25519, z := (-x) mod p_25519, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/curve25519/bignum_optneg_p25519.S
+++ b/x86_att/curve25519/bignum_optneg_p25519.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p25519
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p25519(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/curve25519/bignum_sqr_p25519.S
+++ b/x86_att/curve25519/bignum_sqr_p25519.S
@@ -5,8 +5,7 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/curve25519/bignum_sqr_p25519_alt.S
+++ b/x86_att/curve25519/bignum_sqr_p25519_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_25519, z := (x^2) mod p_25519
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p25519_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p25519_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/curve25519/bignum_sub_p25519.S
+++ b/x86_att/curve25519/bignum_sub_p25519.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_25519, z := (x - y) mod p_25519
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p25519
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p25519(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/curve25519/edwards25519_encode.S
+++ b/x86_att/curve25519/edwards25519_encode.S
@@ -5,8 +5,8 @@
 // Encode edwards25519 point into compressed form as 256-bit number
 // Input p[8]; output z[32] (bytes)
 //
-//    extern void edwards25519_encode
-//     (uint8_t z[static 32], uint64_t p[static 8]);
+//    extern void edwards25519_encode(uint8_t z[static 32],
+//                                    const uint64_t p[static 8]);
 //
 // This assumes that the input buffer p points to a pair of 256-bit
 // numbers x (at p) and y (at p+4) representing a point (x,y) on the

--- a/x86_att/fastmul/bignum_emontredc_8n.S
+++ b/x86_att/fastmul/bignum_emontredc_8n.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce in 8-digit blocks, results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc_8n
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc_8n(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                        uint64_t w);
 //
 // Functionally equivalent to bignum_emontredc (see that file for more detail).
 // But in general assumes that the input k is a multiple of 8.

--- a/x86_att/fastmul/bignum_kmul_16_32.S
+++ b/x86_att/fastmul/bignum_kmul_16_32.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[16], y[16]; output z[32]; temporary buffer t[>=32]
 //
-//    extern void bignum_kmul_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t y[static 16],
-//      uint64_t t[static 32])
+//    extern void bignum_kmul_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  const uint64_t y[static 16],
+//                                  uint64_t t[static 32]);
 //
 // In this x86 code the final temporary space argument t is unused, but
 // it is retained in the prototype above for API consistency with ARM.

--- a/x86_att/fastmul/bignum_kmul_32_64.S
+++ b/x86_att/fastmul/bignum_kmul_32_64.S
@@ -5,9 +5,10 @@
 // Multiply z := x * y
 // Inputs x[32], y[32]; output z[64]; temporary buffer t[>=96]
 //
-//    extern void bignum_kmul_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t y[static 32],
-//      uint64_t t[static 96])
+//    extern void bignum_kmul_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  const uint64_t y[static 32],
+//                                  uint64_t t[static 96]);
 //
 // This is a Karatsuba-style function multiplying half-sized results
 // internally and using temporary buffer t for intermediate results. The size

--- a/x86_att/fastmul/bignum_ksqr_16_32.S
+++ b/x86_att/fastmul/bignum_ksqr_16_32.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[16]; output z[32]; temporary buffer t[>=24]
 //
-//    extern void bignum_ksqr_16_32
-//     (uint64_t z[static 32], uint64_t x[static 16], uint64_t t[static 24]);
+//    extern void bignum_ksqr_16_32(uint64_t z[static 32],
+//                                  const uint64_t x[static 16],
+//                                  uint64_t t[static 24]);
 //
 // In this x86 code the final temporary space argument t is unused, but
 // it is retained in the prototype above for API consistency with ARM.

--- a/x86_att/fastmul/bignum_ksqr_32_64.S
+++ b/x86_att/fastmul/bignum_ksqr_32_64.S
@@ -5,8 +5,9 @@
 // Square, z := x^2
 // Input x[32]; output z[64]; temporary buffer t[>=72]
 //
-//    extern void bignum_ksqr_32_64
-//     (uint64_t z[static 64], uint64_t x[static 32], uint64_t t[static 72]);
+//    extern void bignum_ksqr_32_64(uint64_t z[static 64],
+//                                  const uint64_t x[static 32],
+//                                  uint64_t t[static 72]);
 //
 // This is a Karatsuba-style function squaring half-sized results
 // and using temporary buffer t for intermediate results. The size of 72

--- a/x86_att/fastmul/bignum_mul_4_8.S
+++ b/x86_att/fastmul/bignum_mul_4_8.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8(uint64_t z[static 8], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_mul_4_8_alt.S
+++ b/x86_att/fastmul/bignum_mul_4_8_alt.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[4], y[4]; output z[8]
 //
-//    extern void bignum_mul_4_8_alt
-//      (uint64_t z[static 8], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_4_8_alt(uint64_t z[static 8], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_mul_6_12.S
+++ b/x86_att/fastmul/bignum_mul_6_12.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12(uint64_t z[static 12], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_mul_6_12_alt.S
+++ b/x86_att/fastmul/bignum_mul_6_12_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[6], y[6]; output z[12]
 //
-//    extern void bignum_mul_6_12_alt
-//     (uint64_t z[static 12], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mul_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_mul_8_16.S
+++ b/x86_att/fastmul/bignum_mul_8_16.S
@@ -5,8 +5,8 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16(uint64_t z[static 16], const uint64_t x[static 8],
+//                                const uint64_t y[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_mul_8_16_alt.S
+++ b/x86_att/fastmul/bignum_mul_8_16_alt.S
@@ -5,8 +5,9 @@
 // Multiply z := x * y
 // Inputs x[8], y[8]; output z[16]
 //
-//    extern void bignum_mul_8_16_alt
-//     (uint64_t z[static 16], uint64_t x[static 8], uint64_t y[static 8]);
+//    extern void bignum_mul_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8],
+//                                    const uint64_t y[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/fastmul/bignum_sqr_4_8.S
+++ b/x86_att/fastmul/bignum_sqr_4_8.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8 (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8(uint64_t z[static 8], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/fastmul/bignum_sqr_4_8_alt.S
+++ b/x86_att/fastmul/bignum_sqr_4_8_alt.S
@@ -5,8 +5,8 @@
 // Square, z := x^2
 // Input x[4]; output z[8]
 //
-//    extern void bignum_sqr_4_8_alt
-//      (uint64_t z[static 8], uint64_t x[static 4]);
+//    extern void bignum_sqr_4_8_alt(uint64_t z[static 8],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/fastmul/bignum_sqr_6_12.S
+++ b/x86_att/fastmul/bignum_sqr_6_12.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12 (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12(uint64_t z[static 12], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/fastmul/bignum_sqr_6_12_alt.S
+++ b/x86_att/fastmul/bignum_sqr_6_12_alt.S
@@ -5,7 +5,8 @@
 // Square, z := x^2
 // Input x[6]; output z[12]
 //
-//    extern void bignum_sqr_6_12_alt (uint64_t z[static 12], uint64_t x[static 6]);
+//    extern void bignum_sqr_6_12_alt(uint64_t z[static 12],
+//                                    const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/fastmul/bignum_sqr_8_16.S
+++ b/x86_att/fastmul/bignum_sqr_8_16.S
@@ -5,7 +5,7 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16 (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16(uint64_t z[static 16], const uint64_t x[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/fastmul/bignum_sqr_8_16_alt.S
+++ b/x86_att/fastmul/bignum_sqr_8_16_alt.S
@@ -5,7 +5,8 @@
 // Square, z := x^2
 // Input x[8]; output z[16]
 //
-//    extern void bignum_sqr_8_16_alt (uint64_t z[static 16], uint64_t x[static 8]);
+//    extern void bignum_sqr_8_16_alt(uint64_t z[static 16],
+//                                    const uint64_t x[static 8]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/generic/bignum_add.S
+++ b/x86_att/generic/bignum_add.S
@@ -5,9 +5,8 @@
 // Add, z := x + y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_add
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_add(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x + y operation, truncating modulo p words in general and
 // returning a top carry (0 or 1) in the p'th place, only adding the input

--- a/x86_att/generic/bignum_amontifier.S
+++ b/x86_att/generic/bignum_amontifier.S
@@ -5,8 +5,8 @@
 // Compute "amontification" constant z :== 2^{128k} (congruent mod m)
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_amontifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_amontifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                  uint64_t *t);
 //
 // This is called "amontifier" because any other value x can now be mapped into
 // the almost-Montgomery domain with an almost-Montgomery multiplication by z.

--- a/x86_att/generic/bignum_amontmul.S
+++ b/x86_att/generic/bignum_amontmul.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery multiply, z :== (x * y / 2^{64k}) (congruent mod m)
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_amontmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_amontmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *y, const uint64_t *m);
 //
 // Does z :== (x * y / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/x86_att/generic/bignum_amontredc.S
+++ b/x86_att/generic/bignum_amontredc.S
@@ -5,9 +5,8 @@
 // Almost-Montgomery reduce, z :== (x' / 2^{64p}) (congruent mod m)
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_amontredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_amontredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                 const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a :== (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x. That is, p-fold almost-Montgomery reduction

--- a/x86_att/generic/bignum_amontsqr.S
+++ b/x86_att/generic/bignum_amontsqr.S
@@ -5,8 +5,8 @@
 // Almost-Montgomery square, z :== (x^2 / 2^{64k}) (congruent mod m)
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_amontsqr
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_amontsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                const uint64_t *m);
 //
 // Does z :== (x^2 / 2^{64k}) mod m, meaning that the result, in the native
 // size k, is congruent modulo m, but might not be fully reduced mod m. This

--- a/x86_att/generic/bignum_bitfield.S
+++ b/x86_att/generic/bignum_bitfield.S
@@ -5,8 +5,8 @@
 // Select bitfield starting at bit n with length l <= 64
 // Inputs x[k], n, l; output function return
 //
-//    extern uint64_t bignum_bitfield
-//     (uint64_t k, uint64_t *x, uint64_t n, uint64_t l);
+//    extern uint64_t bignum_bitfield(uint64_t k, const uint64_t *x, uint64_t n,
+//                                    uint64_t l);
 //
 // One-word bitfield from a k-digit (digit=64 bits) bignum, in constant-time
 // style. Bitfield starts at bit n and has length l, indexing from 0 (=LSB).

--- a/x86_att/generic/bignum_bitsize.S
+++ b/x86_att/generic/bignum_bitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_bitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_bitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/x86_att/generic/bignum_cdiv.S
+++ b/x86_att/generic/bignum_cdiv.S
@@ -5,8 +5,8 @@
 // Divide by a single (nonzero) word, z := x / m and return x mod m
 // Inputs x[n], m; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_cdiv
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cdiv(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits, result z is k.
 // Truncates the quotient in general, but always (for nonzero m) returns

--- a/x86_att/generic/bignum_cdiv_exact.S
+++ b/x86_att/generic/bignum_cdiv_exact.S
@@ -5,8 +5,8 @@
 // Divide by a single word, z := x / m *when known to be exact*
 // Inputs x[n], m; output z[k]
 //
-//    extern void bignum_cdiv_exact
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t m);
+//    extern void bignum_cdiv_exact(uint64_t k, uint64_t *z, uint64_t n,
+//                                  const uint64_t *x, uint64_t m);
 //
 // Does the "z := x / m" operation where x is n digits and result z is k,
 // *assuming* that m is nonzero and that the input x is in fact an

--- a/x86_att/generic/bignum_cld.S
+++ b/x86_att/generic/bignum_cld.S
@@ -5,7 +5,7 @@
 // Count leading zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_cld (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_cld(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/x86_att/generic/bignum_clz.S
+++ b/x86_att/generic/bignum_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_clz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_clz(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 64 * k
 //

--- a/x86_att/generic/bignum_cmadd.S
+++ b/x86_att/generic/bignum_cmadd.S
@@ -5,8 +5,8 @@
 // Multiply-add with single-word multiplier, z := z + c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                 const uint64_t *y);
 //
 // Does the "z := z + c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/x86_att/generic/bignum_cmnegadd.S
+++ b/x86_att/generic/bignum_cmnegadd.S
@@ -5,8 +5,8 @@
 // Negated multiply-add with single-word multiplier, z := z - c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmnegadd
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmnegadd(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                    const uint64_t *y);
 //
 // Does the "z := z - c * y" operation where y is n digits, result z is p.
 // Truncates the result in general.

--- a/x86_att/generic/bignum_cmod.S
+++ b/x86_att/generic/bignum_cmod.S
@@ -5,7 +5,7 @@
 // Find bignum modulo a single word
 // Input x[k], m; output function return
 //
-//    extern uint64_t bignum_cmod (uint64_t k, uint64_t *x, uint64_t m);
+//    extern uint64_t bignum_cmod(uint64_t k, const uint64_t *x, uint64_t m);
 //
 // Returns x mod m, assuming m is nonzero.
 //

--- a/x86_att/generic/bignum_cmul.S
+++ b/x86_att/generic/bignum_cmul.S
@@ -5,8 +5,8 @@
 // Multiply by a single word, z := c * y
 // Inputs c, y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_cmul
-//     (uint64_t k, uint64_t *z, uint64_t c, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_cmul(uint64_t k, uint64_t *z, uint64_t c, uint64_t n,
+//                                const uint64_t *y);
 //
 // Does the "z := c * y" operation where y is n digits, result z is p.
 // Truncates the result in general unless p >= n + 1.

--- a/x86_att/generic/bignum_coprime.S
+++ b/x86_att/generic/bignum_coprime.S
@@ -5,8 +5,8 @@
 // Test bignums for coprimality, gcd(x,y) = 1
 // Inputs x[m], y[n]; output function return; temporary buffer t[>=2*max(m,n)]
 //
-//    extern uint64_t bignum_coprime
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y, uint64_t *t);
+//    extern uint64_t bignum_coprime(uint64_t m, const uint64_t *x, uint64_t n,
+//                                   const uint64_t *y, uint64_t *t);
 //
 // Test for whether two bignums are coprime (no common factor besides 1).
 // This is equivalent to testing if their gcd is 1, but a bit faster than

--- a/x86_att/generic/bignum_copy.S
+++ b/x86_att/generic/bignum_copy.S
@@ -5,8 +5,7 @@
 // Copy bignum with zero-extension or truncation, z := x
 // Input x[n]; output z[k]
 //
-//    extern void bignum_copy
-//      (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_copy(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = n, RCX = x
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = n, R9 = x

--- a/x86_att/generic/bignum_ctd.S
+++ b/x86_att/generic/bignum_ctd.S
@@ -5,7 +5,7 @@
 // Count trailing zero digits (64-bit words)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctd(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is k
 //

--- a/x86_att/generic/bignum_ctz.S
+++ b/x86_att/generic/bignum_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_ctz (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_ctz(uint64_t k, const uint64_t *x);
 //
 //
 // In the case of a zero bignum as input the result is 64 * k

--- a/x86_att/generic/bignum_demont.S
+++ b/x86_att/generic/bignum_demont.S
@@ -5,8 +5,8 @@
 // Convert from (almost-)Montgomery form z := (x / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_demont
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_demont(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *m);
 //
 // Does z := (x / 2^{64k}) mod m, hence mapping out of Montgomery domain.
 // In other words, this is a k-fold Montgomery reduction with same-size input.

--- a/x86_att/generic/bignum_digit.S
+++ b/x86_att/generic/bignum_digit.S
@@ -5,7 +5,7 @@
 // Select digit x[n]
 // Inputs x[k], n; output function return
 //
-//    extern uint64_t bignum_digit (uint64_t k, uint64_t *x, uint64_t n);
+//    extern uint64_t bignum_digit(uint64_t k, const uint64_t *x, uint64_t n);
 //
 // n'th digit of a k-digit (digit=64 bits) bignum, in constant-time style.
 // Indexing starts at 0, which is the least significant digit (little-endian).

--- a/x86_att/generic/bignum_digitsize.S
+++ b/x86_att/generic/bignum_digitsize.S
@@ -5,7 +5,7 @@
 // Return size of bignum in digits (64-bit word)
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_digitsize (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_digitsize(uint64_t k, const uint64_t *x);
 //
 // In the case of a zero bignum as input the result is 0
 //

--- a/x86_att/generic/bignum_divmod10.S
+++ b/x86_att/generic/bignum_divmod10.S
@@ -5,7 +5,7 @@
 // Divide bignum by 10: z' := z div 10, returning remainder z mod 10
 // Inputs z[k]; outputs function return (remainder) and z[k]
 //
-//    extern uint64_t bignum_divmod10 (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_divmod10(uint64_t k, uint64_t *z);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = z, returns RAX

--- a/x86_att/generic/bignum_emontredc.S
+++ b/x86_att/generic/bignum_emontredc.S
@@ -5,8 +5,8 @@
 // Extended Montgomery reduce, returning results in input-output buffer
 // Inputs z[2*k], m[k], w; outputs function return (extra result bit) and z[2*k]
 //
-//    extern uint64_t bignum_emontredc
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t w);
+//    extern uint64_t bignum_emontredc(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                     uint64_t w);
 //
 // Assumes that z initially holds a 2k-digit bignum z_0, m is a k-digit odd
 // bignum and m * w == -1 (mod 2^64). This function also uses z for the output

--- a/x86_att/generic/bignum_eq.S
+++ b/x86_att/generic/bignum_eq.S
@@ -5,8 +5,8 @@
 // Test bignums for equality, x = y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_eq
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_eq(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86_att/generic/bignum_even.S
+++ b/x86_att/generic/bignum_even.S
@@ -5,7 +5,7 @@
 // Test bignum for even-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_even (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_even(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86_att/generic/bignum_ge.S
+++ b/x86_att/generic/bignum_ge.S
@@ -5,8 +5,8 @@
 // Compare bignums, x >= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_ge
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_ge(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86_att/generic/bignum_gt.S
+++ b/x86_att/generic/bignum_gt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x > y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_gt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_gt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86_att/generic/bignum_iszero.S
+++ b/x86_att/generic/bignum_iszero.S
@@ -5,7 +5,7 @@
 // Test bignum for zero-ness, x = 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_iszero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_iszero(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86_att/generic/bignum_le.S
+++ b/x86_att/generic/bignum_le.S
@@ -5,8 +5,8 @@
 // Compare bignums, x <= y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_le
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_le(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86_att/generic/bignum_lt.S
+++ b/x86_att/generic/bignum_lt.S
@@ -5,8 +5,8 @@
 // Compare bignums, x < y
 // Inputs x[m], y[n]; output function return
 //
-//    extern uint64_t bignum_lt
-//     (uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_lt(uint64_t m, const uint64_t *x, uint64_t n,
+//                              const uint64_t *y);
 //
 // Standard x86-64 ABI: RDI = m, RSI = x, RDX = n, RCX = y, returns RAX
 // Microsoft x64 ABI:   RCX = m, RDX = x, R8 = n, R9 = y, returns RAX

--- a/x86_att/generic/bignum_madd.S
+++ b/x86_att/generic/bignum_madd.S
@@ -5,9 +5,8 @@
 // Multiply-add, z := z + x * y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_madd
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_madd(uint64_t k, uint64_t *z, uint64_t m,
+//                                const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y + z" operation, while also returning a "next" or
 // "carry" word. In the case where m + n <= p (i.e. the pure product would

--- a/x86_att/generic/bignum_modadd.S
+++ b/x86_att/generic/bignum_modadd.S
@@ -5,8 +5,8 @@
 // Add modulo m, z := (x + y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = y, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = y, [RSP+40] = m

--- a/x86_att/generic/bignum_moddouble.S
+++ b/x86_att/generic/bignum_moddouble.S
@@ -5,8 +5,8 @@
 // Double modulo m, z := (2 * x) mod m, assuming x reduced
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_moddouble
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_moddouble(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                 const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = m

--- a/x86_att/generic/bignum_modifier.S
+++ b/x86_att/generic/bignum_modifier.S
@@ -5,8 +5,8 @@
 // Compute "modification" constant z := 2^{64k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_modifier
-//     (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_modifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "mod-ifier" because given any other k-digit number x we can

--- a/x86_att/generic/bignum_modinv.S
+++ b/x86_att/generic/bignum_modinv.S
@@ -5,8 +5,8 @@
 // Invert modulo m, z = (1/a) mod b, assuming b is an odd number > 1, coprime a
 // Inputs a[k], b[k]; output z[k]; temporary buffer t[>=3*k]
 //
-//    extern void bignum_modinv
-//     (uint64_t k, uint64_t *z, uint64_t *a, uint64_t *b, uint64_t *t);
+//    extern void bignum_modinv(uint64_t k, uint64_t *z, const uint64_t *a,
+//                              const uint64_t *b, uint64_t *t);
 //
 // k-digit (digit=64 bits) "z := a^-1 mod b" (modular inverse of a modulo b)
 // using t as a temporary buffer (t at least 3*k words = 24*k bytes), and

--- a/x86_att/generic/bignum_modoptneg.S
+++ b/x86_att/generic/bignum_modoptneg.S
@@ -6,8 +6,8 @@
 // (if p zero), assuming x reduced
 // Inputs p, x[k], m[k]; output z[k]
 //
-//    extern void bignum_modoptneg
-//      (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x, uint64_t *m);
+//    extern void bignum_modoptneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                 const uint64_t *x, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = p, RCX = x, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = p, R9 = x, [RSP+40] = m

--- a/x86_att/generic/bignum_modsub.S
+++ b/x86_att/generic/bignum_modsub.S
@@ -5,8 +5,8 @@
 // Subtract modulo m, z := (x - y) mod m, assuming x and y reduced
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_modsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_modsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                              const uint64_t *y, const uint64_t *m);
 //
 // Standard x86-64 ABI: RDI = k, RSI = z, RDX = x, RCX = y, R8 = m
 // Microsoft x64 ABI:   RCX = k, RDX = z, R8 = x, R9 = y, [RSP+40] = m

--- a/x86_att/generic/bignum_montifier.S
+++ b/x86_att/generic/bignum_montifier.S
@@ -5,8 +5,8 @@
 // Compute "montification" constant z := 2^{128k} mod m
 // Input m[k]; output z[k]; temporary buffer t[>=k]
 //
-//    extern void bignum_montifier
-//      (uint64_t k, uint64_t *z, uint64_t *m, uint64_t *t);
+//    extern void bignum_montifier(uint64_t k, uint64_t *z, const uint64_t *m,
+//                                 uint64_t *t);
 //
 // The last argument points to a temporary buffer t that should have size >= k.
 // This is called "montifier" because given any other k-digit number x,

--- a/x86_att/generic/bignum_montmul.S
+++ b/x86_att/generic/bignum_montmul.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^{64k}) mod m
 // Inputs x[k], y[k], m[k]; output z[k]
 //
-//    extern void bignum_montmul
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y, uint64_t *m);
+//    extern void bignum_montmul(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *y, const uint64_t *m);
 //
 // Does z := (x * y / 2^{64k}) mod m, assuming x * y <= 2^{64k} * m, which is
 // guaranteed in particular if x < m, y < m initially (the "intended" case).

--- a/x86_att/generic/bignum_montredc.S
+++ b/x86_att/generic/bignum_montredc.S
@@ -5,9 +5,8 @@
 // Montgomery reduce, z := (x' / 2^{64p}) MOD m
 // Inputs x[n], m[k], p; output z[k]
 //
-//    extern void bignum_montredc
-//     (uint64_t k, uint64_t *z,
-//      uint64_t n, uint64_t *x, uint64_t *m, uint64_t p);
+//    extern void bignum_montredc(uint64_t k, uint64_t *z, uint64_t n,
+//                                const uint64_t *x, const uint64_t *m, uint64_t p);
 //
 // Does a := (x' / 2^{64p}) mod m where x' = x if n <= p + k and in general
 // is the lowest (p+k) digits of x, assuming x' <= 2^{64p} * m. That is,

--- a/x86_att/generic/bignum_montsqr.S
+++ b/x86_att/generic/bignum_montsqr.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^{64k}) mod m
 // Inputs x[k], m[k]; output z[k]
 //
-//    extern void bignum_montsqr
-//      (uint64_t k, uint64_t *z, uint64_t *x, uint64_t *m);
+//    extern void bignum_montsqr(uint64_t k, uint64_t *z, const uint64_t *x,
+//                               const uint64_t *m);
 //
 // Does z := (x^2 / 2^{64k}) mod m, assuming x^2 <= 2^{64k} * m, which is
 // guaranteed in particular if x < m initially (the "intended" case).

--- a/x86_att/generic/bignum_mul.S
+++ b/x86_att/generic/bignum_mul.S
@@ -5,9 +5,8 @@
 // Multiply z := x * y
 // Inputs x[m], y[n]; output z[k]
 //
-//    extern void bignum_mul
-//     (uint64_t k, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern void bignum_mul(uint64_t k, uint64_t *z, uint64_t m, const uint64_t *x,
+//                           uint64_t n, const uint64_t *y);
 //
 // Does the "z := x * y" operation where x is m digits, y is n, result z is k.
 // Truncates the result in general unless k >= m + n

--- a/x86_att/generic/bignum_muladd10.S
+++ b/x86_att/generic/bignum_muladd10.S
@@ -5,7 +5,7 @@
 // Multiply bignum by 10 and add word: z := 10 * z + d
 // Inputs z[k], d; outputs function return (carry) and z[k]
 //
-//    extern uint64_t bignum_muladd10 (uint64_t k, uint64_t *z, uint64_t d);
+//    extern uint64_t bignum_muladd10(uint64_t k, uint64_t *z, uint64_t d);
 //
 // Although typically the input d < 10, this is not actually required.
 //

--- a/x86_att/generic/bignum_mux.S
+++ b/x86_att/generic/bignum_mux.S
@@ -5,8 +5,8 @@
 // Multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[k], y[k]; output z[k]
 //
-//    extern void bignum_mux
-//     (uint64_t p, uint64_t k, uint64_t *z, uint64_t *x, uint64_t *y);
+//    extern void bignum_mux(uint64_t p, uint64_t k, uint64_t *z, const uint64_t *x,
+//                           const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 //

--- a/x86_att/generic/bignum_mux16.S
+++ b/x86_att/generic/bignum_mux16.S
@@ -5,8 +5,8 @@
 // Select element from 16-element table, z := xs[k*i]
 // Inputs xs[16*k], i; output z[k]
 //
-//    extern void bignum_mux16
-//     (uint64_t k, uint64_t *z, uint64_t *xs, uint64_t i);
+//    extern void bignum_mux16(uint64_t k, uint64_t *z, const uint64_t *xs,
+//                             uint64_t i);
 //
 // It is assumed that all numbers xs[16] and the target z have the same size k
 // The pointer xs is to a contiguous array of size 16, elements size-k bignums

--- a/x86_att/generic/bignum_negmodinv.S
+++ b/x86_att/generic/bignum_negmodinv.S
@@ -5,8 +5,7 @@
 // Negated modular inverse, z := (-1/x) mod 2^{64k}
 // Input x[k]; output z[k]
 //
-//    extern void bignum_negmodinv
-//     (uint64_t k, uint64_t *z, uint64_t *x);
+//    extern void bignum_negmodinv(uint64_t k, uint64_t *z, const uint64_t *x);
 //
 // Assuming x is odd (otherwise nothing makes sense) the result satisfies
 //

--- a/x86_att/generic/bignum_nonzero.S
+++ b/x86_att/generic/bignum_nonzero.S
@@ -5,7 +5,7 @@
 // Test bignum for nonzero-ness x =/= 0
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_nonzero (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_nonzero(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86_att/generic/bignum_normalize.S
+++ b/x86_att/generic/bignum_normalize.S
@@ -5,7 +5,7 @@
 // Normalize bignum in-place by shifting left till top bit is 1
 // Input z[k]; outputs function return (bits shifted left) and z[k]
 //
-//    extern uint64_t bignum_normalize (uint64_t k, uint64_t *z);
+//    extern uint64_t bignum_normalize(uint64_t k, uint64_t *z);
 //
 // Given a k-digit bignum z, this function shifts it left by its number of
 // leading zero bits, to give result with top bit 1, unless the input number

--- a/x86_att/generic/bignum_odd.S
+++ b/x86_att/generic/bignum_odd.S
@@ -5,7 +5,7 @@
 // Test bignum for odd-ness
 // Input x[k]; output function return
 //
-//    extern uint64_t bignum_odd (uint64_t k, uint64_t *x);
+//    extern uint64_t bignum_odd(uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = k, RSI = x, returns RAX
 // Microsoft x64 ABI:   RCX = k, RDX = x, returns RAX

--- a/x86_att/generic/bignum_of_word.S
+++ b/x86_att/generic/bignum_of_word.S
@@ -5,7 +5,7 @@
 // Convert single digit to bignum, z := n
 // Input n; output z[k]
 //
-//    extern void bignum_of_word (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_of_word(uint64_t k, uint64_t *z, uint64_t n);
 //
 // Create a k-digit (digit=64 bits) bignum at z with value n (mod 2^k)
 // where n is a word. The "mod 2^k" only matters in the degenerate k = 0 case.

--- a/x86_att/generic/bignum_optadd.S
+++ b/x86_att/generic/bignum_optadd.S
@@ -5,8 +5,8 @@
 // Optionally add, z := x + y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual addition, always 0 if p was zero.

--- a/x86_att/generic/bignum_optneg.S
+++ b/x86_att/generic/bignum_optneg.S
@@ -5,8 +5,8 @@
 // Optionally negate, z := -x (if p nonzero) or z := x (if p zero)
 // Inputs p, x[k]; outputs function return (nonzero input) and z[k]
 //
-//    extern uint64_t bignum_optneg
-//     (uint64_t k, uint64_t *z, uint64_t p, uint64_t *x);
+//    extern uint64_t bignum_optneg(uint64_t k, uint64_t *z, uint64_t p,
+//                                  const uint64_t *x);
 //
 // It is assumed that both numbers x and z have the same size k digits.
 // Returns a carry, which is equivalent to "x is nonzero".

--- a/x86_att/generic/bignum_optsub.S
+++ b/x86_att/generic/bignum_optsub.S
@@ -5,8 +5,8 @@
 // Optionally subtract, z := x - y (if p nonzero) or z := x (if p zero)
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsub
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsub(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                  uint64_t p, const uint64_t *y);
 //
 // It is assumed that all numbers x, y and z have the same size k digits.
 // Returns carry-out as per usual subtraction, always 0 if p was zero.

--- a/x86_att/generic/bignum_optsubadd.S
+++ b/x86_att/generic/bignum_optsubadd.S
@@ -5,8 +5,8 @@
 // Optionally subtract or add, z := x + sgn(p) * y interpreting p as signed
 // Inputs x[k], p, y[k]; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_optsubadd
-//     (uint64_t k, uint64_t *z, uint64_t *x, uint64_t p, uint64_t *y);
+//    extern uint64_t bignum_optsubadd(uint64_t k, uint64_t *z, const uint64_t *x,
+//                                     uint64_t p, const uint64_t *y);
 //
 // If p has top bit set (i.e. is negative as a signed int) return z := x - y
 // Else if p is nonzero (i.e. is positive as a signed int) return z := x + y

--- a/x86_att/generic/bignum_pow2.S
+++ b/x86_att/generic/bignum_pow2.S
@@ -5,7 +5,7 @@
 // Return bignum of power of 2, z := 2^n
 // Input n; output z[k]
 //
-//    extern void bignum_pow2 (uint64_t k, uint64_t *z, uint64_t n);
+//    extern void bignum_pow2(uint64_t k, uint64_t *z, uint64_t n);
 //
 // The result is as usual mod 2^{64*k}, so will be zero if n >= 64*k.
 //

--- a/x86_att/generic/bignum_shl_small.S
+++ b/x86_att/generic/bignum_shl_small.S
@@ -5,8 +5,8 @@
 // Shift bignum left by c < 64 bits z := x * 2^c
 // Inputs x[n], c; outputs function return (carry-out) and z[k]
 //
-//    extern uint64_t bignum_shl_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shl_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x << c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/x86_att/generic/bignum_shr_small.S
+++ b/x86_att/generic/bignum_shr_small.S
@@ -5,8 +5,8 @@
 // Shift bignum right by c < 64 bits z := floor(x / 2^c)
 // Inputs x[n], c; outputs function return (bits shifted out) and z[k]
 //
-//    extern uint64_t bignum_shr_small
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x, uint64_t c);
+//    extern uint64_t bignum_shr_small(uint64_t k, uint64_t *z, uint64_t n,
+//                                     const uint64_t *x, uint64_t c);
 //
 // Does the "z := x >> c" operation where x is n digits, result z is p.
 // The shift count c is masked to 6 bits so it actually uses c' = c mod 64.

--- a/x86_att/generic/bignum_sqr.S
+++ b/x86_att/generic/bignum_sqr.S
@@ -5,8 +5,7 @@
 // Square z := x^2
 // Input x[n]; output z[k]
 //
-//    extern void bignum_sqr
-//     (uint64_t k, uint64_t *z, uint64_t n, uint64_t *x);
+//    extern void bignum_sqr(uint64_t k, uint64_t *z, uint64_t n, const uint64_t *x);
 //
 // Does the "z := x^2" operation where x is n digits and result z is k.
 // Truncates the result in general unless k >= 2 * n

--- a/x86_att/generic/bignum_sub.S
+++ b/x86_att/generic/bignum_sub.S
@@ -5,9 +5,8 @@
 // Subtract, z := x - y
 // Inputs x[m], y[n]; outputs function return (carry-out) and z[p]
 //
-//    extern uint64_t bignum_sub
-//     (uint64_t p, uint64_t *z,
-//      uint64_t m, uint64_t *x, uint64_t n, uint64_t *y);
+//    extern uint64_t bignum_sub(uint64_t p, uint64_t *z, uint64_t m,
+//                               const uint64_t *x, uint64_t n, const uint64_t *y);
 //
 // Does the z := x - y operation, truncating modulo p words in general and
 // returning a top borrow (0 or 1) in the p'th place, only subtracting input

--- a/x86_att/generic/word_bytereverse.S
+++ b/x86_att/generic/word_bytereverse.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Reverse the order of bytes in a 64-bit word
 //
-//    extern uint64_t word_bytereverse (uint64_t a);
+//    extern uint64_t word_bytereverse(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86_att/generic/word_clz.S
+++ b/x86_att/generic/word_clz.S
@@ -5,7 +5,7 @@
 // Count leading zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_clz (uint64_t a);
+//    extern uint64_t word_clz(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86_att/generic/word_ctz.S
+++ b/x86_att/generic/word_ctz.S
@@ -5,7 +5,7 @@
 // Count trailing zero bits in a single word
 // Input a; output function return
 //
-//    extern uint64_t word_ctz (uint64_t a);
+//    extern uint64_t word_ctz(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86_att/generic/word_max.S
+++ b/x86_att/generic/word_max.S
@@ -5,7 +5,7 @@
 // Return maximum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_max (uint64_t a, uint64_t b);
+//    extern uint64_t word_max(uint64_t a, uint64_t b);
 //
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX

--- a/x86_att/generic/word_min.S
+++ b/x86_att/generic/word_min.S
@@ -5,7 +5,7 @@
 // Return minimum of two unsigned 64-bit words
 // Inputs a, b; output function return
 //
-//    extern uint64_t word_min (uint64_t a, uint64_t b);
+//    extern uint64_t word_min(uint64_t a, uint64_t b);
 //
 // Standard x86-64 ABI: RDI = a, RSI = b, returns RAX
 // Microsoft x64 ABI:   RCX = a, RDX = b, returns RAX

--- a/x86_att/generic/word_negmodinv.S
+++ b/x86_att/generic/word_negmodinv.S
@@ -5,7 +5,7 @@
 // Single-word negated modular inverse (-1/a) mod 2^64
 // Input a; output function return
 //
-//    extern uint64_t word_negmodinv (uint64_t a);
+//    extern uint64_t word_negmodinv(uint64_t a);
 //
 // A 64-bit function that returns a negated multiplicative inverse mod 2^64
 // of its input, assuming that input is odd. Given odd input a, the result z

--- a/x86_att/generic/word_popcount.S
+++ b/x86_att/generic/word_popcount.S
@@ -5,7 +5,7 @@
 // Count number of set bits in a single 64-bit word (population count)
 // Input a; output function return
 //
-//    extern uint64_t word_popcount (uint64_t a);
+//    extern uint64_t word_popcount(uint64_t a);
 //
 // Standard x86-64 ABI: RDI = a, returns RAX
 // Microsoft x64 ABI:   RCX = a, returns RAX

--- a/x86_att/generic/word_recip.S
+++ b/x86_att/generic/word_recip.S
@@ -5,7 +5,7 @@
 // Single-word reciprocal, underestimate of 2^128 / a with implicit 1 added
 // Input a; output function return
 //
-//    extern uint64_t word_recip (uint64_t a);
+//    extern uint64_t word_recip(uint64_t a);
 //
 // Given an input word "a" with its top bit set (i.e. 2^63 <= a < 2^64), the
 // result "x" is implicitly augmented with a leading 1 giving x' = 2^64 + x.

--- a/x86_att/p256/bignum_add_p256.S
+++ b/x86_att/p256/bignum_add_p256.S
@@ -5,8 +5,8 @@
 // Add modulo p_256, z := (x + y) mod p_256, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p256/bignum_bigendian_4.S
+++ b/x86_att/p256/bignum_bigendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from big-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_bigendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_bigendian_4(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_frombebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tobebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tobebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // Since x86 is little-endian, and bignums are stored with little-endian
 // word order, this is simply byte reversal and is implemented as such.

--- a/x86_att/p256/bignum_cmul_p256.S
+++ b/x86_att/p256/bignum_cmul_p256.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256(uint64_t z[static 4], uint64_t c,
+//                                 const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p256/bignum_cmul_p256_alt.S
+++ b/x86_att/p256/bignum_cmul_p256_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256_alt(uint64_t z[static 4], uint64_t c,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p256/bignum_deamont_p256.S
+++ b/x86_att/p256/bignum_deamont_p256.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86_att/p256/bignum_deamont_p256_alt.S
+++ b/x86_att/p256/bignum_deamont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86_att/p256/bignum_demont_p256.S
+++ b/x86_att/p256/bignum_demont_p256.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p256" instead.

--- a/x86_att/p256/bignum_demont_p256_alt.S
+++ b/x86_att/p256/bignum_demont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p256" instead.

--- a/x86_att/p256/bignum_double_p256.S
+++ b/x86_att/p256/bignum_double_p256.S
@@ -5,8 +5,8 @@
 // Double modulo p_256, z := (2 * x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_half_p256.S
+++ b/x86_att/p256/bignum_half_p256.S
@@ -5,8 +5,7 @@
 // Halve modulo p_256, z := (x / 2) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_littleendian_4.S
+++ b/x86_att/p256/bignum_littleendian_4.S
@@ -5,17 +5,17 @@
 // Convert 4-digit (256-bit) bignum to/from little-endian form
 // Input x[4]; output z[4]
 //
-//    extern void bignum_littleendian_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_littleendian_4(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_4
-//     (uint64_t z[static 4], uint8_t x[static 32]);
+//    extern void bignum_fromlebytes_4(uint64_t z[static 4],
+//                                     const uint8_t x[static 32]);
 //
-//    extern void bignum_tolebytes_4
-//     (uint8_t z[static 32], uint64_t x[static 4]);
+//    extern void bignum_tolebytes_4(uint8_t z[static 32],
+//                                   const uint64_t x[static 4]);
 //
 // Since x86 is little-endian, this is just copying.
 //

--- a/x86_att/p256/bignum_mod_n256.S
+++ b/x86_att/p256/bignum_mod_n256.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86_att/p256/bignum_mod_n256_4.S
+++ b/x86_att/p256/bignum_mod_n256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86_att/p256/bignum_mod_n256_alt.S
+++ b/x86_att/p256/bignum_mod_n256_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_n256_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n256_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-256.
 //

--- a/x86_att/p256/bignum_mod_p256.S
+++ b/x86_att/p256/bignum_mod_p256.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_p256
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p256(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86_att/p256/bignum_mod_p256_4.S
+++ b/x86_att/p256/bignum_mod_p256_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_mod_p256_alt.S
+++ b/x86_att/p256/bignum_mod_p256_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_p256_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p256_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86_att/p256/bignum_montmul_p256.S
+++ b/x86_att/p256/bignum_montmul_p256.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4],
+//                                    const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/x86_att/p256/bignum_montmul_p256_alt.S
+++ b/x86_att/p256/bignum_montmul_p256_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4],
+//                                        const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256 (in particular this is true if we are in

--- a/x86_att/p256/bignum_montsqr_p256.S
+++ b/x86_att/p256/bignum_montsqr_p256.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/x86_att/p256/bignum_montsqr_p256_alt.S
+++ b/x86_att/p256/bignum_montsqr_p256_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256_alt(uint64_t z[static 4],
+//                                        const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256, assuming x^2 <= 2^256 * p_256, which is
 // guaranteed in particular if x < p_256 initially (the "intended" case).

--- a/x86_att/p256/bignum_mux_4.S
+++ b/x86_att/p256/bignum_mux_4.S
@@ -5,9 +5,9 @@
 // 256-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[4], y[4]; output z[4]
 //
-//    extern void bignum_mux_4
-//     (uint64_t p, uint64_t z[static 4],
-//      uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mux_4(uint64_t p, uint64_t z[static 4],
+//                             const uint64_t x[static 4],
+//                             const uint64_t y[static 4]);
 //
 // It is assumed that all numbers x, y and z have the same size 4 digits.
 //

--- a/x86_att/p256/bignum_neg_p256.S
+++ b/x86_att/p256/bignum_neg_p256.S
@@ -5,7 +5,7 @@
 // Negate modulo p_256, z := (-x) mod p_256, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_nonzero_4.S
+++ b/x86_att/p256/bignum_nonzero_4.S
@@ -5,7 +5,7 @@
 // 256-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[4]; output function return
 //
-//    extern uint64_t bignum_nonzero_4(uint64_t x[static 4]);
+//    extern uint64_t bignum_nonzero_4(const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // Microsoft x64 ABI:   RCX = x, returns RAX

--- a/x86_att/p256/bignum_optneg_p256.S
+++ b/x86_att/p256/bignum_optneg_p256.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256(uint64_t z[static 4], uint64_t p,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/p256/bignum_sub_p256.S
+++ b/x86_att/p256/bignum_sub_p256.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256, z := (x - y) mod p_256
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256(uint64_t z[static 4], const uint64_t x[static 4],
+//                                const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p256/bignum_tomont_p256.S
+++ b/x86_att/p256/bignum_tomont_p256.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_tomont_p256_alt.S
+++ b/x86_att/p256/bignum_tomont_p256_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p256/bignum_triple_p256.S
+++ b/x86_att/p256/bignum_triple_p256.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_256,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_256.

--- a/x86_att/p256/bignum_triple_p256_alt.S
+++ b/x86_att/p256/bignum_triple_p256_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256, z := (3 * x) mod p_256
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_256,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_256.

--- a/x86_att/p256/p256_montjadd.S
+++ b/x86_att/p256/p256_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                              const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p256/p256_montjadd_alt.S
+++ b/x86_att/p256/p256_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void p256_montjadd_alt(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p256/p256_montjdouble.S
+++ b/x86_att/p256/p256_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p256/p256_montjdouble_alt.S
+++ b/x86_att/p256/p256_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void p256_montjdouble_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p256/p256_montjmixadd.S
+++ b/x86_att/p256/p256_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p256/p256_montjmixadd_alt.S
+++ b/x86_att/p256/p256_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-256 in Montgomery-Jacobian coordinates
 //
-//    extern void p256_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void p256_montjmixadd_alt(uint64_t p3[static 12],
+//                                     const uint64_t p1[static 12],
+//                                     const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_256.

--- a/x86_att/p384/bignum_add_p384.S
+++ b/x86_att/p384/bignum_add_p384.S
@@ -5,8 +5,8 @@
 // Add modulo p_384, z := (x + y) mod p_384, assuming x and y reduced
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_add_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_add_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p384/bignum_bigendian_6.S
+++ b/x86_att/p384/bignum_bigendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from big-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_bigendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_bigendian_6(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_frombebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_frombebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tobebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tobebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // Since x86 is little-endian, and bignums are stored with little-endian
 // word order, this is simply byte reversal and is implemented as such.

--- a/x86_att/p384/bignum_cmul_p384.S
+++ b/x86_att/p384/bignum_cmul_p384.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[6]; output z[6]
 //
-//    extern void bignum_cmul_p384
-//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//    extern void bignum_cmul_p384(uint64_t z[static 6], uint64_t c,
+//                                 const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p384/bignum_cmul_p384_alt.S
+++ b/x86_att/p384/bignum_cmul_p384_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[6]; output z[6]
 //
-//    extern void bignum_cmul_p384_alt
-//     (uint64_t z[static 6], uint64_t c, uint64_t x[static 6]);
+//    extern void bignum_cmul_p384_alt(uint64_t z[static 6], uint64_t c,
+//                                     const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p384/bignum_deamont_p384.S
+++ b/x86_att/p384/bignum_deamont_p384.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_deamont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_deamont_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 6-digit input will work, with no range restriction.

--- a/x86_att/p384/bignum_deamont_p384_alt.S
+++ b/x86_att/p384/bignum_deamont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_deamont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_deamont_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6]);
 //
 // Convert a 6-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 6-digit input will work, with no range restriction.

--- a/x86_att/p384/bignum_demont_p384.S
+++ b/x86_att/p384/bignum_demont_p384.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_demont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_demont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // This assumes the input is < p_384 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p384" instead.

--- a/x86_att/p384/bignum_demont_p384_alt.S
+++ b/x86_att/p384/bignum_demont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^384) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_demont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_demont_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // This assumes the input is < p_384 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p384" instead.

--- a/x86_att/p384/bignum_double_p384.S
+++ b/x86_att/p384/bignum_double_p384.S
@@ -5,8 +5,8 @@
 // Double modulo p_384, z := (2 * x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_double_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_double_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_half_p384.S
+++ b/x86_att/p384/bignum_half_p384.S
@@ -5,8 +5,7 @@
 // Halve modulo p_384, z := (x / 2) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_half_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_half_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_littleendian_6.S
+++ b/x86_att/p384/bignum_littleendian_6.S
@@ -5,17 +5,17 @@
 // Convert 6-digit (384-bit) bignum to/from little-endian form
 // Input x[6]; output z[6]
 //
-//    extern void bignum_littleendian_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_littleendian_6(uint64_t z[static 6],
+//                                      const uint64_t x[static 6]);
 //
 // The same function is given two other prototypes whose names reflect the
 // treatment of one or other argument as a byte array rather than word array:
 //
-//    extern void bignum_fromlebytes_6
-//     (uint64_t z[static 6], uint8_t x[static 48]);
+//    extern void bignum_fromlebytes_6(uint64_t z[static 6],
+//                                     const uint8_t x[static 48]);
 //
-//    extern void bignum_tolebytes_6
-//     (uint8_t z[static 48], uint64_t x[static 6]);
+//    extern void bignum_tolebytes_6(uint8_t z[static 48],
+//                                   const uint64_t x[static 6]);
 //
 // Since x86 is little-endian, this is just copying.
 //

--- a/x86_att/p384/bignum_mod_n384.S
+++ b/x86_att/p384/bignum_mod_n384.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_n384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86_att/p384/bignum_mod_n384_6.S
+++ b/x86_att/p384/bignum_mod_n384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_n384_6
-//      (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_n384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86_att/p384/bignum_mod_n384_alt.S
+++ b/x86_att/p384/bignum_mod_n384_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_n384_alt
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_n384_alt(uint64_t z[static 6], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the NIST curve P-384.
 //

--- a/x86_att/p384/bignum_mod_p384.S
+++ b/x86_att/p384/bignum_mod_p384.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_p384
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p384(uint64_t z[static 6], uint64_t k,
+//                                const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86_att/p384/bignum_mod_p384_6.S
+++ b/x86_att/p384/bignum_mod_p384_6.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_mod_p384_6
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_mod_p384_6(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_mod_p384_alt.S
+++ b/x86_att/p384/bignum_mod_p384_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_384
 // Input x[k]; output z[6]
 //
-//    extern void bignum_mod_p384_alt
-//     (uint64_t z[static 6], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_p384_alt(uint64_t z[static 6], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86_att/p384/bignum_montmul_p384.S
+++ b/x86_att/p384/bignum_montmul_p384.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6],
+//                                    const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/x86_att/p384/bignum_montmul_p384_alt.S
+++ b/x86_att/p384/bignum_montmul_p384_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^384) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_montmul_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_montmul_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6],
+//                                        const uint64_t y[static 6]);
 //
 // Does z := (2^{-384} * x * y) mod p_384, assuming that the inputs x and y
 // satisfy x * y <= 2^384 * p_384 (in particular this is true if we are in

--- a/x86_att/p384/bignum_montsqr_p384.S
+++ b/x86_att/p384/bignum_montsqr_p384.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384(uint64_t z[static 6],
+//                                    const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/x86_att/p384/bignum_montsqr_p384_alt.S
+++ b/x86_att/p384/bignum_montsqr_p384_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^384) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_montsqr_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_montsqr_p384_alt(uint64_t z[static 6],
+//                                        const uint64_t x[static 6]);
 //
 // Does z := (x^2 / 2^384) mod p_384, assuming x^2 <= 2^384 * p_384, which is
 // guaranteed in particular if x < p_384 initially (the "intended" case).

--- a/x86_att/p384/bignum_mux_6.S
+++ b/x86_att/p384/bignum_mux_6.S
@@ -5,9 +5,9 @@
 // 384-bit multiplex/select z := x (if p nonzero) or z := y (if p zero)
 // Inputs p, x[6], y[6]; output z[6]
 //
-//    extern void bignum_mux_6
-//     (uint64_t p, uint64_t z[static 6],
-//      uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_mux_6(uint64_t p, uint64_t z[static 6],
+//                             const uint64_t x[static 6],
+//                             const uint64_t y[static 6]);
 //
 // It is assumed that all numbers x, y and z have the same size 6 digits.
 //

--- a/x86_att/p384/bignum_neg_p384.S
+++ b/x86_att/p384/bignum_neg_p384.S
@@ -5,7 +5,7 @@
 // Negate modulo p_384, z := (-x) mod p_384, assuming x reduced
 // Input x[6]; output z[6]
 //
-//    extern void bignum_neg_p384 (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_neg_p384(uint64_t z[static 6], const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_nonzero_6.S
+++ b/x86_att/p384/bignum_nonzero_6.S
@@ -5,7 +5,7 @@
 // 384-bit nonzeroness test, returning 1 if x is nonzero, 0 if x is zero
 // Input x[6]; output function return
 //
-//    extern uint64_t bignum_nonzero_6(uint64_t x[static 6]);
+//    extern uint64_t bignum_nonzero_6(const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = x, returns RAX
 // Microsoft x64 ABI:   RCX = x, returns RAX

--- a/x86_att/p384/bignum_optneg_p384.S
+++ b/x86_att/p384/bignum_optneg_p384.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[6]; output z[6]
 //
-//    extern void bignum_optneg_p384
-//      (uint64_t z[static 6], uint64_t p, uint64_t x[static 6]);
+//    extern void bignum_optneg_p384(uint64_t z[static 6], uint64_t p,
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/p384/bignum_sub_p384.S
+++ b/x86_att/p384/bignum_sub_p384.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_384, z := (x - y) mod p_384
 // Inputs x[6], y[6]; output z[6]
 //
-//    extern void bignum_sub_p384
-//     (uint64_t z[static 6], uint64_t x[static 6], uint64_t y[static 6]);
+//    extern void bignum_sub_p384(uint64_t z[static 6], const uint64_t x[static 6],
+//                                const uint64_t y[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p384/bignum_tomont_p384.S
+++ b/x86_att/p384/bignum_tomont_p384.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_tomont_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_tomont_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_tomont_p384_alt.S
+++ b/x86_att/p384/bignum_tomont_p384_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^384 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_tomont_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_tomont_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p384/bignum_triple_p384.S
+++ b/x86_att/p384/bignum_triple_p384.S
@@ -5,8 +5,8 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_triple_p384(uint64_t z[static 6],
+//                                   const uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.

--- a/x86_att/p384/bignum_triple_p384_alt.S
+++ b/x86_att/p384/bignum_triple_p384_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_384, z := (3 * x) mod p_384
 // Input x[6]; output z[6]
 //
-//    extern void bignum_triple_p384_alt
-//     (uint64_t z[static 6], uint64_t x[static 6]);
+//    extern void bignum_triple_p384_alt(uint64_t z[static 6],
+//                                       const uint64_t x[static 6]);
 //
 // The input x can be any 6-digit bignum, not necessarily reduced modulo p_384,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_384.

--- a/x86_att/p384/p384_montjadd.S
+++ b/x86_att/p384/p384_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd(uint64_t p3[static 18], const uint64_t p1[static 18],
+//                              const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p384/p384_montjadd_alt.S
+++ b/x86_att/p384/p384_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 18]);
+//    extern void p384_montjadd_alt(uint64_t p3[static 18],
+//                                  const uint64_t p1[static 18],
+//                                  const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p384/p384_montjdouble.S
+++ b/x86_att/p384/p384_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p384/p384_montjdouble_alt.S
+++ b/x86_att/p384/p384_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjdouble_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18]);
+//    extern void p384_montjdouble_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p384/p384_montjmixadd.S
+++ b/x86_att/p384/p384_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd(uint64_t p3[static 18],
+//                                 const uint64_t p1[static 18],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p384/p384_montjmixadd_alt.S
+++ b/x86_att/p384/p384_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-384 in Montgomery-Jacobian coordinates
 //
-//    extern void p384_montjmixadd_alt
-//      (uint64_t p3[static 18],uint64_t p1[static 18],uint64_t p2[static 12]);
+//    extern void p384_montjmixadd_alt(uint64_t p3[static 18],
+//                                     const uint64_t p1[static 18],
+//                                     const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^384 * x) mod p_384.

--- a/x86_att/p521/bignum_add_p521.S
+++ b/x86_att/p521/bignum_add_p521.S
@@ -5,8 +5,8 @@
 // Add modulo p_521, z := (x + y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_add_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_add_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p521/bignum_cmul_p521.S
+++ b/x86_att/p521/bignum_cmul_p521.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[9]; output z[9]
 //
-//    extern void bignum_cmul_p521
-//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//    extern void bignum_cmul_p521(uint64_t z[static 9], uint64_t c,
+//                                 const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p521/bignum_cmul_p521_alt.S
+++ b/x86_att/p521/bignum_cmul_p521_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[9]; output z[9]
 //
-//    extern void bignum_cmul_p521_alt
-//     (uint64_t z[static 9], uint64_t c, uint64_t x[static 9]);
+//    extern void bignum_cmul_p521_alt(uint64_t z[static 9], uint64_t c,
+//                                     const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/p521/bignum_deamont_p521.S
+++ b/x86_att/p521/bignum_deamont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_deamont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_deamont_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Convert a 9-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 9-digit input will work, with no range restriction.

--- a/x86_att/p521/bignum_demont_p521.S
+++ b/x86_att/p521/bignum_demont_p521.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^576) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_demont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_demont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // This assumes the input is < p_521 for correctness. If this is not the case,
 // use the variant "bignum_deamont_p521" instead.

--- a/x86_att/p521/bignum_double_p521.S
+++ b/x86_att/p521/bignum_double_p521.S
@@ -5,8 +5,8 @@
 // Double modulo p_521, z := (2 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_double_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_double_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_fromlebytes_p521.S
+++ b/x86_att/p521/bignum_fromlebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert little-endian bytes to 9-digit 528-bit bignum
 //
-//    extern void bignum_fromlebytes_p521
-//     (uint64_t z[static 9],uint8_t x[static 66])
+//    extern void bignum_fromlebytes_p521(uint64_t z[static 9],
+//                                        const uint8_t x[static 66]);
 //
 // The result will be < 2^528 since it is translated from 66 bytes.
 // It is mainly intended for inputs x < p_521 < 2^521 < 2^528.

--- a/x86_att/p521/bignum_half_p521.S
+++ b/x86_att/p521/bignum_half_p521.S
@@ -5,8 +5,7 @@
 // Halve modulo p_521, z := (x / 2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_half_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_half_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_mod_n521_9.S
+++ b/x86_att/p521/bignum_mod_n521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_n521_9
-//      (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_n521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Reduction is modulo the group order of the NIST curve P-521.
 //

--- a/x86_att/p521/bignum_mod_n521_9_alt.S
+++ b/x86_att/p521/bignum_mod_n521_9_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_n521_9_alt
-//      (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_n521_9_alt(uint64_t z[static 9],
+//                                      const uint64_t x[static 9]);
 //
 // Reduction is modulo the group order of the NIST curve P-521.
 //

--- a/x86_att/p521/bignum_mod_p521_9.S
+++ b/x86_att/p521/bignum_mod_p521_9.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_mod_p521_9
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_mod_p521_9(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_montmul_p521.S
+++ b/x86_att/p521/bignum_montmul_p521.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/x86_att/p521/bignum_montmul_p521_alt.S
+++ b/x86_att/p521/bignum_montmul_p521_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^576) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_montmul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_montmul_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9],
+//                                        const uint64_t y[static 9]);
 //
 // Does z := (x * y / 2^576) mod p_521, assuming x < p_521, y < p_521. This
 // means the Montgomery base is the "native size" 2^{9*64} = 2^576; since

--- a/x86_att/p521/bignum_montsqr_p521.S
+++ b/x86_att/p521/bignum_montsqr_p521.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/x86_att/p521/bignum_montsqr_p521_alt.S
+++ b/x86_att/p521/bignum_montsqr_p521_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^576) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_montsqr_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_montsqr_p521_alt(uint64_t z[static 9],
+//                                        const uint64_t x[static 9]);
 //
 // Does z := (x^2 / 2^576) mod p_521, assuming x < p_521. This means the
 // Montgomery base is the "native size" 2^{9*64} = 2^576; since p_521 is

--- a/x86_att/p521/bignum_mul_p521.S
+++ b/x86_att/p521/bignum_mul_p521.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p521/bignum_mul_p521_alt.S
+++ b/x86_att/p521/bignum_mul_p521_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_521, z := (x * y) mod p_521, assuming x and y reduced
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_mul_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_mul_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9],
+//                                    const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p521/bignum_neg_p521.S
+++ b/x86_att/p521/bignum_neg_p521.S
@@ -5,7 +5,7 @@
 // Negate modulo p_521, z := (-x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_neg_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_neg_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_optneg_p521.S
+++ b/x86_att/p521/bignum_optneg_p521.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[9]; output z[9]
 //
-//    extern void bignum_optneg_p521
-//      (uint64_t z[static 9], uint64_t p, uint64_t x[static 9]);
+//    extern void bignum_optneg_p521(uint64_t z[static 9], uint64_t p,
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/p521/bignum_sqr_p521.S
+++ b/x86_att/p521/bignum_sqr_p521.S
@@ -5,7 +5,7 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521 (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_sqr_p521(uint64_t z[static 9], const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_sqr_p521_alt.S
+++ b/x86_att/p521/bignum_sqr_p521_alt.S
@@ -5,7 +5,8 @@
 // Square modulo p_521, z := (x^2) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_sqr_p521_alt (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_sqr_p521_alt(uint64_t z[static 9],
+//                                    const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_sub_p521.S
+++ b/x86_att/p521/bignum_sub_p521.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_521, z := (x - y) mod p_521
 // Inputs x[9], y[9]; output z[9]
 //
-//    extern void bignum_sub_p521
-//     (uint64_t z[static 9], uint64_t x[static 9], uint64_t y[static 9]);
+//    extern void bignum_sub_p521(uint64_t z[static 9], const uint64_t x[static 9],
+//                                const uint64_t y[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/p521/bignum_tolebytes_p521.S
+++ b/x86_att/p521/bignum_tolebytes_p521.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Convert 9-digit 528-bit bignum to little-endian bytes
 //
-//    extern void bignum_tolebytes_p521
-//     (uint8_t z[static 66], uint64_t x[static 9]);
+//    extern void bignum_tolebytes_p521(uint8_t z[static 66],
+//                                      const uint64_t x[static 9]);
 //
 // This is assuming the input x is < 2^528 so that it fits in 66 bytes.
 // In particular this holds if x < p_521 < 2^521 < 2^528.

--- a/x86_att/p521/bignum_tomont_p521.S
+++ b/x86_att/p521/bignum_tomont_p521.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^576 * x) mod p_521
 // Input x[9]; output z[9]
 //
-//    extern void bignum_tomont_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_tomont_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_triple_p521.S
+++ b/x86_att/p521/bignum_triple_p521.S
@@ -5,8 +5,8 @@
 // Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_triple_p521
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_triple_p521(uint64_t z[static 9],
+//                                   const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/bignum_triple_p521_alt.S
+++ b/x86_att/p521/bignum_triple_p521_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_521, z := (3 * x) mod p_521, assuming x reduced
 // Input x[9]; output z[9]
 //
-//    extern void bignum_triple_p521_alt
-//     (uint64_t z[static 9], uint64_t x[static 9]);
+//    extern void bignum_triple_p521_alt(uint64_t z[static 9],
+//                                       const uint64_t x[static 9]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/p521/p521_jadd.S
+++ b/x86_att/p521/p521_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                          const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/p521/p521_jadd_alt.S
+++ b/x86_att/p521/p521_jadd_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 27]);
+//    extern void p521_jadd_alt(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                              const uint64_t p2[static 27]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/p521/p521_jdouble.S
+++ b/x86_att/p521/p521_jdouble.S
@@ -4,8 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble(uint64_t p3[static 27], const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/p521/p521_jdouble_alt.S
+++ b/x86_att/p521/p521_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jdouble_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27]);
+//    extern void p521_jdouble_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/p521/p521_jmixadd.S
+++ b/x86_att/p521/p521_jmixadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd(uint64_t p3[static 27], const uint64_t p1[static 27],
+//                             const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/p521/p521_jmixadd_alt.S
+++ b/x86_att/p521/p521_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on NIST curve P-521 in Jacobian coordinates
 //
-//    extern void p521_jmixadd_alt
-//      (uint64_t p3[static 27],uint64_t p1[static 27],uint64_t p2[static 18]);
+//    extern void p521_jmixadd_alt(uint64_t p3[static 27],
+//                                 const uint64_t p1[static 27],
+//                                 const uint64_t p2[static 18]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/bignum_add_p256k1.S
+++ b/x86_att/secp256k1/bignum_add_p256k1.S
@@ -5,8 +5,8 @@
 // Add modulo p_256k1, z := (x + y) mod p_256k1, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/secp256k1/bignum_cmul_p256k1.S
+++ b/x86_att/secp256k1/bignum_cmul_p256k1.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256k1
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256k1(uint64_t z[static 4], uint64_t c,
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/secp256k1/bignum_cmul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_cmul_p256k1_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_p256k1_alt(uint64_t z[static 4], uint64_t c,
+//                                       const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/secp256k1/bignum_deamont_p256k1.S
+++ b/x86_att/secp256k1/bignum_deamont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_256k1,
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86_att/secp256k1/bignum_demont_p256k1.S
+++ b/x86_att/secp256k1/bignum_demont_p256k1.S
@@ -6,8 +6,8 @@
 // assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // This assumes the input is < p_256k1 for correctness. If this is not the
 // case, use the variant "bignum_deamont_p256k1" instead.

--- a/x86_att/secp256k1/bignum_double_p256k1.S
+++ b/x86_att/secp256k1/bignum_double_p256k1.S
@@ -5,8 +5,8 @@
 // Double modulo p_256k1, z := (2 * x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_half_p256k1.S
+++ b/x86_att/secp256k1/bignum_half_p256k1.S
@@ -5,8 +5,8 @@
 // Halve modulo p_256k1, z := (x / 2) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_p256k1(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_mod_n256k1_4.S
+++ b/x86_att/secp256k1/bignum_mod_n256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_n256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_n256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the secp256k1 curve.
 //

--- a/x86_att/secp256k1/bignum_mod_p256k1_4.S
+++ b/x86_att/secp256k1/bignum_mod_p256k1_4.S
@@ -5,8 +5,8 @@
 // Reduce modulo field characteristic, z := x mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_p256k1_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_p256k1_4(uint64_t z[static 4],
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_montmul_p256k1.S
+++ b/x86_att/secp256k1/bignum_montmul_p256k1.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k2 (in particular this is true if we are in

--- a/x86_att/secp256k1/bignum_montmul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_montmul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4],
+//                                          const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_256k1, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_256k2 (in particular this is true if we are in

--- a/x86_att/secp256k1/bignum_montsqr_p256k1.S
+++ b/x86_att/secp256k1/bignum_montsqr_p256k1.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/x86_att/secp256k1/bignum_montsqr_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_montsqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_p256k1_alt(uint64_t z[static 4],
+//                                          const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_256k1, assuming x^2 <= 2^256 * p_256k1, which
 // is guaranteed in particular if x < p_256k1 initially (the "intended" case).

--- a/x86_att/secp256k1/bignum_mul_p256k1.S
+++ b/x86_att/secp256k1/bignum_mul_p256k1.S
@@ -5,8 +5,8 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/secp256k1/bignum_mul_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_mul_p256k1_alt.S
@@ -5,8 +5,9 @@
 // Multiply modulo p_256k1, z := (x * y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_mul_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_mul_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4],
+//                                      const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/secp256k1/bignum_neg_p256k1.S
+++ b/x86_att/secp256k1/bignum_neg_p256k1.S
@@ -5,8 +5,7 @@
 // Negate modulo p_256k1, z := (-x) mod p_256k1, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_optneg_p256k1.S
+++ b/x86_att/secp256k1/bignum_optneg_p256k1.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_p256k1
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_p256k1(uint64_t z[static 4], uint64_t p,
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/secp256k1/bignum_sqr_p256k1.S
+++ b/x86_att/secp256k1/bignum_sqr_p256k1.S
@@ -5,8 +5,7 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_sqr_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_sqr_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Square modulo p_256k1, z := (x^2) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_sqr_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_sqr_p256k1_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_sub_p256k1.S
+++ b/x86_att/secp256k1/bignum_sub_p256k1.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_256k1, z := (x - y) mod p_256k1
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_p256k1(uint64_t z[static 4], const uint64_t x[static 4],
+//                                  const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/secp256k1/bignum_tomont_p256k1.S
+++ b/x86_att/secp256k1/bignum_tomont_p256k1.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256k1
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_tomont_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_tomont_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_p256k1_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_p256k1_alt(uint64_t z[static 4],
+//                                         const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/secp256k1/bignum_triple_p256k1.S
+++ b/x86_att/secp256k1/bignum_triple_p256k1.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256k1, z := (3 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256k1
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256k1(uint64_t z[static 4],
+//                                     const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo
 // p_256k1, and the result is always fully reduced, z = (3 * x) mod p_256k1.

--- a/x86_att/secp256k1/bignum_triple_p256k1_alt.S
+++ b/x86_att/secp256k1/bignum_triple_p256k1_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_256k1, z := (3 * x) mod p_256k1
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_p256k1_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_p256k1_alt(uint64_t z[static 4],
+//                                         const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo
 // p_256k1, and the result is always fully reduced, z = (3 * x) mod p_256k1.

--- a/x86_att/secp256k1/secp256k1_jadd.S
+++ b/x86_att/secp256k1/secp256k1_jadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                               const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/secp256k1_jadd_alt.S
+++ b/x86_att/secp256k1/secp256k1_jadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void secp256k1_jadd_alt(uint64_t p3[static 12],
+//                                   const uint64_t p1[static 12],
+//                                   const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/secp256k1_jdouble.S
+++ b/x86_att/secp256k1/secp256k1_jdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/secp256k1_jdouble.S
+++ b/x86_att/secp256k1/secp256k1_jdouble.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_montjdouble
+//    extern void secp256k1_jdouble
 //      (uint64_t p3[static 12],uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.

--- a/x86_att/secp256k1/secp256k1_jdouble_alt.S
+++ b/x86_att/secp256k1/secp256k1_jdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void secp256k1_jdouble_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/secp256k1_jdouble_alt.S
+++ b/x86_att/secp256k1/secp256k1_jdouble_alt.S
@@ -4,7 +4,7 @@
 // ----------------------------------------------------------------------------
 // Point doubling on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_montjdouble_alt
+//    extern void secp256k1_jdouble_alt
 //      (uint64_t p3[static 12],uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples.

--- a/x86_att/secp256k1/secp256k1_jmixadd.S
+++ b/x86_att/secp256k1/secp256k1_jmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd(uint64_t p3[static 12],
+//                                  const uint64_t p1[static 12],
+//                                  const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/secp256k1/secp256k1_jmixadd_alt.S
+++ b/x86_att/secp256k1/secp256k1_jmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on SECG curve secp256k1 in Jacobian coordinates
 //
-//    extern void secp256k1_jmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void secp256k1_jmixadd_alt(uint64_t p3[static 12],
+//                                      const uint64_t p1[static 12],
+//                                      const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples.
 // A Jacobian triple (x,y,z) represents affine point (x/z^2,y/z^3).

--- a/x86_att/sm2/bignum_add_sm2.S
+++ b/x86_att/sm2/bignum_add_sm2.S
@@ -5,8 +5,8 @@
 // Add modulo p_sm2, z := (x + y) mod p_sm2, assuming x and y reduced
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_add_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_add_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/sm2/bignum_cmul_sm2.S
+++ b/x86_att/sm2/bignum_cmul_sm2.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_sm2
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_sm2(uint64_t z[static 4], uint64_t c,
+//                                const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/sm2/bignum_cmul_sm2_alt.S
+++ b/x86_att/sm2/bignum_cmul_sm2_alt.S
@@ -6,8 +6,8 @@
 // x reduced
 // Inputs c, x[4]; output z[4]
 //
-//    extern void bignum_cmul_sm2_alt
-//     (uint64_t z[static 4], uint64_t c, uint64_t x[static 4]);
+//    extern void bignum_cmul_sm2_alt(uint64_t z[static 4], uint64_t c,
+//                                    const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = c, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = c, R8 = x

--- a/x86_att/sm2/bignum_deamont_sm2.S
+++ b/x86_att/sm2/bignum_deamont_sm2.S
@@ -5,8 +5,8 @@
 // Convert from almost-Montgomery form, z := (x / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_deamont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_deamont_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Convert a 4-digit bignum x out of its (optionally almost) Montgomery form,
 // "almost" meaning any 4-digit input will work, with no range restriction.

--- a/x86_att/sm2/bignum_demont_sm2.S
+++ b/x86_att/sm2/bignum_demont_sm2.S
@@ -5,8 +5,7 @@
 // Convert from Montgomery form z := (x / 2^256) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_demont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_demont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // This assumes the input is < p_sm2 for correctness. If this is not the case,
 // use the variant "bignum_deamont_sm2" instead.

--- a/x86_att/sm2/bignum_double_sm2.S
+++ b/x86_att/sm2/bignum_double_sm2.S
@@ -5,8 +5,7 @@
 // Double modulo p_sm2, z := (2 * x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_double_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_double_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/sm2/bignum_half_sm2.S
+++ b/x86_att/sm2/bignum_half_sm2.S
@@ -5,8 +5,7 @@
 // Halve modulo p_sm2, z := (x / 2) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_half_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_half_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/sm2/bignum_mod_nsm2.S
+++ b/x86_att/sm2/bignum_mod_nsm2.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_nsm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_nsm2(uint64_t z[static 4], uint64_t k,
+//                                const uint64_t *x);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86_att/sm2/bignum_mod_nsm2_4.S
+++ b/x86_att/sm2/bignum_mod_nsm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_nsm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_nsm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86_att/sm2/bignum_mod_nsm2_alt.S
+++ b/x86_att/sm2/bignum_mod_nsm2_alt.S
@@ -5,8 +5,8 @@
 // Reduce modulo group order, z := x mod n_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_nsm2_alt
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_nsm2_alt(uint64_t z[static 4], uint64_t k,
+//                                    const uint64_t *x);
 //
 // Reduction is modulo the group order of the GM/T 0003-2012 curve SM2.
 //

--- a/x86_att/sm2/bignum_mod_sm2.S
+++ b/x86_att/sm2/bignum_mod_sm2.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[k]; output z[4]
 //
-//    extern void bignum_mod_sm2
-//     (uint64_t z[static 4], uint64_t k, uint64_t *x);
+//    extern void bignum_mod_sm2(uint64_t z[static 4], uint64_t k, const uint64_t *x);
 //
 // Standard x86-64 ABI: RDI = z, RSI = k, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = k, R8 = x

--- a/x86_att/sm2/bignum_mod_sm2_4.S
+++ b/x86_att/sm2/bignum_mod_sm2_4.S
@@ -5,8 +5,7 @@
 // Reduce modulo field characteristic, z := x mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_mod_sm2_4
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_mod_sm2_4(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/sm2/bignum_montmul_sm2.S
+++ b/x86_att/sm2/bignum_montmul_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                                   const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/x86_att/sm2/bignum_montmul_sm2_alt.S
+++ b/x86_att/sm2/bignum_montmul_sm2_alt.S
@@ -5,8 +5,9 @@
 // Montgomery multiply, z := (x * y / 2^256) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_montmul_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_montmul_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4],
+//                                       const uint64_t y[static 4]);
 //
 // Does z := (2^{-256} * x * y) mod p_sm2, assuming that the inputs x and y
 // satisfy x * y <= 2^256 * p_sm2 (in particular this is true if we are in

--- a/x86_att/sm2/bignum_montsqr_sm2.S
+++ b/x86_att/sm2/bignum_montsqr_sm2.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2(uint64_t z[static 4],
+//                                   const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/x86_att/sm2/bignum_montsqr_sm2_alt.S
+++ b/x86_att/sm2/bignum_montsqr_sm2_alt.S
@@ -5,8 +5,8 @@
 // Montgomery square, z := (x^2 / 2^256) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_montsqr_sm2_alt
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_montsqr_sm2_alt(uint64_t z[static 4],
+//                                       const uint64_t x[static 4]);
 //
 // Does z := (x^2 / 2^256) mod p_sm2, assuming x^2 <= 2^256 * p_sm2, which is
 // guaranteed in particular if x < p_sm2 initially (the "intended" case).

--- a/x86_att/sm2/bignum_neg_sm2.S
+++ b/x86_att/sm2/bignum_neg_sm2.S
@@ -5,7 +5,7 @@
 // Negate modulo p_sm2, z := (-x) mod p_sm2, assuming x reduced
 // Input x[4]; output z[4]
 //
-//    extern void bignum_neg_sm2 (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_neg_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/sm2/bignum_optneg_sm2.S
+++ b/x86_att/sm2/bignum_optneg_sm2.S
@@ -6,8 +6,8 @@
 // z := x (if p zero), assuming x reduced
 // Inputs p, x[4]; output z[4]
 //
-//    extern void bignum_optneg_sm2
-//     (uint64_t z[static 4], uint64_t p, uint64_t x[static 4]);
+//    extern void bignum_optneg_sm2(uint64_t z[static 4], uint64_t p,
+//                                  const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = p, RDX = x
 // Microsoft x64 ABI:   RCX = z, RDX = p, R8 = x

--- a/x86_att/sm2/bignum_sub_sm2.S
+++ b/x86_att/sm2/bignum_sub_sm2.S
@@ -5,8 +5,8 @@
 // Subtract modulo p_sm2, z := (x - y) mod p_sm2
 // Inputs x[4], y[4]; output z[4]
 //
-//    extern void bignum_sub_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4], uint64_t y[static 4]);
+//    extern void bignum_sub_sm2(uint64_t z[static 4], const uint64_t x[static 4],
+//                               const uint64_t y[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x, RDX = y
 // Microsoft x64 ABI:   RCX = z, RDX = x, R8 = y

--- a/x86_att/sm2/bignum_tomont_sm2.S
+++ b/x86_att/sm2/bignum_tomont_sm2.S
@@ -5,8 +5,7 @@
 // Convert to Montgomery form z := (2^256 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_tomont_sm2
-//     (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_tomont_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // Standard x86-64 ABI: RDI = z, RSI = x
 // Microsoft x64 ABI:   RCX = z, RDX = x

--- a/x86_att/sm2/bignum_triple_sm2.S
+++ b/x86_att/sm2/bignum_triple_sm2.S
@@ -5,8 +5,7 @@
 // Triple modulo p_sm2, z := (3 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_sm2
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_sm2(uint64_t z[static 4], const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_sm2,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_sm2.

--- a/x86_att/sm2/bignum_triple_sm2_alt.S
+++ b/x86_att/sm2/bignum_triple_sm2_alt.S
@@ -5,8 +5,8 @@
 // Triple modulo p_sm2, z := (3 * x) mod p_sm2
 // Input x[4]; output z[4]
 //
-//    extern void bignum_triple_sm2_alt
-//      (uint64_t z[static 4], uint64_t x[static 4]);
+//    extern void bignum_triple_sm2_alt(uint64_t z[static 4],
+//                                      const uint64_t x[static 4]);
 //
 // The input x can be any 4-digit bignum, not necessarily reduced modulo p_sm2,
 // and the result is always fully reduced, i.e. z = (3 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjadd.S
+++ b/x86_att/sm2/sm2_montjadd.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd(uint64_t p3[static 12], const uint64_t p1[static 12],
+//                             const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjadd_alt.S
+++ b/x86_att/sm2/sm2_montjadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 12]);
+//    extern void sm2_montjadd_alt(uint64_t p3[static 12],
+//                                 const uint64_t p1[static 12],
+//                                 const uint64_t p2[static 12]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjdouble.S
+++ b/x86_att/sm2/sm2_montjdouble.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjdouble_alt.S
+++ b/x86_att/sm2/sm2_montjdouble_alt.S
@@ -4,8 +4,8 @@
 // ----------------------------------------------------------------------------
 // Point doubling on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjdouble_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12]);
+//    extern void sm2_montjdouble_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12]);
 //
 // Does p3 := 2 * p1 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjmixadd.S
+++ b/x86_att/sm2/sm2_montjmixadd.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd(uint64_t p3[static 12],
+//                                const uint64_t p1[static 12],
+//                                const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.

--- a/x86_att/sm2/sm2_montjmixadd_alt.S
+++ b/x86_att/sm2/sm2_montjmixadd_alt.S
@@ -4,8 +4,9 @@
 // ----------------------------------------------------------------------------
 // Point mixed addition on GM/T 0003-2012 curve SM2 in Montgomery-Jacobian coordinates
 //
-//    extern void sm2_montjmixadd_alt
-//      (uint64_t p3[static 12],uint64_t p1[static 12],uint64_t p2[static 8]);
+//    extern void sm2_montjmixadd_alt(uint64_t p3[static 12],
+//                                    const uint64_t p1[static 12],
+//                                    const uint64_t p2[static 8]);
 //
 // Does p3 := p1 + p2 where all points are regarded as Jacobian triples with
 // each coordinate in the Montgomery domain, i.e. x' = (2^256 * x) mod p_sm2.


### PR DESCRIPTION
This PR follows #167 and transfers the improvements made there into the assembly head comments.

The process for doing that was, briefly: locally expand `S2N_BIGNUM_STATIC` in the header, reformat the entire header using clang-format, and then write a few lines of python to splat the old head comments with their replacement.

<details>
 <summary>Reproduction instructions</summary>

```shell
$ clang-format --version
Ubuntu clang-format version 18.1.3 (1ubuntu1)

$ tail +32 include/s2n-bignum.h  | sed 's/S2N_BIGNUM_STATIC/static/g' | clang-format > hdrs.h
$ python apply.py
??? function bignum_copy_from_table_32 not in header file
??? function bignum_copy_from_table not in header file
??? function bignum_copy_from_table_8n not in header file
??? function bignum_copy_from_table_16 not in header file
??? function bignum_copy_from_table not in header file

```

apply.py is:

```python
import glob

formatted = {}

collect = ""

def fn_name(text):
    tokens = text.splitlines()[0].split()
    assert tokens[0] == 'extern'
    return tokens[2].split('(')[0]

for line in open('hdrs.h'):
    line = line.rstrip()
    if line.startswith('//') or line.startswith('# ') or not line:
        continue
    collect = collect + '\n' + line.rstrip()
    if line.endswith(';'):
        collect = collect.lstrip()
        fn = fn_name(collect)
        assert fn not in formatted
        formatted[fn] = collect
        collect = ""

for file in glob.glob('*/*/*.S'):
    input = open(file).readlines()
    output = open(file, 'w')

    swallow_until_empty_line = False

    for line in input:
        if line.startswith('//    extern'):
            fn = fn_name(line.replace('//  ', ''))
            if fn in formatted:
                ff = formatted[fn]
                for l in ff.splitlines():
                    output.write('//    ' + l + '\n')
                swallow_until_empty_line = True
                continue
            else:
                print('???', 'function', fn, 'not in header file')

        if line.rstrip() == '//':
            swallow_until_empty_line = False

        if swallow_until_empty_line:
            continue

        output.write(line)
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
