### PR TITLE
Add AVX2 instructions vpsubw, vpaddw, vpmullw and vpmulhw

### DIFF
--- a/common/components.ml
+++ b/common/components.ml
@@ -1529,6 +1529,13 @@ let VALID_COMPONENT_ZEROTOP_32 = prove
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_32];;
 
+let WEAKLY_VALID_COMPONENT_ZEROTOP_32 = prove
+ (`weakly_valid_component(zerotop_32)`,
+  MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+  REWRITE_TAC[VALID_COMPONENT_ZEROTOP_32]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_32];;
+
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_32)];;
 
@@ -1557,6 +1564,13 @@ let VALID_COMPONENT_ZEROTOP_64 = prove
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_64];;
 
+let WEAKLY_VALID_COMPONENT_ZEROTOP_64 = prove
+  (`weakly_valid_component(zerotop_64)`,
+   MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+   REWRITE_TAC[VALID_COMPONENT_ZEROTOP_64]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_64];;
+
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_64)];;
 
@@ -1580,6 +1594,13 @@ let VALID_COMPONENT_ZEROTOP_16 = prove
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_16];;
 
+let WEAKLY_VALID_COMPONENT_ZEROTOP_16 = prove
+  (`weakly_valid_component(zerotop_16)`,
+   MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+   REWRITE_TAC[VALID_COMPONENT_ZEROTOP_16]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_16];;
+
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_16)];;
 
@@ -1602,6 +1623,13 @@ let VALID_COMPONENT_ZEROTOP_8 = prove
   REWRITE_TAC[DIMINDEX_8; DIMINDEX_16] THEN CONV_TAC NUM_REDUCE_CONV);;
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_8];;
+
+let WEAKLY_VALID_COMPONENT_ZEROTOP_8 = prove
+  (`weakly_valid_component(zerotop_8)`,
+   MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+   REWRITE_TAC[VALID_COMPONENT_ZEROTOP_8]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_8];;
 
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_8)];;
@@ -1631,6 +1659,13 @@ let VALID_COMPONENT_ZEROTOP_128 = prove
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_128];;
 
+let WEAKLY_VALID_COMPONENT_ZEROTOP_128 = prove
+  (`weakly_valid_component(zerotop_128)`,
+   MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+   REWRITE_TAC[VALID_COMPONENT_ZEROTOP_128]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_128];;
+
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_128)];;
 
@@ -1653,6 +1688,13 @@ let VALID_COMPONENT_ZEROTOP_256 = prove
   REWRITE_TAC[DIMINDEX_256; DIMINDEX_512] THEN CONV_TAC NUM_REDUCE_CONV);;
 
 add_valid_component_thms [VALID_COMPONENT_ZEROTOP_256];;
+
+let WEAKLY_VALID_COMPONENT_ZEROTOP_256 = prove
+  (`weakly_valid_component(zerotop_256)`,
+   MATCH_MP_TAC VALID_IMP_WEAKLY_VALID_COMPONENT THEN
+   REWRITE_TAC[VALID_COMPONENT_ZEROTOP_256]);;
+
+add_weakly_valid_component_thms [WEAKLY_VALID_COMPONENT_ZEROTOP_256];;
 
 add_component_read_write_thms
  [CONJUNCT1(GEN_REWRITE_RULE I [valid_component] VALID_COMPONENT_ZEROTOP_256)];;

--- a/x86/allowed_asm
+++ b/x86/allowed_asm
@@ -119,6 +119,10 @@
 : test$
 : testq$
 : vpxor$
+: vpaddw$
+: vpmulhw$
+: vpmullw$
+: vpsubw$
 : xchg$
 : xor$
 : xorl$

--- a/x86/proofs/instruction.ml
+++ b/x86/proofs/instruction.ml
@@ -304,6 +304,10 @@ let instruction_INDUCTION,instruction_RECURSION = define_type
    | SUB operand operand
    | TEST operand operand
    | TZCNT operand operand
+   | VPADDW operand operand operand
+   | VPMULHW operand operand operand
+   | VPMULLW operand operand operand
+   | VPSUBW operand operand operand
    | VPXOR operand operand operand
    | XCHG operand operand
    | XOR operand operand";;

--- a/x86/proofs/simulator.ml
+++ b/x86/proofs/simulator.ml
@@ -292,6 +292,10 @@ let iclasses = iclasses @
  [0x66; 0x0f; 0x1f; 0x84; 0x00; 0x00; 0x00; 0x00; 0x00]; (* NOP_N (Memop Word (%%%% (rax,0,rax))) *)
  [0x66; 0x2e; 0x0f; 0x1f; 0x84; 0x00; 0x00; 0x00; 0x00; 0x00]; (* NOP_N (Memop Word (%%%% (rax,0,rax))) *)
  [0x66; 0x66; 0x2e; 0x0f; 0x1f; 0x84; 0x00; 0x00; 0x00; 0x00; 0x00]; (* NOP_N (Memop Word (%%%% (rax,0,rax))) *)
+ [0xc5; 0x85; 0xf9; 0xf6]; (* VPSUBW (%_% ymm6) (%_% ymm15) (%_% ymm6) *)
+ [0xc4; 0x41; 0x45; 0xfd; 0xdb]; (* VPADDW (%_% ymm11) (%_% ymm7) (%_% ymm11) *)
+ [0xc5; 0x7d; 0xd5; 0xc9]; (* VPMULLW (%_% ymm1) (%_% ymm0) (%_% ymm9) *)
+ [0xc5; 0x45; 0xe5; 0xfb]; (* VPMULHW (%_% ymm15) (%_% ymm7) (%_% ymm3) *)
 ];;
 
 (* ------------------------------------------------------------------------- *)
@@ -769,7 +773,7 @@ let cosimulate_sse_mov_aligned_rsp_harness(pfx, opcode) = fun () ->
   to execute and a bool representing whether additional assumptions
   are needed. Currently the additional assumption is for stack
   alignment for certain instructions. To make the tests more diverse
-  the evaluation of harnesses are deferred until an instruction is 
+  the evaluation of harnesses are deferred until an instruction is
   chosen from mem_iclasses *)
 let mem_iclasses = [
   (* ADC r/m64, r64 *)

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -1300,73 +1300,50 @@ let x86_SUB = new_definition
          AF := ~(&(val(word_zx x:nybble)) - &(val(word_zx y:nybble)):int =
                  &(val(word_zx z:nybble)))) s`;;
 
-let x86_VPADDW_256 = new_definition
-  `x86_VPADDW_256 dest src1 src2 s =
-      let (x:256 word) = read src1 s
-      and (y:256 word) = read src2 s in
-      let res:(256)word =
-          simd16 (\(x:16 word) (y:16 word). word_add x y) x y in
-      (dest := res) s`;;
+let x86_VPADDW = new_definition
+  `x86_VPADDW dest src1 src2 (s:x86state) =
+      let (x:N word) = read src1 s
+      and (y:N word) = read src2 s in
+      if dimindex(:N) = 256 then
+        let res:(256)word = simd16 word_add (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s
+      else
+        let res:(128)word = simd8 word_add (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s`;;
 
-let x86_VPADDW_128 = new_definition
-  `x86_VPADDW_128 dest src1 src2 s =
-      let (x:128 word) = read src1 s
-      and (y:128 word) = read src2 s in
-      let res:(128)word =
-          simd8 (\(x:16 word) (y:16 word). word_add x y) x y in
-      (dest := res) s`;;
+let x86_VPMULHW = new_definition
+  `x86_VPMULHW dest src1 src2 (s:x86state) =
+      let (x:N word) = read src1 s
+      and (y:N word) = read src2 s in
+      let f = (\(x:16 word) (y:16 word). word_subword (word_mul ((word_sx x):int32) ((word_sx y):int32)) (16,16)) in
+      if dimindex(:N) = 256 then
+        let res:(256)word = simd16 f (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s
+      else
+        let res:(128)word = simd8 f (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s`;;
 
-let x86_VPMULHW_256 = new_definition
-  `x86_VPMULHW_256 dest src1 src2 s =
-      let (x:256 word) = read src1 s
-      and (y:256 word) = read src2 s in
-      let res:(256)word =
-          simd16 (\(x:16 word) (y:16 word).
-            word_subword (word_mul ((word_sx x):int32) ((word_sx y):int32)) (16,16))
-            x y in
-      (dest := res) s`;;
+let x86_VPMULLW = new_definition
+  `x86_VPMULLW dest src1 src2 (s:x86state) =
+      let (x:N word) = read src1 s
+      and (y:N word) = read src2 s in
+      if dimindex(:N) = 256 then
+        let res:(256)word = simd16 word_mul (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s
+      else
+        let res:(128)word = simd8 word_mul (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s`;;
 
-let x86_VPMULHW_128 = new_definition
-  `x86_VPMULHW_128 dest src1 src2 s =
-      let (x:128 word) = read src1 s
-      and (y:128 word) = read src2 s in
-      let res:(128)word =
-          simd8 (\(x:16 word) (y:16 word).
-            word_subword (word_mul ((word_sx x):int32) ((word_sx y):int32)) (16,16))
-            x y in
-      (dest := res) s`;;
-
-let x86_VPMULLW_256 = new_definition
-  `x86_VPMULLW_256 dest src1 src2 s =
-      let (x:256 word) = read src1 s
-      and (y:256 word) = read src2 s in
-      let res:(256)word =
-          simd16 (\(x:16 word) (y:16 word). word_mul x y) x y in
-      (dest := res) s`;;
-
-let x86_VPMULLW_128 = new_definition
-  `x86_VPMULLW_128 dest src1 src2 s =
-      let (x:128 word) = read src1 s
-      and (y:128 word) = read src2 s in
-      let res:(128)word =
-          simd8 (\(x:16 word) (y:16 word). word_mul x y) x y in
-      (dest := word_join ((word 0):128 word) res) s`;;
-
-let x86_VPSUBW_256 = new_definition
-  `x86_VPSUBW_256 dest src1 src2 s =
-      let (x:256 word) = read src1 s
-      and (y:256 word) = read src2 s in
-      let res:(256)word =
-          simd16 (\(x:16 word) (y:16 word). word_sub x y) x y in
-      (dest := res) s`;;
-
-let x86_VPSUBW_128 = new_definition
-  `x86_VPSUBW_128 dest src1 src2 s =
-      let (x:128 word) = read src1 s
-      and (y:128 word) = read src2 s in
-      let res:(128)word =
-          simd8 (\(x:16 word) (y:16 word). word_sub x y) x y in
-      (dest := res) s`;;
+let x86_VPSUBW = new_definition
+  `x86_VPSUBW dest src1 src2 (s:x86state) =
+      let (x:N word) = read src1 s
+      and (y:N word) = read src2 s in
+      if dimindex(:N) = 256 then
+        let res:(256)word = simd16 word_sub (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s
+      else
+        let res:(128)word = simd8 word_sub (word_zx x) (word_zx y) in
+        (dest := (word_zx res):N word) s`;;
 
 (*** This is roughly AND just for some condition codes ***)
 
@@ -2040,20 +2017,20 @@ let x86_execute = define
          | 16 -> x86_TZCNT (OPERAND16 dest s) (OPERAND16 src s)) s
     | VPADDW dest src1 src2 ->
         (match operand_size dest with
-          256 -> x86_VPADDW_256 (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
-        | 128 -> x86_VPADDW_128 (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
+          256 -> x86_VPADDW (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
+        | 128 -> x86_VPADDW (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
     | VPMULHW dest src1 src2 ->
         (match operand_size dest with
-          256 -> x86_VPMULHW_256 (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
-        | 128 -> x86_VPMULHW_128 (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
+          256 -> x86_VPMULHW (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
+        | 128 -> x86_VPMULHW (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
     | VPMULLW dest src1 src2 ->
         (match operand_size dest with
-          256 -> x86_VPMULLW_256 (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
-        | 128 -> x86_VPMULLW_128 (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
+          256 -> x86_VPMULLW (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
+        | 128 -> x86_VPMULLW (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
     | VPSUBW dest src1 src2 ->
         (match operand_size dest with
-          256 -> x86_VPSUBW_256 (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
-        | 128 -> x86_VPSUBW_128 (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
+          256 -> x86_VPSUBW (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
+        | 128 -> x86_VPSUBW (OPERAND128 dest s) (OPERAND128 src1 s) (OPERAND128 src2 s)) s
     | VPXOR dest src1 src2 ->
         (match operand_size dest with
           256 -> x86_VPXOR (OPERAND256 dest s) (OPERAND256 src1 s) (OPERAND256 src2 s)
@@ -2776,14 +2753,10 @@ let x86_PADDQ_ALT = EXPAND_SIMD_RULE x86_PADDQ;;
 let x86_PCMPGTD_ALT = EXPAND_SIMD_RULE x86_PCMPGTD;;
 let x86_PSHUFD_ALT = EXPAND_SIMD_RULE x86_PSHUFD;;
 let x86_PSRAD_ALT = EXPAND_SIMD_RULE x86_PSRAD;;
-let x86_VPADDW_128_ALT = EXPAND_SIMD_RULE x86_VPADDW_128;;
-let x86_VPADDW_256_ALT = EXPAND_SIMD_RULE x86_VPADDW_256;;
-let x86_VPMULHW_128_ALT = EXPAND_SIMD_RULE x86_VPMULHW_128;;
-let x86_VPMULHW_256_ALT = EXPAND_SIMD_RULE x86_VPMULHW_256;;
-let x86_VPMULLW_128_ALT = EXPAND_SIMD_RULE x86_VPMULLW_128;;
-let x86_VPMULLW_256_ALT = EXPAND_SIMD_RULE x86_VPMULLW_256;;
-let x86_VPSUBW_128_ALT = EXPAND_SIMD_RULE x86_VPSUBW_128;;
-let x86_VPSUBW_256_ALT = EXPAND_SIMD_RULE x86_VPSUBW_256;;
+let x86_VPADDW_ALT = EXPAND_SIMD_RULE x86_VPADDW;;
+let x86_VPMULHW_ALT = EXPAND_SIMD_RULE x86_VPMULHW;;
+let x86_VPMULLW_ALT = EXPAND_SIMD_RULE x86_VPMULLW;;
+let x86_VPSUBW_ALT = EXPAND_SIMD_RULE x86_VPSUBW;;
 
 
 let X86_OPERATION_CLAUSES =
@@ -2802,10 +2775,8 @@ let X86_OPERATION_CLAUSES =
     x86_SAR; x86_SBB_ALT; x86_SET; x86_SHL; x86_SHLD; x86_SHR; x86_SHRD;
     x86_STC; x86_SUB_ALT; x86_TEST; x86_TZCNT; x86_XCHG; x86_XOR;
     (*** AVX2 instructions ***)
-    x86_VPADDW_128_ALT; x86_VPADDW_256_ALT;
-    x86_VPMULHW_128_ALT; x86_VPMULHW_256_ALT;
-    x86_VPMULLW_128_ALT; x86_VPMULLW_256_ALT;
-    x86_VPSUBW_128_ALT; x86_VPSUBW_256_ALT; x86_VPXOR;
+    x86_VPADDW_ALT; x86_VPMULHW_ALT; x86_VPMULLW_ALT; x86_VPSUBW_ALT;
+    x86_VPXOR;
     (*** 32-bit backups since the ALT forms are 64-bit only ***)
     INST_TYPE[`:32`,`:N`] x86_ADC;
     INST_TYPE[`:32`,`:N`] x86_ADCX;


### PR DESCRIPTION
*Description of changes:*

This PR adds AVX2 instructions vpsubw, vpaddw, vpmullw, and vpmulhw. In addition, an issue is fixed in the `read_VEX` function for reading 2-byte VEX.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
