### PR TITLE
Print PC and instruction when {x86,arm}_print_log is set

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -354,6 +354,16 @@ let ARM_THM =
         dest_small_numeral ofs
       with Failure _ ->
         failwith ("ARM_THM: Cannot decompose PC expression: " ^ (string_of_term (concl pc_th))) in
+    let _ = if !arm_print_log then
+      let opt = Option.get execth2.(pc_ofs) in
+      (* opt: |- forall ... aligned_bytes_loaded ..
+                 ==> arm_decode .. (arm_INST ..) *)
+      let t = snd (strip_forall (concl (opt))) in
+      let t = snd (dest_imp t) in
+      let term = snd (dest_comb t) in
+      Printf.printf "Instruction at `pc + %d`: `%s`\n" pc_ofs
+          (string_of_term term)
+    in
     MATCH_MP th (MATCH_MP (Option.get execth2.(pc_ofs)) loaded_mc_th);;
 
 let ARM_ENSURES_SUBLEMMA_TAC =

--- a/arm/tutorial/simple.ml
+++ b/arm/tutorial/simple.ml
@@ -104,4 +104,16 @@ let SIMPLE_SPEC = prove(
    To list which instructions are discarded by the simulation tactic.
    set:
     arm_print_log := true;;
-   This flag will also print helpful informations that are useful. *)
+   This flag will also print helpful informations that are useful.
+
+   Setting this flag to true will also print the executing instructions as well
+   as their PCs.
+   For the above example, it will print:
+
+    Stepping to state s1
+    Instruction at `pc + 0`: `arm_ADD X2 X1 X0`
+    CPU time (user): 0.006777
+    Stepping to state s2
+    Instruction at `pc + 4`: `arm_SUB X2 X2 X1`
+    CPU time (user): 0.00889600000002
+*)

--- a/x86/proofs/decode.ml
+++ b/x86/proofs/decode.ml
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR ISC OR MIT-0
  *)
 
-let decode_log = ref false;;
+let decode_print_log = ref false;;
 
 (* ========================================================================= *)
 (* x86 instruction decoding.                                                 *)
@@ -1452,7 +1452,7 @@ let READ_SIB_CONV,READ_MODRM_CONV,READ_VEX_CONV,DECODE_CONV =
   | _ -> failwith "DECODE_HI_CONV" in
 
   (* A wrapper function of the 'evaluate' function defined below.
-     If decode_log reference variable is assigned true, this will print the
+     If decode_print_log reference variable is assigned true, this will print the
      current evaluation context and the term that is being reduced. *)
   let log_step =
     let print_assignments (ls:(term * term) list): unit =
@@ -1478,7 +1478,7 @@ let READ_SIB_CONV,READ_MODRM_CONV,READ_VEX_CONV,DECODE_CONV =
       let eval_simplified = evaluate t_focus (fun th ->
         let f_partialeval = F th in
         fun ls ->
-          if not !decode_log then f_partialeval ls else
+          if not !decode_print_log then f_partialeval ls else
           let _ = Printf.printf "decode: evaluate (\"%s\", eval id %d):"
             op eval_id in
           let _ = Printf.printf " evaluated to (assigns deferred): `%s`\n%!"
@@ -1486,7 +1486,7 @@ let READ_SIB_CONV,READ_MODRM_CONV,READ_VEX_CONV,DECODE_CONV =
           let _ = print_assignments ls in
           f_partialeval ls) in
       fun ls ->
-        if not !decode_log then eval_simplified ls else
+        if not !decode_print_log then eval_simplified ls else
         let _ = Printf.printf "decode: evaluate (\"%s\", eval id %d):"
             op eval_id in
         let _ = Printf.printf " evaluating: `%s`\n%!"

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -2960,6 +2960,15 @@ let X86_THM =
       with Failure _ ->
         failwith ("X86_THM: Cannot decompose PC expression: " ^
                   string_of_term (concl pc_th)) in
+    let _ = if !x86_print_log then
+      let opt = Option.get execth2.(pc_ofs) in
+      (* opt: |- forall ... bytes_loaded .. ==> x86_decode .. (INST ..) *)
+      let t = snd (strip_forall (concl (opt))) in
+      let t = snd (dest_imp t) in
+      let term = snd (dest_comb t) in
+      Printf.printf "Instruction at `pc + %d`: `%s`\n" pc_ofs
+          (string_of_term term)
+    in
     CONV_RULE
       (ONCE_DEPTH_CONV
         (REWR_CONV (GSYM ADD_ASSOC) THENC RAND_CONV NUM_REDUCE_CONV))

--- a/x86/tutorial/simple.ml
+++ b/x86/tutorial/simple.ml
@@ -106,4 +106,16 @@ let SIMPLE_SPEC = prove(
    To list which instructions are discarded by the simulation tactic.
    set:
     x86_print_log := true;;
-   This flag will also print helpful informations that are useful. *)
+   This flag will also print helpful informations that are useful.
+
+   Setting this flag to true will also print the executing instructions as well
+   as their PCs.
+   For the above example, it will print:
+
+    Stepping to state s1
+    Instruction at `pc + 0`: `3,ADD (% rbx) (% rax)`
+    CPU time (user): 0.071801
+    Stepping to state s2
+    Instruction at `pc + 3`: `3,SUB (% rbx) (% rax)`
+    CPU time (user): 0.093077
+*)


### PR DESCRIPTION
Also rename decode_log to decode_print_log for consistent naming

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
