### PR TITLE
Fix missing `SUBROUTINE_SAFE` counting, resolve failures when running proofs on Mac OS

### DIFF
--- a/arm/proofs/curve25519_x25519base.ml
+++ b/arm/proofs/curve25519_x25519base.ml
@@ -33,6 +33,7 @@ let curve25519_x25519base_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "curve25519_x25519base_constant"
+      | "_curve25519_x25519base_constant"
         -> "curve25519_x25519base_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "curve25519_x25519base_mc"

--- a/arm/proofs/curve25519_x25519base_alt.ml
+++ b/arm/proofs/curve25519_x25519base_alt.ml
@@ -33,6 +33,7 @@ let curve25519_x25519base_alt_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "curve25519_x25519base_alt_constant"
+      | "_curve25519_x25519base_alt_constant"
         -> "curve25519_x25519base_alt_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "curve25519_x25519base_alt_mc"

--- a/arm/proofs/curve25519_x25519base_byte.ml
+++ b/arm/proofs/curve25519_x25519base_byte.ml
@@ -33,6 +33,7 @@ let curve25519_x25519base_byte_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "curve25519_x25519base_byte_constant"
+      | "_curve25519_x25519base_byte_constant"
         -> "curve25519_x25519base_byte_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "curve25519_x25519base_byte_mc"

--- a/arm/proofs/curve25519_x25519base_byte_alt.ml
+++ b/arm/proofs/curve25519_x25519base_byte_alt.ml
@@ -33,6 +33,7 @@ let curve25519_x25519base_byte_alt_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "curve25519_x25519base_byte_alt_constant"
+      | "_curve25519_x25519base_byte_alt_constant"
         -> "curve25519_x25519base_byte_alt_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "curve25519_x25519base_byte_alt_mc"

--- a/arm/proofs/edwards25519_scalarmulbase.ml
+++ b/arm/proofs/edwards25519_scalarmulbase.ml
@@ -32,6 +32,7 @@ let edwards25519_scalarmulbase_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "edwards25519_scalarmulbase_constant"
+      | "_edwards25519_scalarmulbase_constant"
         -> "edwards25519_scalarmulbase_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "edwards25519_scalarmulbase_mc"

--- a/arm/proofs/edwards25519_scalarmulbase_alt.ml
+++ b/arm/proofs/edwards25519_scalarmulbase_alt.ml
@@ -32,6 +32,7 @@ let edwards25519_scalarmulbase_alt_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "edwards25519_scalarmulbase_alt_constant"
+      | "_edwards25519_scalarmulbase_alt_constant"
         -> "edwards25519_scalarmulbase_alt_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "edwards25519_scalarmulbase_alt_mc"

--- a/arm/proofs/edwards25519_scalarmuldouble.ml
+++ b/arm/proofs/edwards25519_scalarmuldouble.ml
@@ -32,6 +32,7 @@ let edwards25519_scalarmuldouble_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "edwards25519_scalarmuldouble_constant"
+      | "_edwards25519_scalarmuldouble_constant"
         -> "edwards25519_scalarmuldouble_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "edwards25519_scalarmuldouble_mc"

--- a/arm/proofs/edwards25519_scalarmuldouble_alt.ml
+++ b/arm/proofs/edwards25519_scalarmuldouble_alt.ml
@@ -32,6 +32,7 @@ let edwards25519_scalarmuldouble_alt_mc,const_data_list =
     ~map_symbol_name:(function
       | "WHOLE_READONLY" | "ltmp1" (* MacOS *)
       | "edwards25519_scalarmuldouble_alt_constant"
+      | "_edwards25519_scalarmuldouble_alt_constant"
         -> "edwards25519_scalarmuldouble_alt_constant_data"
       | s -> failwith ("unknown symbol: " ^ s))
     "edwards25519_scalarmuldouble_alt_mc"

--- a/common/elf.ml
+++ b/common/elf.ml
@@ -397,6 +397,12 @@ let load_macho (cputype:int) (reloc_type:int -> 'a) (file:bytes):
           let new_addend = r_symbolnum in
           res := (butlast !res) @ [relty,(addr,symbolname,new_addend)]
 
+      else if r_type = 0 || r_type = 1 then
+        (* 0: ARM64_RELOC_UNSIGNED.
+           1: ARM64_RELOC_SUBTRACTOR.
+           These relocation entry types are used by CFI. *)
+        ()
+
       else
         let symbolname,_,_,_,_ = List.nth !raw_symbols r_symbolnum in
         res := !res @ [reloc_type r_type,

--- a/tools/count-proofs.sh
+++ b/tools/count-proofs.sh
@@ -19,12 +19,12 @@ export LC_ALL=C
 # Count the number of *_SUBROUTINE_CORRECT theorems that must be proven
 num_correct_ans=`cat proofs/specifications.txt | wc -l`
 # Print & count the *_SUBROUTINE_CORRECT theorems that are actually proven
-num_correct_out=`grep 'SUBROUTINE_CORRECT : thm' */*.correct  | cut -f2 -d' ' | sort | uniq | wc -l`
+num_correct_out=`grep -e 'SUBROUTINE_CORRECT : thm' -e 'SUBROUTINE_SAFE : thm' */*.correct  | cut -f2 -d' ' | sort | uniq | wc -l`
 
 # Print the *_SUBROUTINE_CORRECT theorems that are actually proven
 proven_thms_log=`mktemp`
-echo "Proven *_SUBROUTINE_CORRECT theorems ($num_correct_out):"
-grep 'SUBROUTINE_CORRECT : thm' */*.correct  | cut -f2 -d' ' | sort | uniq > $proven_thms_log
+echo "Proven *_SUBROUTINE_{CORRECT,SAFE} theorems ($num_correct_out):"
+grep -e 'SUBROUTINE_CORRECT : thm' -e 'SUBROUTINE_SAFE : thm' */*.correct  | cut -f2 -d' ' | sort | uniq > $proven_thms_log
 cat $proven_thms_log
 
 echo "Total # SUBROUTINE_CORRECT: ${num_correct_out}/${num_correct_ans}"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
