### PR TITLE
Add AWS-LC integration check with shared libs on, fix the error due to global readonly symbols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,7 @@ jobs:
     - name: Install dependent packages
       run: |
         brew install opam
+        opam init -a
 
     - name: Install HOL Light
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       run: |
         export HOLDIR=`pwd`/hol-light
         cd ${{ matrix.arch }}
-        make tutorial
+        make tutorial -j
 
   s2n-bignum-tutorial-macos-arm:
     runs-on: macos-latest
@@ -185,4 +185,4 @@ jobs:
       run: |
         export HOLDIR=`pwd`/hol-light
         cd arm
-        make tutorial
+        make tutorial -j

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
         mkdir aws-lc-build && cd aws-lc-build
         cmake3 -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIPS=On ../aws-lc
         ninja-build run_tests
+        cmake3 -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIPS=Off -DBUILD_SHARED_LIBS=1 ../aws-lc
+        ninja-build run_tests
         cmake3 -GNinja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DFIPS=Off ../aws-lc
         ninja-build run_tests
 
@@ -153,4 +155,33 @@ jobs:
       run: |
         export HOLDIR=`pwd`/hol-light
         cd ${{ matrix.arch }}
+        make tutorial
+
+  s2n-bignum-tutorial-macos-arm:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install dependent packages
+      run: |
+        brew install opam
+
+    - name: Install HOL Light
+      run: |
+        git clone https://github.com/jrh13/hol-light.git
+        cd hol-light
+        git checkout ${{ env.HOLLIGHT_COMMIT }}
+        make switch-5
+        eval $(opam env)
+        echo $(ocamlc -version)
+        echo $(camlp5 -v)
+        HOLLIGHT_USE_MODULE=1 make
+        cd ..
+
+    - name: Run tutorial
+      run: |
+        export HOLDIR=`pwd`/hol-light
+        cd arm
         make tutorial

--- a/arm/Makefile
+++ b/arm/Makefile
@@ -408,7 +408,9 @@ OBJ = $(POINT_OBJ) $(BIGNUM_OBJ)
 
 TUTORIAL_PROOFS = $(wildcard tutorial/*.ml)
 
-TUTORIAL_OBJ = $(TUTORIAL_PROOFS:.ml=.o) tutorial/rel_loop2.o tutorial/rel_simp2.o tutorial/rel_veceq2.o tutorial/rel_equivtac2.o tutorial/rel_reordertac2.o
+TUTORIAL_OBJ = $(TUTORIAL_PROOFS:.ml=.o) tutorial/rel_loop2.o \
+    tutorial/rel_simp2.o tutorial/rel_veceq2.o tutorial/rel_equivtac2.o \
+    tutorial/rel_reordertac2.o tutorial/rodata_local.o
 
 # According to
 # https://developer.apple.com/documentation/xcode/writing-arm64-code-for-apple-platforms,
@@ -518,6 +520,7 @@ sm2/sm2_montjscalarmul_alt.native: sm2/sm2_montjadd_alt.native sm2/sm2_montjdoub
 .SECONDEXPANSION:
 tutorial/%.native: tutorial/%.ml tutorial/%.o ; ../tools/build-proof.sh "$<" "$(HOLLIGHT)" "$@"
 # Additional dependencies on .o files
+tutorial/rodata.native: tutorial/rodata_local.o
 tutorial/rel_loop.native: tutorial/rel_loop2.o
 tutorial/rel_simp.native: tutorial/rel_simp2.o
 tutorial/rel_veceq.native: tutorial/rel_veceq2.o

--- a/arm/curve25519/curve25519_x25519base.S
+++ b/arm/curve25519/curve25519_x25519base.S
@@ -23,7 +23,6 @@
 .type curve25519_x25519base, %function
 .size curve25519_x25519base, 11292
 
-.global curve25519_x25519base_constant
 .type curve25519_x25519base_constant, %object
 .size curve25519_x25519base_constant, 48576
 #endif

--- a/arm/curve25519/curve25519_x25519base_alt.S
+++ b/arm/curve25519/curve25519_x25519base_alt.S
@@ -23,7 +23,6 @@
 .type curve25519_x25519base_alt, %function
 .size curve25519_x25519base_alt, 8788
 
-.global curve25519_x25519base_alt_constant
 .type curve25519_x25519base_alt_constant, %object
 .size curve25519_x25519base_alt_constant, 48576
 #endif

--- a/arm/curve25519/curve25519_x25519base_byte.S
+++ b/arm/curve25519/curve25519_x25519base_byte.S
@@ -23,7 +23,6 @@
 .type curve25519_x25519base_byte, %function
 .size curve25519_x25519base_byte, 11772
 
-.global curve25519_x25519base_byte_constant
 .type curve25519_x25519base_byte_constant, %object
 .size curve25519_x25519base_byte_constant, 48576
 #endif

--- a/arm/curve25519/curve25519_x25519base_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519base_byte_alt.S
@@ -23,7 +23,6 @@
 .type curve25519_x25519base_byte_alt, %function
 .size curve25519_x25519base_byte_alt, 9268
 
-.global curve25519_x25519base_byte_alt_constant
 .type curve25519_x25519base_byte_alt_constant, %object
 .size curve25519_x25519base_byte_alt_constant, 48576
 #endif

--- a/arm/curve25519/edwards25519_scalarmulbase.S
+++ b/arm/curve25519/edwards25519_scalarmulbase.S
@@ -22,7 +22,6 @@
 .type edwards25519_scalarmulbase, %function
 .size edwards25519_scalarmulbase, 12072
 
-.global edwards25519_scalarmulbase_constant
 .type edwards25519_scalarmulbase_constant, %object
 .size edwards25519_scalarmulbase_constant, 48576
 #endif

--- a/arm/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/arm/curve25519/edwards25519_scalarmulbase_alt.S
@@ -22,7 +22,6 @@
 .type edwards25519_scalarmulbase_alt, %function
 .size edwards25519_scalarmulbase_alt, 9248
 
-.global edwards25519_scalarmulbase_alt_constant
 .type edwards25519_scalarmulbase_alt_constant, %object
 .size edwards25519_scalarmulbase_alt_constant, 48576
 #endif

--- a/arm/curve25519/edwards25519_scalarmuldouble.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble.S
@@ -30,7 +30,6 @@
 .type edwards25519_scalarmuldouble, %function
 .size edwards25519_scalarmuldouble, 32168
 
-.global edwards25519_scalarmuldouble_constant
 .type edwards25519_scalarmuldouble_constant, %object
 .size edwards25519_scalarmuldouble_constant, 768
 #endif

--- a/arm/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -30,7 +30,6 @@
 .type edwards25519_scalarmuldouble_alt, %function
 .size edwards25519_scalarmuldouble_alt, 22184
 
-.global edwards25519_scalarmuldouble_alt_constant
 .type edwards25519_scalarmuldouble_alt_constant, %object
 .size edwards25519_scalarmuldouble_alt_constant, 768
 #endif

--- a/arm/proofs/curve25519_x25519base.ml
+++ b/arm/proofs/curve25519_x25519base.ml
@@ -28,9 +28,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf  "arm/curve25519/curve25519_x25519base.o";;
  ****)
 
-let curve25519_x25519base_mc,[curve25519_x25519base_constant_data] =
-  define_assert_relocs_from_elf "curve25519_x25519base_mc"
-  "arm/curve25519/curve25519_x25519base.o"
+let curve25519_x25519base_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "curve25519_x25519base_constant"
+        -> "curve25519_x25519base_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "curve25519_x25519base_mc"
+    "arm/curve25519/curve25519_x25519base.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -44,8 +50,8 @@ let curve25519_x25519base_mc,[curve25519_x25519base_constant_data] =
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
   w 0xf94003e0;         (* arm_LDR X0 SP (Immediate_Offset (word 0)) *)
   w 0xf27d001f;         (* arm_TST X0 (rvalue (word 8)) *)
-  ADRP (mk_var("curve25519_x25519base_data",`:num`),0,48,19);
-  ADD_rri64 (mk_var("curve25519_x25519base_data",`:num`),0,19,19);
+  ADRP (mk_var("curve25519_x25519base_constant_data",`:num`),0,48,19);
+  ADD_rri64 (mk_var("curve25519_x25519base_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -2856,6 +2862,8 @@ let curve25519_x25519base_mc,[curve25519_x25519base_constant_data] =
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let curve25519_x25519base_constant_data = last const_data_list;;
 
 let CURVE25519_X25519BASE_EXEC =
   ARM_MK_EXEC_RULE curve25519_x25519base_mc;;

--- a/arm/proofs/curve25519_x25519base_alt.ml
+++ b/arm/proofs/curve25519_x25519base_alt.ml
@@ -28,9 +28,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf "arm/curve25519/curve25519_x25519base_alt.o";;
  ****)
 
-let curve25519_x25519base_alt_mc,[curve25519_x25519base_alt_constant_data] =
-  define_assert_relocs_from_elf "curve25519_x25519base_alt_mc"
-  "arm/curve25519/curve25519_x25519base_alt.o"
+let curve25519_x25519base_alt_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "curve25519_x25519base_alt_constant"
+        -> "curve25519_x25519base_alt_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "curve25519_x25519base_alt_mc"
+    "arm/curve25519/curve25519_x25519base_alt.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -44,8 +50,8 @@ let curve25519_x25519base_alt_mc,[curve25519_x25519base_alt_constant_data] =
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
   w 0xf94003e0;         (* arm_LDR X0 SP (Immediate_Offset (word 0)) *)
   w 0xf27d001f;         (* arm_TST X0 (rvalue (word 8)) *)
-  ADRP (mk_var("curve25519_x25519base_alt_constant",`:num`),0,48,19);
-  ADD_rri64 (mk_var("curve25519_x25519base_alt_constant",`:num`),0,19,19);
+  ADRP (mk_var("curve25519_x25519base_alt_constant_data",`:num`),0,48,19);
+  ADD_rri64 (mk_var("curve25519_x25519base_alt_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -2230,6 +2236,8 @@ let curve25519_x25519base_alt_mc,[curve25519_x25519base_alt_constant_data] =
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let curve25519_x25519base_alt_constant_data = last const_data_list;;
 
 let CURVE25519_X25519BASE_ALT_EXEC =
   ARM_MK_EXEC_RULE curve25519_x25519base_alt_mc;;

--- a/arm/proofs/curve25519_x25519base_byte.ml
+++ b/arm/proofs/curve25519_x25519base_byte.ml
@@ -28,9 +28,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf "arm/curve25519/curve25519_x25519base_byte.o";;
  ****)
 
-let curve25519_x25519base_byte_mc,[curve25519_x25519base_byte_constant_data] =
-  define_assert_relocs_from_elf "curve25519_x25519base_byte_mc"
-  "arm/curve25519/curve25519_x25519base_byte.o"
+let curve25519_x25519base_byte_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "curve25519_x25519base_byte_constant"
+        -> "curve25519_x25519base_byte_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "curve25519_x25519base_byte_mc"
+    "arm/curve25519/curve25519_x25519base_byte.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -102,8 +108,8 @@ let curve25519_x25519base_byte_mc,[curve25519_x25519base_byte_constant_data] =
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
   w 0xf94003e0;         (* arm_LDR X0 SP (Immediate_Offset (word 0)) *)
   w 0xf27d001f;         (* arm_TST X0 (rvalue (word 8)) *)
-  ADRP (mk_var("curve25519_x25519base_byte_constant",`:num`),0,280,19);
-  ADD_rri64 (mk_var("curve25519_x25519base_byte_constant",`:num`),0,19,19);
+  ADRP (mk_var("curve25519_x25519base_byte_constant_data",`:num`),0,280,19);
+  ADD_rri64 (mk_var("curve25519_x25519base_byte_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -2976,6 +2982,8 @@ let curve25519_x25519base_byte_mc,[curve25519_x25519base_byte_constant_data] =
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let curve25519_x25519base_byte_constant_data = const_data_list;;
 
 let CURVE25519_X25519BASE_BYTE_EXEC =
   ARM_MK_EXEC_RULE curve25519_x25519base_byte_mc;;

--- a/arm/proofs/curve25519_x25519base_byte_alt.ml
+++ b/arm/proofs/curve25519_x25519base_byte_alt.ml
@@ -28,9 +28,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf "arm/curve25519/curve25519_x25519base_byte_alt.o";;
  ****)
 
-let curve25519_x25519base_byte_alt_mc,[curve25519_x25519base_byte_alt_constant_data] =
-  define_assert_relocs_from_elf "curve25519_x25519base_byte_alt_mc"
-  "arm/curve25519/curve25519_x25519base_byte_alt.o"
+let curve25519_x25519base_byte_alt_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "curve25519_x25519base_byte_alt_constant"
+        -> "curve25519_x25519base_byte_alt_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "curve25519_x25519base_byte_alt_mc"
+    "arm/curve25519/curve25519_x25519base_byte_alt.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -102,8 +108,8 @@ let curve25519_x25519base_byte_alt_mc,[curve25519_x25519base_byte_alt_constant_d
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
   w 0xf94003e0;         (* arm_LDR X0 SP (Immediate_Offset (word 0)) *)
   w 0xf27d001f;         (* arm_TST X0 (rvalue (word 8)) *)
-  ADRP (mk_var("curve25519_x25519base_byte_alt_constant",`:num`),0,280,19);
-  ADD_rri64 (mk_var("curve25519_x25519base_byte_alt_constant",`:num`),0,19,19);
+  ADRP (mk_var("curve25519_x25519base_byte_alt_constant_data",`:num`),0,280,19);
+  ADD_rri64 (mk_var("curve25519_x25519base_byte_alt_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -2350,6 +2356,8 @@ let curve25519_x25519base_byte_alt_mc,[curve25519_x25519base_byte_alt_constant_d
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let curve25519_x25519base_byte_alt_constant_data = last const_data_list;;
 
 let CURVE25519_X25519BASE_BYTE_ALT_EXEC =
   ARM_MK_EXEC_RULE curve25519_x25519base_byte_alt_mc;;

--- a/arm/proofs/edwards25519_scalarmulbase.ml
+++ b/arm/proofs/edwards25519_scalarmulbase.ml
@@ -27,9 +27,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf  "arm/curve25519/edwards25519_scalarmulbase.o";;
  ****)
 
-let edwards25519_scalarmulbase_mc,[edwards25519_scalarmulbase_constant_data] =
-  define_assert_relocs_from_elf "edwards25519_scalarmulbase_mc"
-  "arm/curve25519/edwards25519_scalarmulbase.o"
+let edwards25519_scalarmulbase_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "edwards25519_scalarmulbase_constant"
+        -> "edwards25519_scalarmulbase_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "edwards25519_scalarmulbase_mc"
+    "arm/curve25519/edwards25519_scalarmulbase.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -74,8 +80,8 @@ let edwards25519_scalarmulbase_mc,[edwards25519_scalarmulbase_constant_data] =
   w 0xf24501bf;         (* arm_TST X13 (rvalue (word 576460752303423488)) *)
   w 0x9244f9ad;         (* arm_AND X13 X13 (rvalue (word 17870283321406128127)) *)
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
-  ADRP (mk_var("edwards25519_scalarmulbase_constant",`:num`),0,172,19);
-  ADD_rri64 (mk_var("edwards25519_scalarmulbase_constant",`:num`),0,19,19);
+  ADRP (mk_var("edwards25519_scalarmulbase_constant_data",`:num`),0,172,19);
+  ADD_rri64 (mk_var("edwards25519_scalarmulbase_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -3050,6 +3056,8 @@ let edwards25519_scalarmulbase_mc,[edwards25519_scalarmulbase_constant_data] =
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let edwards25519_scalarmulbase_constant_data = last const_data_list;;
 
 let EDWARDS25519_SCALARMULBASE_EXEC =
   ARM_MK_EXEC_RULE edwards25519_scalarmulbase_mc;;

--- a/arm/proofs/edwards25519_scalarmulbase_alt.ml
+++ b/arm/proofs/edwards25519_scalarmulbase_alt.ml
@@ -27,9 +27,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf  "arm/curve25519/edwards25519_scalarmulbase_alt.o";;
  ****)
 
-let edwards25519_scalarmulbase_alt_mc,[edwards25519_scalarmulbase_alt_constant_data] =
-  define_assert_relocs_from_elf "edwards25519_scalarmulbase_alt_mc"
-  "arm/curve25519/edwards25519_scalarmulbase_alt.o"
+let edwards25519_scalarmulbase_alt_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "edwards25519_scalarmulbase_alt_constant"
+        -> "edwards25519_scalarmulbase_alt_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "edwards25519_scalarmulbase_alt_mc"
+    "arm/curve25519/edwards25519_scalarmulbase_alt.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -74,8 +80,8 @@ let edwards25519_scalarmulbase_alt_mc,[edwards25519_scalarmulbase_alt_constant_d
   w 0xf24501bf;         (* arm_TST X13 (rvalue (word 576460752303423488)) *)
   w 0x9244f9ad;         (* arm_AND X13 X13 (rvalue (word 17870283321406128127)) *)
   w 0xa90137ec;         (* arm_STP X12 X13 SP (Immediate_Offset (iword (&16))) *)
-  ADRP (mk_var("edwards25519_scalarmulbase_alt_constant",`:num`),0,172,19);
-  ADD_rri64 (mk_var("edwards25519_scalarmulbase_alt_constant",`:num`),0,19,19);
+  ADRP (mk_var("edwards25519_scalarmulbase_alt_constant_data",`:num`),0,172,19);
+  ADD_rri64 (mk_var("edwards25519_scalarmulbase_alt_constant_data",`:num`),0,19,19);
   w 0xa9400660;         (* arm_LDP X0 X1 X19 (Immediate_Offset (iword (&0))) *)
   w 0xa9460e62;         (* arm_LDP X2 X3 X19 (Immediate_Offset (iword (&96))) *)
   w 0x9a820000;         (* arm_CSEL X0 X0 X2 Condition_EQ *)
@@ -2344,6 +2350,8 @@ let edwards25519_scalarmulbase_alt_mc,[edwards25519_scalarmulbase_alt_constant_d
   w 0xa8c153f3;         (* arm_LDP X19 X20 SP (Postimmediate_Offset (iword (&16))) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let edwards25519_scalarmulbase_alt_constant_data = last const_data_list;;
 
 let EDWARDS25519_SCALARMULBASE_ALT_EXEC =
   ARM_MK_EXEC_RULE edwards25519_scalarmulbase_alt_mc;;

--- a/arm/proofs/edwards25519_scalarmuldouble.ml
+++ b/arm/proofs/edwards25519_scalarmuldouble.ml
@@ -27,9 +27,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf  "arm/curve25519/edwards25519_scalarmuldouble.o";;
  ****)
 
-let edwards25519_scalarmuldouble_mc,[edwards25519_scalarmuldouble_constant_data] =
-  define_assert_relocs_from_elf "edwards25519_scalarmuldouble_mc"
-  "arm/curve25519/edwards25519_scalarmuldouble.o"
+let edwards25519_scalarmuldouble_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "edwards25519_scalarmuldouble_constant"
+        -> "edwards25519_scalarmuldouble_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "edwards25519_scalarmuldouble_mc"
+    "arm/curve25519/edwards25519_scalarmuldouble.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -305,8 +311,8 @@ let edwards25519_scalarmuldouble_mc,[edwards25519_scalarmuldouble_constant_data]
   w 0xd2801f93;         (* arm_MOV X19 (rvalue (word 252)) *)
   w 0xf9401fe0;         (* arm_LDR X0 SP (Immediate_Offset (word 56)) *)
   w 0xd37cfc14;         (* arm_LSR X20 X0 60 *)
-  ADRP (mk_var("edwards25519_scalarmuldouble_constant",`:num`),0,1096,14);
-  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_constant",`:num`),0,14,14);
+  ADRP (mk_var("edwards25519_scalarmuldouble_constant_data",`:num`),0,1096,14);
+  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_constant_data",`:num`),0,14,14);
   w 0xd2800020;         (* arm_MOV X0 (rvalue (word 1)) *)
   w 0xaa1f03e1;         (* arm_MOV X1 XZR *)
   w 0xaa1f03e2;         (* arm_MOV X2 XZR *)
@@ -734,8 +740,8 @@ let edwards25519_scalarmuldouble_mc,[edwards25519_scalarmuldouble_constant_data]
   w 0xf1002014;         (* arm_SUBS X20 X0 (rvalue (word 8)) *)
   w 0xda942694;         (* arm_CNEG X20 X20 Condition_CC *)
   w 0xda9f23f5;         (* arm_CSETM X21 Condition_CC *)
-  ADRP (mk_var("edwards25519_scalarmuldouble_constant",`:num`),0,2812,14);
-  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_constant",`:num`),0,14,14);
+  ADRP (mk_var("edwards25519_scalarmuldouble_constant_data",`:num`),0,2812,14);
+  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_constant_data",`:num`),0,14,14);
   w 0xd2800020;         (* arm_MOV X0 (rvalue (word 1)) *)
   w 0xaa1f03e1;         (* arm_MOV X1 XZR *)
   w 0xaa1f03e2;         (* arm_MOV X2 XZR *)
@@ -8074,6 +8080,8 @@ let edwards25519_scalarmuldouble_mc,[edwards25519_scalarmuldouble_constant_data]
   w 0x910303ff;         (* arm_ADD SP SP (rvalue (word 192)) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let edwards25519_scalarmuldouble_constant_data = last const_data_list;;
 
 let EDWARDS25519_SCALARMULDOUBLE_EXEC =
   ARM_MK_EXEC_RULE edwards25519_scalarmuldouble_mc;;

--- a/arm/proofs/edwards25519_scalarmuldouble_alt.ml
+++ b/arm/proofs/edwards25519_scalarmuldouble_alt.ml
@@ -27,9 +27,15 @@ prioritize_num();;
 (**** print_literal_relocs_from_elf  "arm/curve25519/edwards25519_scalarmuldouble_alt.o";;
  ****)
 
-let edwards25519_scalarmuldouble_alt_mc,[edwards25519_scalarmuldouble_alt_constant_data] =
-  define_assert_relocs_from_elf "edwards25519_scalarmuldouble_alt_mc"
-  "arm/curve25519/edwards25519_scalarmuldouble_alt.o"
+let edwards25519_scalarmuldouble_alt_mc,const_data_list =
+  define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
+      | "edwards25519_scalarmuldouble_alt_constant"
+        -> "edwards25519_scalarmuldouble_alt_constant_data"
+      | s -> failwith ("unknown symbol: " ^ s))
+    "edwards25519_scalarmuldouble_alt_mc"
+    "arm/curve25519/edwards25519_scalarmuldouble_alt.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
   w 0xa9bf53f3;         (* arm_STP X19 X20 SP (Preimmediate_Offset (iword (-- &16))) *)
   w 0xa9bf5bf5;         (* arm_STP X21 X22 SP (Preimmediate_Offset (iword (-- &16))) *)
@@ -227,8 +233,8 @@ let edwards25519_scalarmuldouble_alt_mc,[edwards25519_scalarmuldouble_alt_consta
   w 0xd2801f93;         (* arm_MOV X19 (rvalue (word 252)) *)
   w 0xf9401fe0;         (* arm_LDR X0 SP (Immediate_Offset (word 56)) *)
   w 0xd37cfc14;         (* arm_LSR X20 X0 60 *)
-  ADRP (mk_var("edwards25519_scalarmuldouble_alt_constant",`:num`),0,784,14);
-  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_alt_constant",`:num`),0,14,14);
+  ADRP (mk_var("edwards25519_scalarmuldouble_alt_constant_data",`:num`),0,784,14);
+  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_alt_constant_data",`:num`),0,14,14);
   w 0xd2800020;         (* arm_MOV X0 (rvalue (word 1)) *)
   w 0xaa1f03e1;         (* arm_MOV X1 XZR *)
   w 0xaa1f03e2;         (* arm_MOV X2 XZR *)
@@ -656,8 +662,8 @@ let edwards25519_scalarmuldouble_alt_mc,[edwards25519_scalarmuldouble_alt_consta
   w 0xf1002014;         (* arm_SUBS X20 X0 (rvalue (word 8)) *)
   w 0xda942694;         (* arm_CNEG X20 X20 Condition_CC *)
   w 0xda9f23f5;         (* arm_CSETM X21 Condition_CC *)
-  ADRP (mk_var("edwards25519_scalarmuldouble_alt_constant",`:num`),0,2500,14);
-  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_alt_constant",`:num`),0,14,14);
+  ADRP (mk_var("edwards25519_scalarmuldouble_alt_constant_data",`:num`),0,2500,14);
+  ADD_rri64 (mk_var("edwards25519_scalarmuldouble_alt_constant_data",`:num`),0,14,14);
   w 0xd2800020;         (* arm_MOV X0 (rvalue (word 1)) *)
   w 0xaa1f03e1;         (* arm_MOV X1 XZR *)
   w 0xaa1f03e2;         (* arm_MOV X2 XZR *)
@@ -5578,6 +5584,8 @@ let edwards25519_scalarmuldouble_alt_mc,[edwards25519_scalarmuldouble_alt_consta
   w 0x910303ff;         (* arm_ADD SP SP (rvalue (word 192)) *)
   w 0xd65f03c0          (* arm_RET X30 *)
 ]);;
+
+let edwards25519_scalarmuldouble_alt_constant_data = last const_data_list;;
 
 let EDWARDS25519_SCALARMULDOUBLE_ALT_EXEC =
   ARM_MK_EXEC_RULE edwards25519_scalarmuldouble_alt_mc;;

--- a/arm/tutorial/rodata.ml
+++ b/arm/tutorial/rodata.ml
@@ -10,7 +10,7 @@
 needs "arm/proofs/base.ml";;
 
 (* The following command will print the assertion checker fn of
-   "arm/tutorial/rodata.o":
+   "arm/tutorial/rodata.o".
 
    print_literal_relocs_from_elf "arm/tutorial/rodata.o";;
 
@@ -19,24 +19,21 @@ needs "arm/proofs/base.ml";;
    save_literal_relocs_from_elf "out.txt" "arm/tutorial/rodata.o";;
 *)
 
-let a_mc,a_constants_data = define_assert_relocs_from_elf "a_mc"
+let rodata_mc,rodata_constants_data = define_assert_relocs_from_elf
+    "rodata_mc"
     "arm/tutorial/rodata.o"
 (fun w BL ADR ADRP ADD_rri64 -> [
 (* int f(int) *)
   w 0xaa0003e3;         (* arm_MOV X3 X0 *)
 
-  (* NOTE: The two entries below have the names of symbols. If they appear as
-     an empty string on your custom object file, please check whether the
-     symbols are defined as global in assembly. Local symbols will not have
-     their names recorded in string table. *)
-  ADRP (mk_var("x",`:num`),0,4,10);
-  ADD_rri64 (mk_var("x",`:num`),0,10,10);
+  ADRP (mk_var("x_data",`:num`),0,4,10);
+  ADD_rri64 (mk_var("x_data",`:num`),0,10,10);
 
   w 0xaa0303e1;         (* arm_MOV X1 X3 *)
   w 0xb8617941;         (* arm_LDR W1 X10 (Shiftreg_Offset X1 2) *)
 
-  ADRP (mk_var("y",`:num`),0,20,11);
-  ADD_rri64 (mk_var("y",`:num`),0,11,11);
+  ADRP (mk_var("y_data",`:num`),0,20,11);
+  ADD_rri64 (mk_var("y_data",`:num`),0,11,11);
 
   w 0xaa0303e2;         (* arm_MOV X2 X3 *)
   w 0xb8627960;         (* arm_LDR W0 X11 (Shiftreg_Offset X2 2) *)
@@ -44,8 +41,8 @@ let a_mc,a_constants_data = define_assert_relocs_from_elf "a_mc"
   w 0xd65f03c0;         (* arm_RET X30 *)
 
 (* int g(int) *)
-  ADRP (mk_var("z",`:num`),0,44,10);
-  ADD_rri64 (mk_var("z",`:num`),0,10,10);
+  ADRP (mk_var("z_data",`:num`),0,44,10);
+  ADD_rri64 (mk_var("z_data",`:num`),0,10,10);
   w 0xb9400141;         (* arm_LDR W1 X10 (Immediate_Offset (word 0)) *)
   w 0x8b000020;         (* arm_ADD X0 X1 X0 *)
   w 0x17fffff1          (* arm_B (word 268435396) *)
@@ -54,29 +51,33 @@ let a_mc,a_constants_data = define_assert_relocs_from_elf "a_mc"
 (* Compared to the result of define_asserts_from_elf, the return value of
     define_assert_relocs_from_elf has the following differences:
 
-    1. It returns a_constants_data, which is a list of thm.
+    1. It returns rodata_constants_data, which is a list of thm.
       Each thm describes a definition of an object in a read-only section:
 
-      # a_constants_data;;
+      # rodata_constants_data;;
 
       - : thm list =
       [|- z_data = [word 30; word 0; word 0; word 0];
        |- y_data = [word 1; word 0; word 0; word 0; ...];
-       |- x_data = [word 2; word 0; word 0; word 0; ...]]
+       |- x_data = [word 2; word 0; word 0; word 0; ...];
+       |- WHOLE_READONLY_data = [word 2; word 0; word 0; word 0; ...]]
 
-    2. The returned a_mc is a function that takes the addresses of pc, x, y and
-       (x and y are the addresses of the two constant arrays) and returns
-       the corresponding machine code.
+    2. The returned rodata_mc is a function that takes the addresses of pc, x,
+       rodata, z (x and z are the addresses of the two constant arrays, and
+       rodata is the whole contents) and returns the corresponding machine code.
 
-      # a_mc;;
+      # rodata_mc;;
 
       - : thm =
-      |- forall x pc y. a_mc pc x y = CONS (word 227) (...)
+      |- forall pc x_data rodata z_data.
+       rodata_mc pc x_data y_data z_data = CONS (word 227) (...)
 *)
 
-let EXEC = ARM_MK_EXEC_RULE a_mc;;
+let EXEC = ARM_MK_EXEC_RULE rodata_mc;;
 
-(* Two helper tactics.
+(* Two helper tactics (unrelevant to treating the readonly section, just for
+     proving the upcoming properties).
+
    1. INTRO_READ_MEMORY_FROM_BYTES8_TAC t:
       If t is `read (memory :> bytesN ...) sM`, prove a theorem
       `read (memory :> bytesN ...) sM = <some expr>` and introduce it
@@ -98,11 +99,11 @@ let INTRO_READ_MEMORY_FROM_BYTES8_TAC (t:term) =
   CONV_TAC (LAND_CONV WORD_REDUCE_CONV) THEN
   DISCH_TAC;;
 
-let EXPLODE_BYTELIST_ASSUM_TAC =
+let EXPLODE_BYTELIST_ASSUM_TAC const_data =
   FIRST_X_ASSUM (fun th ->
     let _ = find_term (fun t -> name_of t = "bytelist") (concl th) in
     (* Unfold the constant arrays! *)
-    let unfolded_bytes_loaded = REWRITE_RULE a_constants_data th in
+    let unfolded_bytes_loaded = REWRITE_RULE const_data th in
     (* Fold LENGTH array, and explode arr using BYTELIST_EXPAND_CONV *)
     MP_TAC (CONV_RULE (ONCE_DEPTH_CONV LENGTH_CONV THENC
                       LAND_CONV BYTELIST_EXPAND_CONV)
@@ -121,7 +122,7 @@ let F_SPEC = prove(`forall x y z i pc retpc.
   val i < 10
   ==>
   ensures arm
-    (\s. aligned_bytes_loaded s (word pc) (a_mc pc x y z) /\
+    (\s. aligned_bytes_loaded s (word pc) (rodata_mc pc x y z) /\
          read (memory :> bytelist (word x, LENGTH x_data)) s = x_data /\
          read (memory :> bytelist (word y, LENGTH y_data)) s = y_data /\
          read PC s = word pc /\
@@ -136,13 +137,15 @@ let F_SPEC = prove(`forall x y z i pc retpc.
 
   (* Let's prove the constant array is storing some structured int sequence. *)
   SUBGOAL_THEN
-      `read (memory :> bytes32 (word_add (word x) (word (4 * val (i:int64))))) s0 = word (2 * (val i+1)) /\
-       read (memory :> bytes32 (word_add (word y) (word (4 * val i)))) s0 = word (val i+1)`
+      `read (memory :> bytes32 (word_add (word x) (word (4 * val (i:int64)))))
+          s0 = word (2 * (val i+1)) /\
+       read (memory :> bytes32 (word_add (word y) (word (4 * val i))))
+          s0 = word (val i+1)`
       MP_TAC THENL [
 
     (* Explode the 40-byte constant memory reads into 40 1-bytes!
        Do it twice, one for x and one for y. *)
-    REPEAT_N 2 EXPLODE_BYTELIST_ASSUM_TAC THEN
+    REPEAT_N 2 (EXPLODE_BYTELIST_ASSUM_TAC rodata_constants_data) THEN
 
     (* For each case where i < 10, concretely evaluate the values from the
        exploded bytes, proving the equality. *)
@@ -186,7 +189,7 @@ let G_SPEC = prove(`forall x y z i pc retpc.
   val i < 9
   ==>
   ensures arm
-    (\s. aligned_bytes_loaded s (word pc) (a_mc pc x y z) /\
+    (\s. aligned_bytes_loaded s (word pc) (rodata_mc pc x y z) /\
          read (memory :> bytelist (word x, LENGTH x_data)) s = x_data /\
          read (memory :> bytelist (word y, LENGTH y_data)) s = y_data /\
          read (memory :> bytelist (word z, LENGTH z_data)) s = z_data /\
@@ -205,7 +208,7 @@ let G_SPEC = prove(`forall x y z i pc retpc.
   FIRST_X_ASSUM (fun th -> MP_TAC th THEN IMP_REWRITE_TAC[ADRP_ADD_FOLD] THEN DISCH_TAC) THEN
 
   (* Prepare load z. *)
-  EXPLODE_BYTELIST_ASSUM_TAC THEN
+  EXPLODE_BYTELIST_ASSUM_TAC rodata_constants_data THEN
   INTRO_READ_MEMORY_FROM_BYTES8_TAC
     `read (memory :> bytes32 (word z)) s2` THEN
   (* Expand read W0 to read X0. *)
@@ -220,7 +223,7 @@ let G_SPEC = prove(`forall x y z i pc retpc.
 
   (* Call ARM_SUBROUTINE_SIM_TAC with its arguments. *)
   ARM_SUBROUTINE_SIM_TAC
-   (SPEC_ALL a_mc,EXEC,0,SPEC_ALL a_mc,F_SPEC)
+   (SPEC_ALL rodata_mc,EXEC,0,SPEC_ALL rodata_mc,F_SPEC)
    [`x:num`;`y:num`;`z:num`;`read X0 s`;
     `pc:num`; `read X30 s`] 6 THEN
 
@@ -230,3 +233,237 @@ let G_SPEC = prove(`forall x y z i pc retpc.
   ASM_REWRITE_TAC[VAL_WORD_ADD;DIMINDEX_64] THEN
   AP_TERM_TAC THEN CONV_TAC WORD_REDUCE_CONV THEN
   IMP_REWRITE_TAC[MOD_LT] THEN ASM_ARITH_TAC);;
+
+
+(* The next example of this tutorial is rodata_local.S which has an identical
+   text to rodata.S but has all readonly symbols (x,y,z) defined as local.
+   When the symbols are local, their relocation table entries for the
+   instructions using x,y, and z do not directly point to the symbol table
+   entries of x,y,z. Instead, they use relative offsets from the beginning of
+   the readonly section (or __const section for MachO).
+
+   Therefore, we must define a constant that holds all byte data in the readonly
+   section and use it. In fact, in the previous example, there was already
+   'WHOLE_READONLY_data' which was exactly containing the whole readonly data.
+   We can use that, but the name wasn't pretty.
+   In this example, we will use the optional 'map_symbol_name' argument of
+   define_assert_relocs_from_elf to assign more meaningful name to it, like
+   this:
+
+      define_assert_relocs_from_elf
+            ~map_symbol_name:(function
+            | "WHOLE_READONLY" -> "rodata"
+            | s -> "unused_" ^ s)
+          "rodata_local_mc"
+          "arm/tutorial/rodata_local.o"
+
+   (Note that if this optional 'map_symbol_name' argument is not given, it will
+    unconditionally attach the "_data" suffix to the names of symbols and
+    use "WHOLE_READONLY_data" for the whole readonly data, as shown before.)
+
+   To generate the assertion checker, you can use print_literal_relocs_from_elf
+   (and of course save_literal_relocs_from_elf) with the same argument: 
+
+   print_literal_relocs_from_elf
+        ~map_symbol_name:(function
+        | "WHOLE_READONLY" -> "rodata"
+        | s -> "unused_" ^ s)
+      "arm/tutorial/rodata_local.o";;
+*)
+
+let rodata_local_mc,rodata_local_constants_data = define_assert_relocs_from_elf
+    ~map_symbol_name:(function
+      | "WHOLE_READONLY" -> "rodata"
+      (* Mapping ltmp1 is necessary for MachO; ltmp1 is an autogenerated name
+          by the MacOS assembler. *)
+      | "ltmp1" -> "rodata"
+      | s -> "unused_" ^ s)
+    "rodata_local_mc"
+    "arm/tutorial/rodata_local.o"
+(fun w BL ADR ADRP ADD_rri64 -> [
+    w 0xaa0003e3;         (* arm_MOV X3 X0 *)
+    ADRP (mk_var("rodata",`:num`),0,4,10);
+    ADD_rri64 (mk_var("rodata",`:num`),0,10,10);
+    w 0xaa0303e1;         (* arm_MOV X1 X3 *)
+    w 0xb8617941;         (* arm_LDR W1 X10 (Shiftreg_Offset X1 2) *)
+    ADRP (mk_var("rodata",`:num`),40,20,11);
+    ADD_rri64 (mk_var("rodata",`:num`),40,11,11);
+    w 0xaa0303e2;         (* arm_MOV X2 X3 *)
+    w 0xb8627960;         (* arm_LDR W0 X11 (Shiftreg_Offset X2 2) *)
+    w 0x0b000020;         (* arm_ADD W0 W1 W0 *)
+    w 0xd65f03c0;         (* arm_RET X30 *)
+    ADRP (mk_var("rodata",`:num`),80,44,10);
+    ADD_rri64 (mk_var("rodata",`:num`),80,10,10);
+    w 0xb9400141;         (* arm_LDR W1 X10 (Immediate_Offset (word 0)) *)
+    w 0x8b000020;         (* arm_ADD X0 X1 X0 *)
+    w 0x17fffff1          (* arm_B (word 268435396) *)
+]);;
+
+(* The new rodata_local_constants_data has a list of thm, each of which defines
+   the byte contents of local symbol with accordingly modified names:
+
+    # rodata_local_constants_data;;
+
+    - : thm list =
+    [|- unused_Lz = [word 1; word 0; word 0; word 0];
+      |- unused_Ly = [word 1; word 0; word 0; word 0; ...];
+      |- unused_Lx = [word 2; word 0; word 0; word 0; ...];
+      |- rodata = [word 2; word 0; word 0; word 0; ...]]
+
+   The above result is for ELF binaries. On Mac, you will only see the last
+   item. 
+
+   The definition of rodata_local_mc only receives two arguments: pc and
+   rodata.
+
+    # rodata_local_mc;;
+
+    - : thm =
+    |- forall pc rodata. rodata_local_mc pc rodata = ...
+*)
+
+let EXEC = ARM_MK_EXEC_RULE rodata_local_mc;;
+
+(*
+   Now, let's prove the properties that are analogous to F_SPEC and G_SPEC
+   but for rodata_local.S.
+*)
+
+let F_LOCAL_SPEC = prove(`forall rodata_addr i pc retpc.
+  adrp_within_bounds (word rodata_addr) (word (pc + 4)) /\
+  adrp_within_bounds (word (rodata_addr + 40)) (word (pc + 20)) /\
+  val i < 10
+  ==>
+  ensures arm
+    (\s. aligned_bytes_loaded s (word pc) (rodata_local_mc pc rodata_addr) /\
+         read (memory :> bytelist (word rodata_addr, LENGTH rodata)) s =
+            rodata /\
+         read PC s = word pc /\
+         read X0 s = i /\
+         read X30 s = retpc)
+    (\s. read W0 s = word (3 * (1 + val i)) /\
+         read PC s = retpc)
+    (MAYCHANGE [X0; X1; X2; X3; X10; X11; PC] ,, MAYCHANGE [events])`,
+
+  REPEAT STRIP_TAC THEN
+  ENSURES_INIT_TAC "s0" THEN
+
+  (* Let's prove the constant array is storing some structured int sequence. *)
+  SUBGOAL_THEN
+      `read (memory :> bytes32
+            (word_add (word rodata_addr) (word (4 * val (i:int64)))))
+          s0 = word (2 * (val i+1)) /\
+       read (memory :> bytes32
+            (word_add (word (rodata_addr + 40)) (word (4 * val i))))
+          s0 = word (val i+1)`
+      MP_TAC THENL [
+
+    (* Explode the 84-byte constant memory reads into 84 1-bytes! *)
+    EXPLODE_BYTELIST_ASSUM_TAC rodata_local_constants_data THEN
+
+    (* For each case where i < 10, concretely evaluate the values from the
+       exploded bytes, proving the equality. *)
+    ABBREV_TAC `i' = val (i:int64)` THEN
+    UNDISCH_TAC `i' < 10` THEN
+    SPEC_TAC (`i':num`,`i':num`) THEN
+    CONV_TAC EXPAND_CASES_CONV THEN
+    REWRITE_TAC[ARITH;WORD_ADD_0;
+      WORD_RULE`word_add (word (x+40)) (word y):int64 =
+                word_add (word x) (word (40+y))`] THEN
+
+    REPEAT CONJ_TAC THEN (fun (asl,w) ->
+      INTRO_READ_MEMORY_FROM_BYTES8_TAC (lhs w) (asl,w)
+    ) THEN ASM_REWRITE_TAC[];
+
+    ALL_TAC
+  ] THEN
+
+  STRIP_TAC THEN
+
+  ARM_STEPS_TAC EXEC (1--3) THEN
+  FIRST_X_ASSUM (fun th -> MP_TAC th THEN IMP_REWRITE_TAC[ADRP_ADD_FOLD] THEN DISCH_TAC) THEN
+
+  ARM_STEPS_TAC EXEC (4--7) THEN
+  FIRST_X_ASSUM (fun th -> MP_TAC th THEN IMP_REWRITE_TAC[ADRP_ADD_FOLD] THEN DISCH_TAC) THEN
+
+  ARM_STEPS_TAC EXEC (8--11) THEN
+
+  (* Prove the postcondition. *)
+  ENSURES_FINAL_STATE_TAC THEN
+
+  ASM_REWRITE_TAC[WREG_EXPAND_CLAUSES;READ_ZEROTOP_32] THEN
+  REWRITE_TAC[WORD_BLAST`word_zx (word_zx (x:(32)word):(64)word):(32)word = x`] THEN
+  CONV_TAC WORD_RULE);;
+
+
+(* Proving the specification of function g(i) that calls f(i + z). *)
+
+let G_LOCAL_SPEC = prove(`forall rodata_addr i pc retpc.
+  adrp_within_bounds (word rodata_addr) (word (pc + 4)) /\
+  adrp_within_bounds (word (rodata_addr + 40)) (word (pc + 20)) /\
+  adrp_within_bounds (word (rodata_addr + 80)) (word (pc + 44)) /\
+  val i < 9
+  ==>
+  ensures arm
+    (\s. aligned_bytes_loaded s (word pc) (rodata_local_mc pc rodata_addr) /\
+         read (memory :> bytelist (word rodata_addr, LENGTH rodata)) s =
+            rodata /\
+         read PC s = word (pc + 0x2c) /\
+         read X0 s = i /\
+         read X30 s = retpc)
+    (\s. read W0 s = word (3 * (2 + val i)) /\
+         read PC s = retpc)
+    (MAYCHANGE [X0; X1; X2; X3; X10; X11; PC] ,, MAYCHANGE [events])`,
+
+  REPEAT STRIP_TAC THEN
+
+  ENSURES_INIT_TAC "s0" THEN
+
+  ARM_STEPS_TAC EXEC (1--2) THEN
+  FIRST_X_ASSUM (fun th -> MP_TAC th THEN IMP_REWRITE_TAC[ADRP_ADD_FOLD] THEN DISCH_TAC) THEN
+
+  (* Prepare load z. *)
+  SUBGOAL_THEN `read (memory :> bytes32 (word (rodata_addr + 80))) s2 = word 1`
+      ASSUME_TAC THENL [
+    EXPLODE_BYTELIST_ASSUM_TAC rodata_local_constants_data THEN
+    REPEAT_N 2 (CONV_TAC (ONCE_DEPTH_CONV (READ_MEMORY_SPLIT_CONV 1))) THEN
+    REWRITE_TAC (map WORD_RULE
+        [`word_add (word (x+80)) (word k) = word_add (word x) (word (80+k))`;
+        `word (x+80):int64 = word_add (word x) (word 80)`]) THEN
+    ASM_REWRITE_TAC[ARITH] THEN CONV_TAC WORD_REDUCE_CONV;
+
+    ALL_TAC
+  ] THEN
+
+  (* Expand read W0 to read X0. *)
+  RULE_ASSUM_TAC(REWRITE_RULE[WREG_EXPAND_CLAUSES;READ_ZEROTOP_32]) THEN
+  ARM_STEPS_TAC EXEC (3--4) THEN
+
+  SUBGOAL_THEN `val (word_add (word 1) i:int64) < 10` ASSUME_TAC THENL [
+    REWRITE_TAC[VAL_WORD_ADD;VAL_WORD;DIMINDEX_64] THEN ASM_ARITH_TAC;
+    ALL_TAC
+  ] THEN
+  ARM_STEPS_TAC EXEC [5] THEN
+
+  (* Call ARM_SUBROUTINE_SIM_TAC with its arguments. *)
+  ARM_SUBROUTINE_SIM_TAC
+   (SPEC_ALL rodata_local_mc,EXEC,0,SPEC_ALL rodata_local_mc,F_LOCAL_SPEC)
+   [`rodata_addr:num`;`read X0 s`;`pc:num`; `read X30 s`] 6 THEN
+
+  (* Prove the postcondition. *)
+  ENSURES_FINAL_STATE_TAC THEN
+
+  ASM_REWRITE_TAC[VAL_WORD_ADD;DIMINDEX_64] THEN
+  AP_TERM_TAC THEN CONV_TAC WORD_REDUCE_CONV THEN
+  IMP_REWRITE_TAC[MOD_LT] THEN ASM_ARITH_TAC);;
+
+(*
+   It is also possible to think about a more complicated case where some symbols
+   are global and some are local, and actually s2n-bignum's ELF/Mach-O loader
+   can successfully deal with that. However, one hidden trickiness is that the
+   definition of machine code diverges between ELF and Mach-O, making the
+   specification of correctness and accordingly its proof diverge depending
+   on the object file type.
+   For simplicity, this tutorial deals with a case where all readonly symbols
+   are local, which does not exhibit this divergence problem.
+*)

--- a/arm/tutorial/rodata_local.S
+++ b/arm/tutorial/rodata_local.S
@@ -1,0 +1,106 @@
+/*
+  This assembly file is a cleaned (and less ABI-compliant) version of GCC
+  output of the following
+  C program:
+
+  static const int x[10] = {2, 4, 6, 8, 10, 12, 14, 16, 18, 20};
+  static const int y[10] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+  static const int z = 1;
+
+  int f(uint64_t i) {
+    return x[i] + y[i];
+  }
+
+  int g(int64_t i) {
+    return f(i + z);
+  }
+*/
+
+#if defined(__linux__) && defined(__ELF__)
+.section  .rodata
+  .type  Lx, %object
+  .size  Lx, 40
+#elif defined(__APPLE__)
+.const_data
+#endif
+  .align  3
+Lx:
+  .word  2
+  .word  4
+  .word  6
+  .word  8
+  .word  10
+  .word  12
+  .word  14
+  .word  16
+  .word  18
+  .word  20
+
+#if defined(__linux__) && defined(__ELF__)
+  .type  Ly, %object
+  .size  Ly, 40
+#endif
+  .align  3
+Ly:
+  .word  1
+  .word  2
+  .word  3
+  .word  4
+  .word  5
+  .word  6
+  .word  7
+  .word  8
+  .word  9
+  .word  10
+
+#if defined(__linux__) && defined(__ELF__)
+  .type  Lz, %object
+  .size  Lz, 4
+#endif
+  .align  3
+Lz:
+  .word  1
+
+.text
+  .align  2
+#if defined(__linux__) && defined(__ELF__)
+  .type  f, %function
+#endif
+
+f:
+  mov x3, x0
+#if defined(__linux__) && defined(__ELF__)
+  adrp  x10, Lx
+  add  x10, x10, :lo12:Lx
+#else
+  adrp  x10, Lx@PAGE
+  add  x10, x10, Lx@PAGEOFF
+#endif
+  mov x1, x3
+  ldr  w1, [x10, x1, lsl 2]
+#if defined(__linux__) && defined(__ELF__)
+  adrp  x11, Ly
+  add  x11, x11, :lo12:Ly
+#else
+  adrp  x11, Ly@PAGE
+  add  x11, x11, Ly@PAGEOFF
+#endif
+  mov x2, x3
+  ldr  w0, [x11, x2, lsl 2]
+  add  w0, w1, w0
+  ret
+
+#if defined(__linux__) && defined(__ELF__)
+  .type  g, %function
+#endif
+g:
+#if defined(__linux__) && defined(__ELF__)
+  adrp  x10, Lz
+  add  x10, x10, :lo12:Lz
+#else
+  adrp  x10, Lz@PAGE
+  add  x10, x10, Lz@PAGEOFF
+#endif
+  ldr w1, [x10]
+  add x0, x1, x0
+  b f


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

AWS-LC integration of s2n-bignum fails when `-DBUILD_SHARED_LIBS=1` is set, and this can be resolved if the constant symbols used in assemblies are defined as local symbols.

The first commit

- Adds support for reading readonly symbols in Arm (both ELF and MachO)
- Extends the tutorial to deal with the case when all symbols are local.
  To exhibit this case, a new 'rodata_local.S' example is added.
- Add the 'map_symbol_name' optional argument to define_assert_relocs_from_elf
  and its printing function family.
  This argument receives a function that maps the raw symbol name (string) to a
  symbol name that might be more suitable for defining HOL Light constants & hence
  writing proofs. This feature is also important to make the specs equal for
  MachO and ELF when local symbols are existent.
- Fixes define_assert_relocs_from_elf to correctly report divergence between
  the given opcodes and actual object binary

The second~fourth commit adds a new `-DBUILD_SHARED_LIBS=1` case to the AWS integration CI check as well as a new Github Action for s2n-bignum-tutorial on MacOS (Arm64) because the rodata tutorial has to be checked for both ELF and MachO formats.

The fifth commit resolves the integration error when `-DBUILD_SHARED_LIBS=1` is set, by removing the global directives for the symbols and (minimally) updating the proofs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
