### PR TITLE
fix f-string syntaxerror in collect-signatures.py

### DIFF
--- a/tools/collect-signatures.py
+++ b/tools/collect-signatures.py
@@ -31,7 +31,7 @@ class FnDecl:
     print(f"- Return type: {self.return_ty}")
     print("- Args:")
     for (argname, argtype, isconst) in self.args:
-      print(f"  - {argname}: {"const " if isconst else ""}{argtype}")
+      print(f"  - {argname}: {'const ' if isconst else ''}{argtype}")
 
 
 class FnMemInputOutput:


### PR DESCRIPTION
There was a f-string SyntaxError across Python versions. 

Changed the inner quotes to single quotes
before:
print(f"  - {argname}: {"const " if isconst else ""}{argtype}")

after:
print(f"  - {argname}: {'const ' if isconst else ''}{argtype}")

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
