### PR TITLE
Fix several BSD portability issues

### DIFF
--- a/arm/curve25519/curve25519_x25519base.S
+++ b/arm/curve25519/curve25519_x25519base.S
@@ -538,7 +538,7 @@ S2N_BN_SYMBOL(curve25519_x25519base):
         ldr     x0, [scalar]
         ands    xzr, x0, #8
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(curve25519_x25519base_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(curve25519_x25519base_constant)
 #else
@@ -1988,7 +1988,7 @@ S2N_BN_SIZE_DIRECTIVE(curve25519_x25519base)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(curve25519_x25519base_constant), %object
 .size S2N_BN_SYMBOL(curve25519_x25519base_constant), 48576

--- a/arm/curve25519/curve25519_x25519base_alt.S
+++ b/arm/curve25519/curve25519_x25519base_alt.S
@@ -380,7 +380,7 @@ S2N_BN_SYMBOL(curve25519_x25519base_alt):
         ldr     x0, [scalar]
         ands    xzr, x0, #8
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(curve25519_x25519base_alt_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(curve25519_x25519base_alt_constant)
 #else
@@ -1831,7 +1831,7 @@ S2N_BN_SIZE_DIRECTIVE(curve25519_x25519base_alt)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(curve25519_x25519base_alt_constant), %object
 .size S2N_BN_SYMBOL(curve25519_x25519base_alt_constant), 48576

--- a/arm/curve25519/curve25519_x25519base_byte.S
+++ b/arm/curve25519/curve25519_x25519base_byte.S
@@ -597,7 +597,7 @@ S2N_BN_SYMBOL(curve25519_x25519base_byte):
         ldr     x0, [scalar]
         ands    xzr, x0, #8
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(curve25519_x25519base_byte_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(curve25519_x25519base_byte_constant)
 #else
@@ -2114,7 +2114,7 @@ S2N_BN_SIZE_DIRECTIVE(curve25519_x25519base_byte)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(curve25519_x25519base_byte_constant), %object
 .size S2N_BN_SYMBOL(curve25519_x25519base_byte_constant), 48576

--- a/arm/curve25519/curve25519_x25519base_byte_alt.S
+++ b/arm/curve25519/curve25519_x25519base_byte_alt.S
@@ -439,7 +439,7 @@ S2N_BN_SYMBOL(curve25519_x25519base_byte_alt):
         ldr     x0, [scalar]
         ands    xzr, x0, #8
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(curve25519_x25519base_byte_alt_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(curve25519_x25519base_byte_alt_constant)
 #else
@@ -1956,7 +1956,7 @@ S2N_BN_SIZE_DIRECTIVE(curve25519_x25519base_byte_alt)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(curve25519_x25519base_byte_alt_constant), %object
 .size S2N_BN_SYMBOL(curve25519_x25519base_byte_alt_constant), 48576

--- a/arm/curve25519/edwards25519_scalarmulbase.S
+++ b/arm/curve25519/edwards25519_scalarmulbase.S
@@ -585,7 +585,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmulbase):
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(edwards25519_scalarmulbase_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmulbase_constant)
 #else
@@ -2032,7 +2032,7 @@ S2N_BN_SIZE_DIRECTIVE(edwards25519_scalarmulbase)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(edwards25519_scalarmulbase_constant), %object
 .size S2N_BN_SYMBOL(edwards25519_scalarmulbase_constant), 48576

--- a/arm/curve25519/edwards25519_scalarmulbase_alt.S
+++ b/arm/curve25519/edwards25519_scalarmulbase_alt.S
@@ -427,7 +427,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt):
 // Initialize accumulator "acc" to either 0 or 2^251 * B depending on
 // bit 251 of the (reduced) scalar. That leaves bits 0..250 to handle.
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    tab, S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt_constant)
         add     tab, tab, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt_constant)
 #else
@@ -1874,7 +1874,7 @@ S2N_BN_SIZE_DIRECTIVE(edwards25519_scalarmulbase_alt)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt_constant), %object
 .size S2N_BN_SYMBOL(edwards25519_scalarmulbase_alt_constant), 48576

--- a/arm/curve25519/edwards25519_scalarmuldouble.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble.S
@@ -852,7 +852,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmuldouble):
 
 // ...and constant-time indexing based on that index
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    x14, S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant)
         add     x14, x14, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant)
 #else
@@ -1330,7 +1330,7 @@ Ledwards25519_scalarmuldouble_loop:
 
 // ... then doing constant-time lookup with the appropriate index...
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    x14, S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant)
         add     x14, x14, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant)
 #else
@@ -3064,7 +3064,7 @@ S2N_BN_SIZE_DIRECTIVE(Ledwards25519_scalarmuldouble_pepadd)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant), %object
 .size S2N_BN_SYMBOL(edwards25519_scalarmuldouble_constant), 768

--- a/arm/curve25519/edwards25519_scalarmuldouble_alt.S
+++ b/arm/curve25519/edwards25519_scalarmuldouble_alt.S
@@ -636,7 +636,7 @@ S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt):
 
 // ...and constant-time indexing based on that index
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    x14, S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant)
         add     x14, x14, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant)
 #else
@@ -1114,7 +1114,7 @@ Ledwards25519_scalarmuldouble_alt_loop:
 
 // ... then doing constant-time lookup with the appropriate index...
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
         adrp    x14, S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant)
         add     x14, x14, :lo12:S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant)
 #else
@@ -2848,7 +2848,7 @@ S2N_BN_SIZE_DIRECTIVE(Ledwards25519_scalarmuldouble_alt_pepadd)
 // The precomputed data (all read-only).
 // ****************************************************************************
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section .rodata
 .type S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant), %object
 .size S2N_BN_SYMBOL(edwards25519_scalarmuldouble_alt_constant), 768

--- a/arm/tutorial/rodata.S
+++ b/arm/tutorial/rodata.S
@@ -16,7 +16,7 @@
   }
 */
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section  .rodata
   .global  x
   .type  x, %object
@@ -37,7 +37,7 @@ x:
   .word  18
   .word  20
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .global  y
   .type  y, %object
   .size  y, 40
@@ -55,7 +55,7 @@ y:
   .word  9
   .word  10
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .global  z
   .type  z, %object
   .size  z, 4
@@ -66,13 +66,13 @@ z:
 
 .text
   .align  2
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  f, %function
 #endif
 
 f:
   mov x3, x0
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x10, x
   add  x10, x10, :lo12:x
 #else
@@ -81,7 +81,7 @@ f:
 #endif
   mov x1, x3
   ldr  w1, [x10, x1, lsl 2]
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x11, y
   add  x11, x11, :lo12:y
 #else
@@ -93,11 +93,11 @@ f:
   add  w0, w1, w0
   ret
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  g, %function
 #endif
 g:
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x10, z
   add  x10, x10, :lo12:z
 #else

--- a/arm/tutorial/rodata_local.S
+++ b/arm/tutorial/rodata_local.S
@@ -16,7 +16,7 @@
   }
 */
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
 .section  .rodata
   .type  Lx, %object
   .size  Lx, 40
@@ -36,7 +36,7 @@ Lx:
   .word  18
   .word  20
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  Ly, %object
   .size  Ly, 40
 #endif
@@ -53,7 +53,7 @@ Ly:
   .word  9
   .word  10
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  Lz, %object
   .size  Lz, 4
 #endif
@@ -63,13 +63,13 @@ Lz:
 
 .text
   .align  2
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  f, %function
 #endif
 
 f:
   mov x3, x0
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x10, Lx
   add  x10, x10, :lo12:Lx
 #else
@@ -78,7 +78,7 @@ f:
 #endif
   mov x1, x3
   ldr  w1, [x10, x1, lsl 2]
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x11, Ly
   add  x11, x11, :lo12:Ly
 #else
@@ -90,11 +90,11 @@ f:
   add  w0, w1, w0
   ret
 
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   .type  g, %function
 #endif
 g:
-#if defined(__linux__) && defined(__ELF__)
+#if defined(__ELF__)
   adrp  x10, Lz
   add  x10, x10, :lo12:Lz
 #else

--- a/tests/arch.h
+++ b/tests/arch.h
@@ -43,6 +43,21 @@ int supports_bmi2_and_adx(void)
     return (hwcaps & HWCAP_SHA3) != 0;
   }
 
+#elif __FreeBSD__ || __OpenBSD__
+
+  #include <elf.h>
+  #include <sys/auxv.h>
+
+  int supports_arm_sha3(void)
+  {
+    unsigned long hwcaps;
+    if (elf_aux_info(AT_HWCAP, &hwcaps, sizeof(hwcaps)) != 0)
+     { printf("Warning: Failed to read AT_HWCAP\n");
+       return 0;
+     }
+    return (hwcaps & HWCAP_SHA3) != 0;
+  }
+
 #else
 
   int supports_arm_sha3(void)

--- a/tests/test.c
+++ b/tests/test.c
@@ -15,8 +15,11 @@
 #include <inttypes.h>
 #include <math.h>
 #include <time.h>
-#include <alloca.h>
 #include <string.h>
+
+#if (__linux__)
+  #include <alloca.h>
+#endif
 
 // Prototypes for the assembler implementations
 


### PR DESCRIPTION
A few aspects were previously only reliable on Linux or Mac OS:

 * The choice of the two different relocation syntaxes for ARM is really just an ELF versus Mach-O difference, so the extra defined(__linux__) guard is now removed.

 * We don't want to explicitly include alloca.h on BSD, and in fact we don't need to do it on Mac OS either, so it's now guarded by __linux__.

 * The method of querying for the existence of SHA3 hardware on ARM is slightly different on BSD.

So far this has only been tested with FreeBSD 14 on ARM, but it is hoped it will work on OpenBSD and other versions too.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
