### PR TITLE
Make s2n-bignum _CET_ENDBR play nice with downstream

### DIFF
--- a/include/_internal_s2n_bignum.h
+++ b/include/_internal_s2n_bignum.h
@@ -33,9 +33,12 @@
 // slowdown from executing one more instruction.
 
 #if NO_IBT
-#define _CET_ENDBR
+#   if defined(_CET_ENDBR)
+#     error "The s2n-bignum build option NO_IBT was configured, but _CET_ENDBR is defined in this compilation unit. That is weird, so failing the build."
+#   endif
+#   define _CET_ENDBR
 #elif defined(__CET__)
-#include <cet.h>
-#else
-#define _CET_ENDBR .byte 0xf3,0x0f,0x1e,0xfa
+#   include <cet.h>
+#elif !defined(_CET_ENDBR)
+#   define _CET_ENDBR .byte 0xf3,0x0f,0x1e,0xfa
 #endif


### PR DESCRIPTION
*Description of changes:*

Downstream can define `_CET_ENDBR` if `cet.h` is not present. And sometimes, in downstream, s2n-bignum source code is not compiled in isolated s2n-bignum-only compilation units. The result of those two facts is redefinitions of `_CET_ENDBR`.

Prevent this by guarding the definition of `_CET_ENDBR` with a is-it-already-defined-? test.

Also, make sure that an inconsistent build configuration cannot proceed i.e. `NO_IBT` is defined but `_CET_ENDBR` is also defined... I believe this should be a fatal build error, so I made it that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
