### PR TITLE
Update HOL Light commit hash to the one with faster net

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  HOLLIGHT_COMMIT: "af5d20e033025a9f30a490d9c39edace632405a3"
+  HOLLIGHT_COMMIT: "b19af6934759eed622d7aca25092367f81656eee"
 
 jobs:
   s2n-bignum-tests:


### PR DESCRIPTION
This shortens the CI proof checking time by around 20 minutes (4hr 40 mins -> 4hr 20mins).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
