### PR TITLE
Refactor GEN_PROVE_SAFETY_SPEC_TAC and fix value restriction issues.

### DIFF
--- a/common/consttime.ml
+++ b/common/consttime.ml
@@ -550,7 +550,8 @@ let ASSERT_CONCL_TAC (t:term): tactic =
 (* Tactics corresponding to Hoare rules.                                     *)
 (* ------------------------------------------------------------------------- *)
 
-let allowed_vars_e = ref [];;
+(*monomorphic type annotation to avoid value-restriction weak vars in generated files*)
+let allowed_vars_e : term list ref = ref [];;
 
 let NIL_IMPLIES_APPEND_EQ =
   prove(`forall (l:(A)list) m m'. m = m' /\ [] = l ==> m = APPEND l m'`,


### PR DESCRIPTION
*Issue #, if available:*
1. A generated .ml file did not compile because of a value-restriction error containing a non-generalisable type variable ('_weak1). This was due to the  `GEN_PROVE_SAFETY_SPEC_TAC` helper tactic being set up such that the outer binding was the result of executing mainfn, rather than a syntactic function value.
2. Another value-restriction error occurred with `allowed_vars_e`, which did not have a concrete type.

*Description of changes:*
1. Applied eta-expansion to make the binding an explicit function value by adding its parameters to the top-level binding.
2. Added the type annotation `let allowed_vars_e : term list ref = ref [];;` to make the reference monomorphic and concrete.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
