### PR TITLE
x86: Adds an 8-bit instance of the CMP instruction model

### DIFF
--- a/x86/proofs/simulator.ml
+++ b/x86/proofs/simulator.ml
@@ -1662,6 +1662,7 @@ let simple_memory_iclasses = iclasses_simplemem @
   [0xc4; 0xe2; 0x79; 0x30; 0x04; 0x24]; (* VPMOVZXBW (%_% xmm0) (Memop Quadword (%% (rsp,0))) *)
   [0xc5; 0xed; 0xf8; 0x0c; 0x24]; (* VPSUBB (%_% ymm1) (%_% ymm2) (Memop Word256 (%% (rsp,0))) *)
   [0xc5; 0xe9; 0xf8; 0x0c; 0x24]; (* VPSUBB (%_% xmm1) (%_% xmm2) (Memop Word128 (%% (rsp,0))) *)
+  [0x80; 0x3c; 0x24; 0x00]; (* CMP (Memop Byte (%% (rsp,0))) (Imm8 (word 0)) *)
 ];;
 
 let simplemem_iclasses =

--- a/x86/proofs/x86.ml
+++ b/x86/proofs/x86.ml
@@ -4746,12 +4746,13 @@ let X86_OPERATION_CLAUSES =
     x86_VPUNPCKLQDQ_ALT; x86_VPUNPCKHQDQ_ALT; x86_VPBROADCASTQ_ALT; x86_VPERM2I128_ALT;
     x86_VMOVMSKPS_ALT; x86_VPABSD_ALT; x86_VPMOVMSKB_ALT; x86_VPMOVSXBD_ALT;
     x86_VPMOVZXBD_ALT; x86_VPMOVZXBW_ALT; x86_VPSUBB_ALT; x86_VPTEST_ALT; x86_VZEROUPPER_ALT;
-    (*** 32-bit backups since the ALT forms are 64-bit only ***)
+    (*** 32/8-bit backups since the ALT forms are 64-bit only ***)
     INST_TYPE[`:32`,`:N`] x86_ADC;
     INST_TYPE[`:32`,`:N`] x86_ADCX;
     INST_TYPE[`:32`,`:N`] x86_ADOX;
     INST_TYPE[`:32`,`:N`] x86_ADD;
     INST_TYPE[`:32`,`:N`] x86_CMP;
+    INST_TYPE[`:8`,`:N`] x86_CMP;
     INST_TYPE[`:32`,`:N`] x86_SBB;
     INST_TYPE[`:32`,`:N`] x86_SUB];;
 


### PR DESCRIPTION
*Description of changes:*

X86_OPERATION_CLAUSES previously carried x86_CMP only at :64 (x86_CMP_ALT)
and :32. Byte-sized memory/immediate compares dispatch to x86_CMP at :8,
which had no matching rewrite clause, so the symbolic stepper left the term
unexpanded and the step failed (surfacing as the generic "Equality between
two states is ill-formed" error).

simulator.ml gains the byte-CMP encoding (cmp BYTE PTR [rsp], 0) in its
extra-checks list so sematest cosimulates the new clause against hardware.

Needed to simplify https://github.com/awslabs/s2n-bignum/pull/415 proof (which created it's own workaround).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
