### PR TITLE
Combine `{ARM,X86}[_BASIC]?_STEP_TAC` with their `_N` versions, print more error messages

### DIFF
--- a/arm/proofs/base.ml
+++ b/arm/proofs/base.ml
@@ -34,6 +34,7 @@ loadt "common/components.ml";;
 loadt "common/alignment.ml";;
 loadt "common/records.ml";;
 loadt "common/relational.ml";;
+loadt "common/relational_n.ml";;
 loadt "common/interval.ml";;
 loadt "common/elf.ml";;
 

--- a/common/relational2.ml
+++ b/common/relational2.ml
@@ -752,8 +752,22 @@ let ENSURES2_WHILE_PAUP_TAC =
       nsteps_pre1 nsteps_pre2
       nsteps_post1 nsteps_post2
       nsteps_backedge1 nsteps_backedge2 ->
-    MATCH_MP_TAC pth THEN
-    MAP_EVERY EXISTS_TAC [a;b;pc1_head;pc1_backedge;pc2_head;pc2_backedge;
+    (MATCH_MP_TAC pth ORELSE
+     (fun (asl,w) ->
+      let t = snd (dest_imp (snd (strip_forall (concl pth)))) in
+      Printf.printf "ENSURES2_WHILE_PAUP_TAC: the conclusion does not match\n";
+      print_qterm t;
+      FAIL_TAC "ENSURES2_WHILE_PAUP_TAC: input goal state ill-formed" (asl,w)))
+    THEN
+    MAP_EVERY (fun t ->
+        W (fun (asl,w) ->
+          EXISTS_TAC t ORELSE
+          let v = fst (dest_exists w) in
+          FAIL_TAC ("ENSURES2_WHILE_PAUP_TAC: var `" ^ (string_of_term v)
+              ^ ":" ^ (string_of_type (type_of v)) ^ "` does not match "
+              ^ "expression `" ^ (string_of_term t) ^ ":"
+              ^ (string_of_type (type_of t)) ^ "`")))
+      [a;b;pc1_head;pc1_backedge;pc2_head;pc2_backedge;
       loopinv;flagcond1;flagcond2;
       f_nsteps1;f_nsteps2;nsteps_pre1;nsteps_pre2;nsteps_post1;nsteps_post2;
       nsteps_backedge1;nsteps_backedge2] THEN

--- a/common/relational_n.ml
+++ b/common/relational_n.ml
@@ -10,7 +10,6 @@
 (*                                Juneyoung Lee                              *)
 (* ========================================================================= *)
 
-needs "common/bignum.ml";;
 needs "common/components.ml";;
 needs "common/relational.ml";;
 
@@ -192,15 +191,15 @@ let EVENTUALLY_N_COMPOSE = prove(
     FIRST_X_ASSUM MP_TAC THEN REWRITE_TAC[STEPS_ADD] THEN
     STRIP_TAC THEN ASM_MESON_TAC[];
 
-    ASM_CASES_TAC `n' < n1` THENL [
+    ASM_CASES_TAC `(n':num) < n1` THENL [
       ASM_MESON_TAC[];
 
-      SUBGOAL_THEN `n' = n1 + (n' - n1)` ASSUME_TAC THENL [
+      SUBGOAL_THEN `(n':num) = n1 + (n' - n1)` ASSUME_TAC THENL [
         SIMPLE_ARITH_TAC; ALL_TAC
       ] THEN
-      ABBREV_TAC `k = n' - n1` THEN
-      UNDISCH_THEN `n' = n1 + k` SUBST_ALL_TAC THEN
-      SUBGOAL_THEN `k < n2` ASSUME_TAC THENL [SIMPLE_ARITH_TAC;ALL_TAC] THEN
+      ABBREV_TAC `(k:num) = n' - n1` THEN
+      UNDISCH_THEN `(n':num) = n1 + k` SUBST_ALL_TAC THEN
+      SUBGOAL_THEN `(k:num) < n2` ASSUME_TAC THENL [SIMPLE_ARITH_TAC;ALL_TAC] THEN
       RULE_ASSUM_TAC(REWRITE_RULE[STEPS_ADD]) THEN ASM_MESON_TAC[]
     ]
   ]);;
@@ -233,7 +232,7 @@ let EVENTUALLY_N_STEP =
           UNDISCH_TAC `n' = SUC n''` THEN REWRITE_TAC[ARITH_RULE`!k. SUC k = 1+k`] THEN
           DISCH_THEN SUBST_ALL_TAC THEN
           RULE_ASSUM_TAC (REWRITE_RULE[STEPS_ADD;STEPS_ONE]) THEN
-          SUBGOAL_THEN `n''<n` ASSUME_TAC THENL [ASM_ARITH_TAC;ALL_TAC] THEN
+          SUBGOAL_THEN `n'':num < n` ASSUME_TAC THENL [ASM_ARITH_TAC;ALL_TAC] THEN
           ASM_MESON_TAC[]
         ]
       ]
@@ -260,7 +259,7 @@ let EVENTUALLY_N_IMP_EVENTUALLY_N = prove
     REWRITE_TAC [eventually_n] THEN
     REPEAT STRIP_TAC THENL [
       ASM_MESON_TAC[STEPS_ADD];
-      DISJ_CASES_TAC (ARITH_RULE `n' < n1 \/ n' >= n1`) THENL [
+      DISJ_CASES_TAC (ARITH_RULE `n':num < n1 \/ n' >= n1`) THENL [
         ASM_MESON_TAC[STEPS_ADD];
         FIRST_X_ASSUM (fun th -> CHOOSE_THEN ASSUME_TAC (REWRITE_RULE [GE; LE_EXISTS] th)) THEN
         ASM_MESON_TAC [LT_ADD_LCANCEL; STEPS_ADD]]]]);;
@@ -522,7 +521,7 @@ let ENSURES_N_TRANS = prove(
   CONJ_TAC THENL [
     ASM_MESON_TAC [STEPS_ADD; seq];
     REPEAT STRIP_TAC THEN
-    DISJ_CASES_TAC (ARITH_RULE `n' < n1 \/ n' >= n1`) THENL [
+    DISJ_CASES_TAC (ARITH_RULE `n':num < n1 \/ n' >= n1`) THENL [
       ASM_MESON_TAC [];
       FIRST_X_ASSUM (fun th -> CHOOSE_THEN ASSUME_TAC (REWRITE_RULE [GE; LE_EXISTS] th)) THEN
       ASM_MESON_TAC [LT_ADD_LCANCEL; STEPS_ADD]]]);;
@@ -564,14 +563,6 @@ let ENSURES_N_SEQUENCE_TAC =
 (* test at the end. Versions for up from 0...k-1, down from k-1...0 and up   *)
 (* from a...b-1.                                                             *)
 (* ------------------------------------------------------------------------- *)
-
-let COMPONENT_SINK = prove(`!B. ((\a:A b:B. T) ,, (\a:B b:C. T)) = (\a:A b:C. T)`, REWRITE_TAC [FUN_EQ_THM; seq]);;
-
-let MAYCHANGE_IDEMPOT_TAC' (asl, w as gl) =
-  match w with
-    Comb(Comb(Const("=", _), Comb(Comb(Const(",,", _), _), _)), Abs(_, Abs(_, Const("T", _)))) ->
-      MATCH_ACCEPT_TAC COMPONENT_SINK gl
-  | _ -> MAYCHANGE_IDEMPOT_TAC gl;;
 
 let ENSURES_N_WHILE_UP_TAC, ENSURES_N_WHILE_DOWN_TAC,
     ENSURES_N_WHILE_AUP_TAC, ENSURES_N_WHILE_ADOWN_TAC =
@@ -621,7 +612,7 @@ let ENSURES_N_WHILE_UP_TAC, ENSURES_N_WHILE_DOWN_TAC,
       CONJ_TAC THENL [
         UNDISCH_THEN `j + 1 < k` (MP_TAC o MP (ARITH_RULE `j + 1 < k ==> j < k`)) THEN
         FIRST_X_ASSUM (UNIFY_ACCEPT_TAC [`Q:A->bool`]);
-        SUBST1_TAC (ARITH_RULE `f_nsteps (j + 1) + nsteps_back = nsteps_back + f_nsteps (j + 1)`) THEN
+        SUBST1_TAC (ARITH_RULE `((f_nsteps (j + 1)):num) + nsteps_back = nsteps_back + f_nsteps (j + 1)`) THEN
         MATCH_MP_TAC ENSURES_N_TRANS_SIMPLE THEN META_EXISTS_TAC THEN
         ASM_REWRITE_TAC [] THEN
         CONJ_TAC THENL [
@@ -702,7 +693,8 @@ let ENSURES_N_WHILE_UP_TAC, ENSURES_N_WHILE_DOWN_TAC,
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP
+          (ARITH_RULE `a:num < b ==> a <= b - 1`) (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   let sth = prove(
     `!a b pc1 pc2 (loopinvariant:num->A->bool) nsteps_pre f_nsteps nsteps_back nsteps_post.
@@ -739,28 +731,28 @@ let ENSURES_N_WHILE_UP_TAC, ENSURES_N_WHILE_DOWN_TAC,
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   (fun k pc1 pc2 iv f_nsteps nsteps_pre nsteps_back nsteps_post ->
     MATCH_MP_TAC pth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_back; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun k pc1 pc2 iv f_nsteps nsteps_pre nsteps_back nsteps_post ->
     MATCH_MP_TAC qth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_back; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun a b pc1 pc2 iv f_nsteps nsteps_pre nsteps_back nsteps_post ->
     MATCH_MP_TAC rth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_back; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun b a pc1 pc2 iv f_nsteps nsteps_pre nsteps_back nsteps_post ->
     MATCH_MP_TAC sth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_back; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]);;
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]);;
 
 (* ------------------------------------------------------------------------- *)
 (* Variants where there is an extra conjunct in the end state that may       *)
@@ -898,7 +890,8 @@ let ENSURES_N_WHILE_PUP_TAC,ENSURES_N_WHILE_PDOWN_TAC,
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`)
+          (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   let sth = prove(
     `!a b pc1 pc2 p (q:num->A->bool) nsteps_pre f_nsteps nsteps_post.
@@ -935,28 +928,29 @@ let ENSURES_N_WHILE_PUP_TAC,ENSURES_N_WHILE_PDOWN_TAC,
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       FIRST_X_ASSUM MATCH_MP_TAC THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`)
+          (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   (fun k pc1 pc2 p q f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC pth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; p; q; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun k pc1 pc2 p q f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC qth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; p; q; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun a b pc1 pc2 p q f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC rth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; p; q; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun b a pc1 pc2 p q f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC sth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; p; q; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]);;
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]);;
 
 
 (* ------------------------------------------------------------------------- *)
@@ -1142,15 +1136,16 @@ let ENSURES_N_WHILE_UP2_TAC, ENSURES_N_WHILE_DOWN2_TAC,
         (\s. program_decodes s /\ read pcounter s = word pc /\ precondition s)
         postcondition C (\s. nsteps)`,
     REPEAT STRIP_TAC THEN MATCH_MP_TAC pth THEN
-    MAP_EVERY EXISTS_TAC [`b - a`; `pc1:num`; `pc2:num`; `\i. (loopinvariant:num->A->bool) (a + i)`; `nsteps_pre:num`; `\i. (f_nsteps:num->num) (a + i)`; `nsteps_post:num`] THEN
+    MAP_EVERY EXISTS_TAC [`b:num - a`; `pc1:num`; `pc2:num`; `\i. (loopinvariant:num->A->bool) (a + i)`; `nsteps_pre:num`; `\i. (f_nsteps:num->num) (a + i)`; `nsteps_post:num`] THEN
     ASM_REWRITE_TAC [SUB_EQ_0; NOT_LE; ADD_CLAUSES] THEN
-    ASM_SIMP_TAC [ARITH_RULE `a < b ==> a + b - a = b`] THEN
+    ASM_SIMP_TAC [ARITH_RULE `a:num < b ==> a + b - a = b`] THEN
     REWRITE_TAC [ADD_ASSOC] THEN STRIP_TAC THENL [
-      GEN_TAC THEN FIRST_X_ASSUM (MP_TAC o SPEC `a + i`) THEN
+      GEN_TAC THEN FIRST_X_ASSUM (MP_TAC o SPEC `(a:num) + i`) THEN
       REWRITE_TAC[ARITH_RULE `(a + i) + 1 < b <=> i + 1 < b - a`] THEN
       DISCH_THEN (fun th -> IMP_REWRITE_TAC[th]) THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`)
+          (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   let sth = prove(
     `!a b pc1 pc2 (loopinvariant:num->A->bool) nsteps_pre f_nsteps nsteps_post.
@@ -1174,33 +1169,34 @@ let ENSURES_N_WHILE_UP2_TAC, ENSURES_N_WHILE_DOWN2_TAC,
         (\s. program_decodes s /\ read pcounter s = word pc /\ precondition s)
         postcondition C (\s. nsteps)`,
     REPEAT STRIP_TAC THEN MATCH_MP_TAC qth THEN
-    MAP_EVERY EXISTS_TAC [`b - a`; `pc1:num`; `pc2:num`; `\i. (loopinvariant:num->A->bool) (a + i)`; `nsteps_pre:num`; `\i. (f_nsteps:num->num) (a + i)`; `nsteps_post:num`] THEN
+    MAP_EVERY EXISTS_TAC [`b:num - a`; `pc1:num`; `pc2:num`; `\i. (loopinvariant:num->A->bool) (a + i)`; `nsteps_pre:num`; `\i. (f_nsteps:num->num) (a + i)`; `nsteps_post:num`] THEN
     ASM_REWRITE_TAC [SUB_EQ_0; NOT_LE; ADD_CLAUSES] THEN
-    ASM_SIMP_TAC [ARITH_RULE `a < b ==> a + b - a = b`] THEN
+    ASM_SIMP_TAC [ARITH_RULE `a:num < b ==> a + b - a = b`] THEN
     REWRITE_TAC [ADD_ASSOC] THEN STRIP_TAC THENL [
-      GEN_TAC THEN FIRST_X_ASSUM (MP_TAC o SPEC `a + i`) THEN
+      GEN_TAC THEN FIRST_X_ASSUM (MP_TAC o SPEC `(a:num) + i`) THEN
       REWRITE_TAC[ARITH_RULE `a + i > a <=> i > 0`] THEN
       DISCH_THEN (fun th -> IMP_REWRITE_TAC[th]) THEN ASM_ARITH_TAC;
       REWRITE_TAC [ARITH_RULE `b - a - 1 = b - 1 - a`] THEN
-      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`) (ASSUME `a < b`))] THEN
+      ONCE_ASM_REWRITE_TAC [MATCH_MP NSUM_OFFSET_0 (MP (ARITH_RULE `a < b ==> a <= b - 1`)
+          (ASSUME `a:num < b`))] THEN
       ASM_REWRITE_TAC [ADD_SYM]]) in
   (fun k pc1 pc2 iv f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC pth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun k pc1 pc2 iv f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC qth THEN
     MAP_EVERY EXISTS_TAC [k; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun a b pc1 pc2 iv f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC rth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]),
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]),
   (fun b a pc1 pc2 iv f_nsteps nsteps_pre nsteps_post ->
     MATCH_MP_TAC sth THEN
     MAP_EVERY EXISTS_TAC [a; b; pc1; pc2; iv; nsteps_pre; f_nsteps; nsteps_post] THEN
     BETA_TAC THEN
-    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC'; ALL_TAC]);;
+    CONJ_TAC THENL [MAYCHANGE_IDEMPOT_TAC; ALL_TAC]);;

--- a/x86/proofs/base.ml
+++ b/x86/proofs/base.ml
@@ -34,6 +34,7 @@ loadt "common/components.ml";;
 loadt "common/alignment.ml";;
 loadt "common/records.ml";;
 loadt "common/relational.ml";;
+loadt "common/relational_n.ml";;
 loadt "common/interval.ml";;
 loadt "common/elf.ml";;
 

--- a/x86/proofs/equiv.ml
+++ b/x86/proofs/equiv.ml
@@ -150,31 +150,6 @@ let BYTES_LOADED_BARRIER_X86_STUCK = prove(
 (* Tactics for simulating a program whose postcondition is eventually_n.     *)
 (* ------------------------------------------------------------------------- *)
 
-(* A variant of X86_BASIC_STEP_TAC, but targets eventually_n *)
-let X86_N_BASIC_STEP_TAC =
-  let x86_tm = `x86` and x86_ty = `:x86state` and one = `1:num` in
-  fun decode_th sname store_inst_term_to (asl,w) ->
-    (* w = `eventually_n _ {stepn} _ {sv}` *)
-    let sv = rand w and sv' = mk_var(sname,x86_ty) in
-    let atm = mk_comb(mk_comb(x86_tm,sv),sv') in
-    let eth = X86_CONV decode_th (map snd asl) atm in
-    (* store the decoded instruction at store_inst_term_to *)
-    (match store_inst_term_to with | Some r -> r := rhs (concl eth) | None -> ());
-    let stepn = dest_numeral(rand(rator(rator w))) in
-    let stepn_decr = stepn -/ num 1 in
-    (* stepn = 1+{stepn-1}*)
-    let stepn_thm = GSYM (NUM_ADD_CONV (mk_binary "+" (one,mk_numeral(stepn_decr)))) in
-    (GEN_REWRITE_TAC (RATOR_CONV o RATOR_CONV o RAND_CONV) [stepn_thm] THEN
-      GEN_REWRITE_TAC I [EVENTUALLY_N_STEP] THEN CONJ_TAC THENL
-     [GEN_REWRITE_TAC BINDER_CONV [eth] THEN
-      (CONV_TAC EXISTS_NONTRIVIAL_CONV ORELSE
-       (PRINT_GOAL_TAC THEN
-        FAIL_TAC ("Equality between two states is ill-formed." ^
-                  " Did you forget extra condition like pointer alignment?")));
-      X_GEN_TAC sv' THEN GEN_REWRITE_TAC LAND_CONV [eth] THEN
-      REPEAT X86_UNDEFINED_CHOOSE_TAC]) (asl,w);;
-
-
 (* A variant of X86_STEP_TAC for equivalence checking.
 
    If 'store_update_to' is Some ref, a list of
@@ -187,58 +162,30 @@ let X86_N_BASIC_STEP_TAC =
 let X86_N_STEP_TAC (mc_length_th,decode_ths) subths sname
                   (store_update_to:(thm list * thm list) ref option)
                   (store_inst_term_to: term ref option)  =
-  (*** This does the basic decoding setup ***)
+  X86_STEP_TAC (mc_length_th,decode_th) subths sname store_inst_term_to
+    (fun th ->
+      let has_auxmems = ref false in
+      (** If there is an 'unsimplified' memory read on the right hand side,
+          try to synthesize an expression using bigdigit and use it. **)
+      DISCH_THEN (fun simplified_th (asl,w) ->
+        let res_th,newmems_th = DIGITIZE_MEMORY_READS simplified_th th (asl,w) in
+        (* MP_TAC res_th and newmems_th first, to drop their assumptions. *)
+        (MP_TAC res_th THEN
+        (match newmems_th with
+        | None -> (has_auxmems := false; ALL_TAC)
+        | Some ths -> (has_auxmems := true; MP_TAC ths))) (asl,w))
+      THEN
 
-  X86_N_BASIC_STEP_TAC decode_ths sname store_inst_term_to THEN
-
-  (*** This part shows the code isn't self-modifying ***)
-
-  NONSELFMODIFYING_STATE_UPDATE_TAC (MATCH_MP bytes_loaded_update mc_length_th) THEN
-
-  (*** Attempt also to show subroutines aren't modified, if applicable ***)
-
-  MAP_EVERY (TRY o NONSELFMODIFYING_STATE_UPDATE_TAC o
-    MATCH_MP bytes_loaded_update o CONJUNCT1) subths THEN
-
-  (*** This part produces any updated versions of existing asms ***)
-
-  ASSUMPTION_STATE_UPDATE_TAC THEN
-
-  (*** Produce updated "MAYCHANGE" assumption ***)
-
-  MAYCHANGE_STATE_UPDATE_TAC THEN
-
-  (*** This adds state component theorems for the updates ***)
-  (*** Could also assume th itself but I throw it away   ***)
-
-  DISCH_THEN(fun th ->
-    let thl = STATE_UPDATE_NEW_RULE th in
-    if thl = [] then ALL_TAC else
-    MP_TAC(end_itlist CONJ thl) THEN
-    ASSEMBLER_SIMPLIFY_TAC THEN
-
-    let has_auxmems = ref false in
-    (** If there is an 'unsimplified' memory read on the right hand side,
-        try to synthesize an expression using bigdigit and use it. **)
-    DISCH_THEN (fun simplified_th (asl,w) ->
-      let res_th,newmems_th = DIGITIZE_MEMORY_READS simplified_th th (asl,w) in
-      (* MP_TAC res_th and newmems_th first, to drop their assumptions. *)
-      (MP_TAC res_th THEN
-      (match newmems_th with
-       | None -> (has_auxmems := false; ALL_TAC)
-       | Some ths -> (has_auxmems := true; MP_TAC ths))) (asl,w))
-    THEN
-
-    (* store it to a reference, or make them assumptions *)
-    W (fun _ ->
-      match store_update_to with
-      | None -> STRIP_TAC THEN (if !has_auxmems then STRIP_TAC else ALL_TAC)
-      | Some to_ref ->
-        if !has_auxmems then
-          DISCH_THEN (fun auxmems -> DISCH_THEN (fun res ->
-            to_ref := (CONJUNCTS res, CONJUNCTS auxmems); ALL_TAC))
-        else
-          DISCH_THEN (fun res -> to_ref := (CONJUNCTS res, []); ALL_TAC)));;
+      (* store it to a reference, or make them assumptions *)
+      W (fun _ ->
+        match store_update_to with
+        | None -> STRIP_TAC THEN (if !has_auxmems then STRIP_TAC else ALL_TAC)
+        | Some to_ref ->
+          if !has_auxmems then
+            DISCH_THEN (fun auxmems -> DISCH_THEN (fun res ->
+              to_ref := (CONJUNCTS res, CONJUNCTS auxmems); ALL_TAC))
+          else
+            DISCH_THEN (fun res -> to_ref := (CONJUNCTS res, []); ALL_TAC)));;
 
 (* A variant of X86_STEPS_TAC but uses DISCARD_OLDSTATE_AGGRESSIVELY_TAC
    instead.

--- a/x86/proofs/equiv.ml
+++ b/x86/proofs/equiv.ml
@@ -162,7 +162,7 @@ let BYTES_LOADED_BARRIER_X86_STUCK = prove(
 let X86_N_STEP_TAC (mc_length_th,decode_ths) subths sname
                   (store_update_to:(thm list * thm list) ref option)
                   (store_inst_term_to: term ref option)  =
-  X86_STEP_TAC (mc_length_th,decode_th) subths sname store_inst_term_to
+  X86_STEP_TAC (mc_length_th,decode_ths) subths sname store_inst_term_to
     (fun th ->
       let has_auxmems = ref false in
       (** If there is an 'unsimplified' memory read on the right hand side,

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -2914,20 +2914,49 @@ let X86_CONV (decode_ths:thm option array) ths tm =
  ) tm;;
 
 let X86_BASIC_STEP_TAC =
-  let x86_tm = `x86` and x86_ty = `:x86state` in
-  fun (decode_ths: thm option array) sname (asl,w) ->
+  let x86_tm = `x86` and x86_ty = `:x86state` and one = `1:num` in
+  fun (decode_ths: thm option array) sname store_inst_term_to (asl,w) ->
     let sv = rand w and sv' = mk_var(sname,x86_ty) in
     let atm = mk_comb(mk_comb(x86_tm,sv),sv') in
     let eth = X86_CONV decode_ths (map snd asl) atm in
-    (GEN_REWRITE_TAC I [eventually_CASES] THEN DISJ2_TAC THEN CONJ_TAC THENL
-     [GEN_REWRITE_TAC BINDER_CONV [eth] THEN CONV_TAC EXISTS_NONTRIVIAL_CONV;
+
+    (* store the decoded instruction at store_inst_term_to *)
+    (match store_inst_term_to with
+     | Some r -> r := rhs (concl eth)
+     | None -> ());
+
+    (* prepare a tactic for progressing to a next step. *)
+    let progress_tac =
+      let c,_ = strip_comb w in
+      if name_of c = "eventually" then
+        GEN_REWRITE_TAC I [eventually_CASES] THEN DISJ2_TAC
+      else if name_of c = "eventually_n" then
+        let stepn = dest_numeral(rand(rator(rator w))) in
+        let stepn_decr = stepn -/ num 1 in
+        (* stepn = 1+{stepn-1}*)
+        let stepn_thm = GSYM (NUM_ADD_CONV
+          (mk_binary "+" (one,mk_numeral(stepn_decr)))) in
+        GEN_REWRITE_TAC (RATOR_CONV o RATOR_CONV o RAND_CONV) [stepn_thm] THEN
+        GEN_REWRITE_TAC I [EVENTUALLY_N_STEP]
+      else failwith "X86_BASIC_STEP_TAC: neither eventually nor eventually_n"
+      in
+
+    (progress_tac THEN CONJ_TAC THENL
+     [GEN_REWRITE_TAC BINDER_CONV [eth] THEN
+      (CONV_TAC EXISTS_NONTRIVIAL_CONV ORELSE
+        (PRINT_GOAL_TAC THEN
+        FAIL_TAC ("X86_BASIC_STEP_TAC: Equality between two states is " ^
+                  "ill-formed. Did you forget to assume an extra condition" ^
+                  " like pointer alignment?")));
       X_GEN_TAC sv' THEN GEN_REWRITE_TAC LAND_CONV [eth] THEN
       REPEAT X86_UNDEFINED_CHOOSE_TAC]) (asl,w);;
 
-let X86_STEP_TAC (mc_length_th,decode_ths) subths sname =
+let X86_STEP_TAC (mc_length_th,decode_ths) subths sname
+      (store_inst_term_to: term ref option)
+      (strip_component_tac: thm_tactic) =
   (*** This does the basic decoding setup ***)
 
-  X86_BASIC_STEP_TAC decode_ths sname THEN
+  X86_BASIC_STEP_TAC decode_ths sname store_inst_term_to THEN
 
   (*** This part shows the code isn't self-modifying ***)
 
@@ -2955,15 +2984,15 @@ let X86_STEP_TAC (mc_length_th,decode_ths) subths sname =
     if thl = [] then ALL_TAC else
     MP_TAC(end_itlist CONJ thl) THEN
     ASSEMBLER_SIMPLIFY_TAC THEN
-    STRIP_TAC);;
+    strip_component_tac th);;
 
 let X86_VERBOSE_STEP_TAC (exth1,exth2) sname g =
   Format.print_string("Stepping to state "^sname); Format.print_newline();
-  X86_STEP_TAC (exth1,exth2) [] sname g;;
+  X86_STEP_TAC (exth1,exth2) [] sname None (K STRIP_TAC) g;;
 
 let X86_VERBOSE_SUBSTEP_TAC (exth1,exth2) subths sname g =
   Format.print_string("Stepping to state "^sname); Format.print_newline();
-  X86_STEP_TAC (exth1,exth2) subths sname g;;
+  X86_STEP_TAC (exth1,exth2) subths sname None (K STRIP_TAC) g;;
 
 (* ------------------------------------------------------------------------- *)
 (* Throw away assumptions according to patterns.                             *)


### PR DESCRIPTION
*Description of changes:*

This patch does a refactoring of symbolic simulation tactics for `ensures` and `ensures_n` so that their implementations share the common part.

Also, this patch adds a small update in `ENSURES2_WHILE_PAUP_TAC` to print the reason when the tactic fails.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
