### PR TITLE
Add ARM NEON instructions BIF and REV32 (vector)

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -511,6 +511,10 @@ let decode = new_definition `!w:int32. decode w =
     // BIT
     SOME (arm_BIT (QREG' Rd) (QREG' Rn) (QREG' Rm) (if q then 128 else 64))
 
+  | [0:1; q; 0b101110111:9; Rm:5; 0b000111:6; Rn:5; Rd:5] ->
+    // BIF
+    SOME (arm_BIF (QREG' Rd) (QREG' Rn) (QREG' Rm) (if q then 128 else 64))
+
   // Two sizes of FCSEL, not allowing FP16 case at all
   | [0b00011110:8; 0b00:2; 0b1:1; Rm:5; cond:4; 0b11:2; Rn:5; Rd:5] ->
     SOME (arm_FCSEL (QREG' Rd) (QREG' Rn) (QREG' Rm) (Condition cond) 32)
@@ -731,6 +735,14 @@ let decode = new_definition `!w:int32. decode w =
     else
       let esize:(64)word = word_shl (word 0b1000: (64)word) (val size) in
       SOME (arm_REV64_VEC (QREG' Rd) (QREG' Rn) (val esize))
+
+  | [0:1; q; 0b101110:6; size:2; 0b100000000010:12; Rn:5; Rd:5] ->
+    // REV32
+    if ~q then NONE // datasize = 64 is unsupported yet
+    else if size = (word 0b10: (2)word) \/ size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize:(64)word = word_shl (word 0b1000: (64)word) (val size) in
+      SOME (arm_REV32_VEC (QREG' Rd) (QREG' Rn) (val esize))
 
   | [0b01101110000:11; imm5:5; 0:1; imm4:4; 1:1; Rn:5; Rd:5] ->
     // INS, or "MOV (element)"

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -3561,7 +3561,7 @@ let ARM_OPERATION_CLAUSES =
     (*** Alphabetically sorted, new alphabet appears in the next line ***)
       [arm_ADC; arm_ADCS_ALT; arm_ADD; arm_ADD_VEC_ALT; arm_ABS_VEC_ALT; arm_ADDS_ALT; arm_ADR;
        arm_ADRP; arm_AND; arm_AND_VEC; arm_ANDS; arm_ASR; arm_ASRV;
-       arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIT; arm_BIF;
+       arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIF; arm_BIT;
        arm_BL; arm_BL_ABSOLUTE; arm_Bcond;
        arm_CBNZ_ALT; arm_CBZ_ALT; arm_CCMN; arm_CCMP; arm_CLZ;
        arm_CMGE_VEC_ALT; arm_CMGT_VEC_ALT; arm_CMHI_VEC_ALT; arm_CMLE_VEC_ZERO_ALT; arm_CNT_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1489,14 +1489,8 @@ let arm_REV64_VEC = define
 let arm_REV32_VEC = define
  `arm_REV32_VEC Rd Rn esize =
     \s. let n:(128)word = read Rn (s:armstate) in
-        let n_reversed16 = usimd4 (\x. word_join
-          (word_subword x (0,16):(16)word) (word_subword x (16,16):(16)word)
-          : (32)word) n in
-        if esize = 16 then (Rd := n_reversed16) s else
-        let n_reversed8 = usimd8 (\x. word_join
-          (word_subword x (0,8):(8)word) (word_subword x (8,8):(8)word)
-          : (16)word) n_reversed16 in
-        (Rd := n_reversed8) s`;;
+        let n_reversed = usimd4 (word_reversefields esize) n in
+        (Rd := n_reversed) s`;;
 
 let arm_RORV = define
  `arm_RORV Rd Rm Rn =

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -988,6 +988,18 @@ let arm_BIT = define
           let out':(64)word = word_subword out (0,64) in
           (Rd := word_zx out':(128)word) s`;;
 
+let arm_BIF = define
+ `arm_BIF Rd Rn Rm datasize =
+    \s. let m = read Rm s
+        and n = read Rn s
+        and d = read Rd s in
+        let out:(128)word = word_or (word_and d m) (word_and n (word_not m)) in
+        if datasize = 128 then
+          (Rd := out) s
+        else
+          let out':(64)word = word_subword out (0,64) in
+          (Rd := word_zx out':(128)word) s`;;
+
 (*** As with x86, we have relative and absolute versions of branch & link ***)
 (*** The absolute one gives a natural way of handling linker-insertions.  ***)
 
@@ -1468,6 +1480,18 @@ let arm_REV64_VEC = define
         let n_reversed16 = usimd4 (\x. word_join
           (word_subword x (0,16):(16)word) (word_subword x (16,16):(16)word)
           : (32)word) n_reversed32 in
+        if esize = 16 then (Rd := n_reversed16) s else
+        let n_reversed8 = usimd8 (\x. word_join
+          (word_subword x (0,8):(8)word) (word_subword x (8,8):(8)word)
+          : (16)word) n_reversed16 in
+        (Rd := n_reversed8) s`;;
+
+let arm_REV32_VEC = define
+ `arm_REV32_VEC Rd Rn esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let n_reversed16 = usimd4 (\x. word_join
+          (word_subword x (0,16):(16)word) (word_subword x (16,16):(16)word)
+          : (32)word) n in
         if esize = 16 then (Rd := n_reversed16) s else
         let n_reversed8 = usimd8 (\x. word_join
           (word_subword x (0,8):(8)word) (word_subword x (8,8):(8)word)
@@ -3416,6 +3440,7 @@ let arm_PMUL_VEC_ALT =   EXPAND_SIMD_RULE arm_PMUL_VEC;;
 let arm_PMULL_VEC_ALT =  EXPAND_SIMD_RULE arm_PMULL_VEC;;
 let arm_PMULL2_VEC_ALT = EXPAND_SIMD_RULE arm_PMULL2_VEC;;
 let arm_REV64_VEC_ALT =  EXPAND_SIMD_RULE arm_REV64_VEC;;
+let arm_REV32_VEC_ALT =  EXPAND_SIMD_RULE arm_REV32_VEC;;
 let arm_SHL_VEC_ALT =    EXPAND_SIMD_RULE arm_SHL_VEC;;
 let arm_SSHR_VEC_ALT =   EXPAND_SIMD_RULE arm_SSHR_VEC;;
 let arm_SHRN_ALT =       EXPAND_SIMD_RULE arm_SHRN;;
@@ -3536,7 +3561,7 @@ let ARM_OPERATION_CLAUSES =
     (*** Alphabetically sorted, new alphabet appears in the next line ***)
       [arm_ADC; arm_ADCS_ALT; arm_ADD; arm_ADD_VEC_ALT; arm_ABS_VEC_ALT; arm_ADDS_ALT; arm_ADR;
        arm_ADRP; arm_AND; arm_AND_VEC; arm_ANDS; arm_ASR; arm_ASRV;
-       arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIT;
+       arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIT; arm_BIF;
        arm_BL; arm_BL_ABSOLUTE; arm_Bcond;
        arm_CBNZ_ALT; arm_CBZ_ALT; arm_CCMN; arm_CCMP; arm_CLZ;
        arm_CMGE_VEC_ALT; arm_CMGT_VEC_ALT; arm_CMHI_VEC_ALT; arm_CMLE_VEC_ZERO_ALT; arm_CNT_ALT;
@@ -3554,7 +3579,7 @@ let ARM_OPERATION_CLAUSES =
        arm_ORN; arm_ORR; arm_ORR_VEC;
        arm_PMUL_VEC_ALT;
        arm_PMULL_VEC_ALT; arm_PMULL2_VEC_ALT;
-       arm_RET; arm_REV; arm_REV64_VEC_ALT; arm_RORV;
+       arm_RET; arm_REV; arm_REV32_VEC_ALT; arm_REV64_VEC_ALT; arm_RORV;
        arm_SBC; arm_SBCS_ALT; arm_SBFM; arm_SHL_VEC_ALT; arm_SHRN_ALT;
        arm_SRSHR_VEC_ALT;
        arm_SSHR_VEC_ALT;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -126,6 +126,9 @@ let iclasses =
   (*** BIT ***)
   "0x101110101xxxxx000111xxxxxxxxxx";
 
+  (*** BIF ***)
+  "0x101110111xxxxx000111xxxxxxxxxx";
+
   (*** CMGT, vector, register, signed ***)
   "0x001110xx1xxxxx001101xxxxxxxxxx";
 
@@ -246,6 +249,9 @@ let iclasses =
 
   (*** REV64 ***)
   "01001110xx100000000010xxxxxxxxxx";
+
+  (*** REV32 ***)
+  "01101110xx100000000010xxxxxxxxxx";
 
   (*** SHA256 Intrinsics ***)
   (*** SHA256H ***)


### PR DESCRIPTION
Adds decode + semantics + simulator entries for two ARM NEON instructions
needed for verification of the AES-GCM optimised implementation:

- **BIF** (Bitwise Insert if False) — `0q101110111 Rm 000111 Rn Rd`
- **REV32** (vector, reverse within 32-bit elements) — `0q101110 size 100000000010 Rn Rd`

## Changes
- `arm/proofs/decode.ml`: bit-pattern decode entries
- `arm/proofs/instruction.ml`: semantic definitions, ALT rules, operation list
- `arm/proofs/simulator_iclasses.ml`: sematest entries

## Testing
Focused sematest (only BIF + REV32 in iclasses): 13,413 random instances
across 4 parallel processes, 0 failures. Cosimulated against hardware on
AArch64.