### PR TITLE
Add missing arch specifier patch from Hanno's pull request (#263)

### DIFF
--- a/arm/sha3/sha3_keccak2_f1600.S
+++ b/arm/sha3/sha3_keccak2_f1600.S
@@ -29,6 +29,7 @@
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
+        .arch armv8.4-a+sha3
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(sha3_keccak2_f1600)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(sha3_keccak2_f1600)
         .text

--- a/arm/sha3/sha3_keccak2_f1600_alt.S
+++ b/arm/sha3/sha3_keccak2_f1600_alt.S
@@ -29,6 +29,7 @@
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
+        .arch armv8.4-a+sha3
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(sha3_keccak2_f1600_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(sha3_keccak2_f1600_alt)
         .text

--- a/arm/sha3/sha3_keccak4_f1600.S
+++ b/arm/sha3/sha3_keccak4_f1600.S
@@ -30,6 +30,7 @@
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
+        .arch armv8.4-a+sha3
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(sha3_keccak4_f1600)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(sha3_keccak4_f1600)
         .text

--- a/arm/sha3/sha3_keccak4_f1600_alt2.S
+++ b/arm/sha3/sha3_keccak4_f1600_alt2.S
@@ -31,6 +31,7 @@
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
+        .arch armv8.4-a+sha3
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(sha3_keccak4_f1600_alt2)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(sha3_keccak4_f1600_alt2)
         .text

--- a/arm/sha3/sha3_keccak_f1600_alt.S
+++ b/arm/sha3/sha3_keccak_f1600_alt.S
@@ -26,6 +26,7 @@
 // ----------------------------------------------------------------------------
 #include "_internal_s2n_bignum.h"
 
+        .arch armv8.4-a+sha3
         S2N_BN_SYM_VISIBILITY_DIRECTIVE(sha3_keccak_f1600_alt)
         S2N_BN_SYM_PRIVACY_DIRECTIVE(sha3_keccak_f1600_alt)
         .text


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

SHA3: Add .arch specifier to asm relying on Arm SHA3 instructions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
