### PR TITLE
Arm: Model SADDW, SSUBL, SSUBW, USUBL, and USUBW

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -1018,6 +1018,32 @@ let decode = new_definition `!w:int32. decode w =
       else
         SOME (arm_UMLSL_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
 
+  | [0:1; q; 0b101110:6; size:2; 0b1:1; Rm:5; 0b001000:6; Rn:5; Rd:5] ->
+    // USUBL (vector, Q = 0). USUBL2 (vector, Q = 1)
+    // Unsigned widening long subtract: both source operands are narrow
+    // (esize-bit) lanes that get zero-extended to 2*esize.
+    // size=11 (esize=64) is UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      if q then
+        SOME (arm_USUBL2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+      else
+        SOME (arm_USUBL (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
+  | [0:1; q; 0b101110:6; size:2; 0b1:1; Rm:5; 0b001100:6; Rn:5; Rd:5] ->
+    // USUBW (vector, Q = 0). USUBW2 (vector, Q = 1)
+    // Unsigned widening subtract: Vn is already wide; the narrow (esize-bit)
+    // Vm lanes are zero-extended to 2*esize and subtracted.
+    // size=11 (esize=64) is UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      if q then
+        SOME (arm_USUBW2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+      else
+        SOME (arm_USUBW (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
   | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b000100:6; Rn:5; Rd:5] ->
     // SADDW (vector, Q = 0). SADDW2 (vector, Q = 1)
     // esize is the *source* (narrow) element size in bits; destination

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -1018,6 +1018,18 @@ let decode = new_definition `!w:int32. decode w =
       else
         SOME (arm_UMLSL_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
 
+  | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b000100:6; Rn:5; Rd:5] ->
+    // SADDW (vector, Q = 0). SADDW2 (vector, Q = 1)
+    // esize is the *source* (narrow) element size in bits; destination
+    // elements are 2*esize wide. size=11 (esize=64) is UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      if q then
+        SOME (arm_SADDW2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+      else
+        SOME (arm_SADDW (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
   | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b100000:6; Rn:5; Rd:5] ->
     // SMLAL (vector, Q = 0). SMLAL2 (vector, Q=1)
     if size = (word 0b11: (2)word) then NONE // "UNDEFINED"

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -1030,6 +1030,32 @@ let decode = new_definition `!w:int32. decode w =
       else
         SOME (arm_SADDW (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
 
+  | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b001000:6; Rn:5; Rd:5] ->
+    // SSUBL (vector, Q = 0). SSUBL2 (vector, Q = 1)
+    // Signed widening long subtract: both source operands are narrow
+    // (esize-bit) lanes that get sign-extended to 2*esize.
+    // size=11 (esize=64) is UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      if q then
+        SOME (arm_SSUBL2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+      else
+        SOME (arm_SSUBL (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
+  | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b001100:6; Rn:5; Rd:5] ->
+    // SSUBW (vector, Q = 0). SSUBW2 (vector, Q = 1)
+    // Signed widening subtract: Vn is already wide; the narrow (esize-bit)
+    // Vm lanes are sign-extended to 2*esize and subtracted.
+    // size=11 (esize=64) is UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      if q then
+        SOME (arm_SSUBW2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+      else
+        SOME (arm_SSUBW (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
+
   | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b100000:6; Rn:5; Rd:5] ->
     // SMLAL (vector, Q = 0). SMLAL2 (vector, Q=1)
     if size = (word 0b11: (2)word) then NONE // "UNDEFINED"

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2237,6 +2237,84 @@ let arm_SADDW2 = define
           let mhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) mhi in
           (Rd := simd8 word_add n mhisx) s`;;
 
+(*** SSUBL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>: signed widening long subtract.   ***)
+(*** Both operands are narrow: the low 64 bits of Vn and Vm hold esize-bit    ***)
+(*** lanes that are each sign-extended to 2*esize bits, then subtracted        ***)
+(*** lane-wise (Vd = sx(Vn) - sx(Vm)).  esize is the *source* element size.   ***)
+let arm_SSUBL = define
+ `arm_SSUBL Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let nlow:(64)word = word_subword n (0,64) in
+        let mlow:(64)word = word_subword m (0,64) in
+        if esize = 32 then
+          let nlowsx:(128)word = usimd2 (word_sx:(32)word->(64)word) nlow in
+          let mlowsx:(128)word = usimd2 (word_sx:(32)word->(64)word) mlow in
+          (Rd := simd2 word_sub nlowsx mlowsx) s
+        else if esize = 16 then
+          let nlowsx:(128)word = usimd4 (word_sx:(16)word->(32)word) nlow in
+          let mlowsx:(128)word = usimd4 (word_sx:(16)word->(32)word) mlow in
+          (Rd := simd4 word_sub nlowsx mlowsx) s
+        else // esize = 8
+          let nlowsx:(128)word = usimd8 (word_sx:(8)word->(16)word) nlow in
+          let mlowsx:(128)word = usimd8 (word_sx:(8)word->(16)word) mlow in
+          (Rd := simd8 word_sub nlowsx mlowsx) s`;;
+
+(*** SSUBL2: same as SSUBL but reads the high 64 bits of Vn and Vm.           ***)
+let arm_SSUBL2 = define
+ `arm_SSUBL2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let nhi:(64)word = word_subword n (64,64) in
+        let mhi:(64)word = word_subword m (64,64) in
+        if esize = 32 then
+          let nhisx:(128)word = usimd2 (word_sx:(32)word->(64)word) nhi in
+          let mhisx:(128)word = usimd2 (word_sx:(32)word->(64)word) mhi in
+          (Rd := simd2 word_sub nhisx mhisx) s
+        else if esize = 16 then
+          let nhisx:(128)word = usimd4 (word_sx:(16)word->(32)word) nhi in
+          let mhisx:(128)word = usimd4 (word_sx:(16)word->(32)word) mhi in
+          (Rd := simd4 word_sub nhisx mhisx) s
+        else // esize = 8
+          let nhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) nhi in
+          let mhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) mhi in
+          (Rd := simd8 word_sub nhisx mhisx) s`;;
+
+(*** SSUBW <Vd>.<Ta>, <Vn>.<Ta>, <Vm>.<Tb>: signed widening subtract.         ***)
+(*** Vn is the wide (already 2*esize per lane) operand; the low 64 bits of    ***)
+(*** Vm hold the narrow (esize-bit) lanes that are sign-extended and          ***)
+(*** subtracted (Vd = Vn - sx(Vm)).                                           ***)
+let arm_SSUBW = define
+ `arm_SSUBW Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mlow:(64)word = word_subword m (0,64) in
+        if esize = 32 then
+          let mlowsx:(128)word = usimd2 (word_sx:(32)word->(64)word) mlow in
+          (Rd := simd2 word_sub n mlowsx) s
+        else if esize = 16 then
+          let mlowsx:(128)word = usimd4 (word_sx:(16)word->(32)word) mlow in
+          (Rd := simd4 word_sub n mlowsx) s
+        else // esize = 8
+          let mlowsx:(128)word = usimd8 (word_sx:(8)word->(16)word) mlow in
+          (Rd := simd8 word_sub n mlowsx) s`;;
+
+(*** SSUBW2: same as SSUBW but takes the high 64 bits of Vm.                  ***)
+let arm_SSUBW2 = define
+ `arm_SSUBW2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mhi:(64)word = word_subword m (64,64) in
+        if esize = 32 then
+          let mhisx:(128)word = usimd2 (word_sx:(32)word->(64)word) mhi in
+          (Rd := simd2 word_sub n mhisx) s
+        else if esize = 16 then
+          let mhisx:(128)word = usimd4 (word_sx:(16)word->(32)word) mhi in
+          (Rd := simd4 word_sub n mhisx) s
+        else // esize = 8
+          let mhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) mhi in
+          (Rd := simd8 word_sub n mhisx) s`;;
+
 let arm_USHR_VEC = define
  `arm_USHR_VEC Rd Rn amt esize datasize =
     \s. let n = read Rn s in
@@ -3484,6 +3562,10 @@ let arm_SMULL_VEC_ALT =  EXPAND_SIMD_RULE arm_SMULL_VEC;;
 let arm_SMULL2_VEC_ALT = EXPAND_SIMD_RULE arm_SMULL2_VEC;;
 let arm_SADDW_ALT =      EXPAND_SIMD_RULE arm_SADDW;;
 let arm_SADDW2_ALT =     EXPAND_SIMD_RULE arm_SADDW2;;
+let arm_SSUBL_ALT =      EXPAND_SIMD_RULE arm_SSUBL;;
+let arm_SSUBL2_ALT =     EXPAND_SIMD_RULE arm_SSUBL2;;
+let arm_SSUBW_ALT =      EXPAND_SIMD_RULE arm_SSUBW;;
+let arm_SSUBW2_ALT =     EXPAND_SIMD_RULE arm_SSUBW2;;
 let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
 let arm_TBL_ALT =        EXPAND_SIMD_RULE arm_TBL;;
@@ -3625,6 +3707,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SMULH;
        arm_SQDMULH_VEC_ALT;
        arm_SQRDMULH_VEC_ALT;
+       arm_SSUBL_ALT; arm_SSUBL2_ALT; arm_SSUBW_ALT; arm_SSUBW2_ALT;
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
        arm_TBL_ALT; arm_TBL2_ALT;
        arm_TRN1_ALT; arm_TRN2_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2200,6 +2200,43 @@ let arm_SSHLL2_VEC = define
           let r:(128)word = usimd8 (\x. word_shl (word_sx x:(16)word) shift) nl in
           (Rd := r) s`;;
 
+(*** SADDW <Vd>.<Ta>, <Vn>.<Ta>, <Vm>.<Tb>: signed widening add (low half) ***)
+(*** Vn is the wide (already 2*esize per lane) operand; the low 64 bits of   ***)
+(*** Vm hold the narrow (esize-bit) lanes that are sign-extended and added.  ***)
+(*** Here esize is the *source* (narrow) element size in bits (8/16/32);     ***)
+(*** the destination element size is 2*esize.                                ***)
+let arm_SADDW = define
+ `arm_SADDW Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mlow:(64)word = word_subword m (0,64) in
+        if esize = 32 then
+          let mlowsx:(128)word = usimd2 (word_sx:(32)word->(64)word) mlow in
+          (Rd := simd2 word_add n mlowsx) s
+        else if esize = 16 then
+          let mlowsx:(128)word = usimd4 (word_sx:(16)word->(32)word) mlow in
+          (Rd := simd4 word_add n mlowsx) s
+        else // esize = 8
+          let mlowsx:(128)word = usimd8 (word_sx:(8)word->(16)word) mlow in
+          (Rd := simd8 word_add n mlowsx) s`;;
+
+(*** SADDW2: same as SADDW but takes the high 64 bits of Vm as the narrow    ***)
+(*** source operand.                                                         ***)
+let arm_SADDW2 = define
+ `arm_SADDW2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mhi:(64)word = word_subword m (64,64) in
+        if esize = 32 then
+          let mhisx:(128)word = usimd2 (word_sx:(32)word->(64)word) mhi in
+          (Rd := simd2 word_add n mhisx) s
+        else if esize = 16 then
+          let mhisx:(128)word = usimd4 (word_sx:(16)word->(32)word) mhi in
+          (Rd := simd4 word_add n mhisx) s
+        else // esize = 8
+          let mhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) mhi in
+          (Rd := simd8 word_add n mhisx) s`;;
+
 let arm_USHR_VEC = define
  `arm_USHR_VEC Rd Rn amt esize datasize =
     \s. let n = read Rn s in
@@ -3445,6 +3482,8 @@ let arm_SMLSL_VEC_ALT =  EXPAND_SIMD_RULE arm_SMLSL_VEC;;
 let arm_SMLSL2_VEC_ALT = EXPAND_SIMD_RULE arm_SMLSL2_VEC;;
 let arm_SMULL_VEC_ALT =  EXPAND_SIMD_RULE arm_SMULL_VEC;;
 let arm_SMULL2_VEC_ALT = EXPAND_SIMD_RULE arm_SMULL2_VEC;;
+let arm_SADDW_ALT =      EXPAND_SIMD_RULE arm_SADDW;;
+let arm_SADDW2_ALT =     EXPAND_SIMD_RULE arm_SADDW2;;
 let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
 let arm_TBL_ALT =        EXPAND_SIMD_RULE arm_TBL;;
@@ -3574,6 +3613,7 @@ let ARM_OPERATION_CLAUSES =
        arm_PMUL_VEC_ALT;
        arm_PMULL_VEC_ALT; arm_PMULL2_VEC_ALT;
        arm_RET; arm_REV; arm_REV32_VEC_ALT; arm_REV64_VEC_ALT; arm_RORV;
+       arm_SADDW_ALT; arm_SADDW2_ALT;
        arm_SBC; arm_SBCS_ALT; arm_SBFM; arm_SHL_VEC_ALT; arm_SHRN_ALT;
        arm_SRSHR_VEC_ALT;
        arm_SSHR_VEC_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2315,6 +2315,80 @@ let arm_SSUBW2 = define
           let mhisx:(128)word = usimd8 (word_sx:(8)word->(16)word) mhi in
           (Rd := simd8 word_sub n mhisx) s`;;
 
+(*** USUBL <Vd>.<Ta>, <Vn>.<Tb>, <Vm>.<Tb>: unsigned widening long subtract.  ***)
+(*** Like SSUBL but both narrow operands are *zero*-extended.                 ***)
+let arm_USUBL = define
+ `arm_USUBL Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let nlow:(64)word = word_subword n (0,64) in
+        let mlow:(64)word = word_subword m (0,64) in
+        if esize = 32 then
+          let nlowzx:(128)word = usimd2 (word_zx:(32)word->(64)word) nlow in
+          let mlowzx:(128)word = usimd2 (word_zx:(32)word->(64)word) mlow in
+          (Rd := simd2 word_sub nlowzx mlowzx) s
+        else if esize = 16 then
+          let nlowzx:(128)word = usimd4 (word_zx:(16)word->(32)word) nlow in
+          let mlowzx:(128)word = usimd4 (word_zx:(16)word->(32)word) mlow in
+          (Rd := simd4 word_sub nlowzx mlowzx) s
+        else // esize = 8
+          let nlowzx:(128)word = usimd8 (word_zx:(8)word->(16)word) nlow in
+          let mlowzx:(128)word = usimd8 (word_zx:(8)word->(16)word) mlow in
+          (Rd := simd8 word_sub nlowzx mlowzx) s`;;
+
+(*** USUBL2: same as USUBL but reads the high 64 bits of Vn and Vm.           ***)
+let arm_USUBL2 = define
+ `arm_USUBL2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let nhi:(64)word = word_subword n (64,64) in
+        let mhi:(64)word = word_subword m (64,64) in
+        if esize = 32 then
+          let nhizx:(128)word = usimd2 (word_zx:(32)word->(64)word) nhi in
+          let mhizx:(128)word = usimd2 (word_zx:(32)word->(64)word) mhi in
+          (Rd := simd2 word_sub nhizx mhizx) s
+        else if esize = 16 then
+          let nhizx:(128)word = usimd4 (word_zx:(16)word->(32)word) nhi in
+          let mhizx:(128)word = usimd4 (word_zx:(16)word->(32)word) mhi in
+          (Rd := simd4 word_sub nhizx mhizx) s
+        else // esize = 8
+          let nhizx:(128)word = usimd8 (word_zx:(8)word->(16)word) nhi in
+          let mhizx:(128)word = usimd8 (word_zx:(8)word->(16)word) mhi in
+          (Rd := simd8 word_sub nhizx mhizx) s`;;
+
+(*** USUBW <Vd>.<Ta>, <Vn>.<Ta>, <Vm>.<Tb>: unsigned widening subtract.       ***)
+(*** Like SSUBW but the narrow Vm lanes are *zero*-extended (Vd = Vn-zx(Vm)). ***)
+let arm_USUBW = define
+ `arm_USUBW Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mlow:(64)word = word_subword m (0,64) in
+        if esize = 32 then
+          let mlowzx:(128)word = usimd2 (word_zx:(32)word->(64)word) mlow in
+          (Rd := simd2 word_sub n mlowzx) s
+        else if esize = 16 then
+          let mlowzx:(128)word = usimd4 (word_zx:(16)word->(32)word) mlow in
+          (Rd := simd4 word_sub n mlowzx) s
+        else // esize = 8
+          let mlowzx:(128)word = usimd8 (word_zx:(8)word->(16)word) mlow in
+          (Rd := simd8 word_sub n mlowzx) s`;;
+
+(*** USUBW2: same as USUBW but takes the high 64 bits of Vm.                  ***)
+let arm_USUBW2 = define
+ `arm_USUBW2 Rd Rn Rm esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let m:(128)word = read Rm (s:armstate) in
+        let mhi:(64)word = word_subword m (64,64) in
+        if esize = 32 then
+          let mhizx:(128)word = usimd2 (word_zx:(32)word->(64)word) mhi in
+          (Rd := simd2 word_sub n mhizx) s
+        else if esize = 16 then
+          let mhizx:(128)word = usimd4 (word_zx:(16)word->(32)word) mhi in
+          (Rd := simd4 word_sub n mhizx) s
+        else // esize = 8
+          let mhizx:(128)word = usimd8 (word_zx:(8)word->(16)word) mhi in
+          (Rd := simd8 word_sub n mhizx) s`;;
+
 let arm_USHR_VEC = define
  `arm_USHR_VEC Rd Rn amt esize datasize =
     \s. let n = read Rn s in
@@ -3566,6 +3640,10 @@ let arm_SSUBL_ALT =      EXPAND_SIMD_RULE arm_SSUBL;;
 let arm_SSUBL2_ALT =     EXPAND_SIMD_RULE arm_SSUBL2;;
 let arm_SSUBW_ALT =      EXPAND_SIMD_RULE arm_SSUBW;;
 let arm_SSUBW2_ALT =     EXPAND_SIMD_RULE arm_SSUBW2;;
+let arm_USUBL_ALT =      EXPAND_SIMD_RULE arm_USUBL;;
+let arm_USUBL2_ALT =     EXPAND_SIMD_RULE arm_USUBL2;;
+let arm_USUBW_ALT =      EXPAND_SIMD_RULE arm_USUBW;;
+let arm_USUBW2_ALT =     EXPAND_SIMD_RULE arm_USUBW2;;
 let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
 let arm_TBL_ALT =        EXPAND_SIMD_RULE arm_TBL;;
@@ -3720,7 +3798,9 @@ let ARM_OPERATION_CLAUSES =
        arm_UMIN_VEC_ALT;
        arm_USHL_VEC_ALT;
        arm_USHLL_VEC_ALT; arm_USHLL2_VEC_ALT;
-       arm_USHR_VEC_ALT; arm_USRA_VEC_ALT; arm_UZP1_ALT;
+       arm_USHR_VEC_ALT; arm_USRA_VEC_ALT;
+       arm_USUBL_ALT; arm_USUBL2_ALT; arm_USUBW_ALT; arm_USUBW2_ALT;
+       arm_UZP1_ALT;
        arm_UZP2_ALT;
        arm_XAR; arm_XTN_ALT;
        arm_ZIP1_ALT; arm_ZIP2_ALT;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -253,6 +253,12 @@ let iclasses =
   (*** REV32 ***)
   "01101110xx100000000010xxxxxxxxxx";
 
+  (*** SADDW ***)
+  "00001110xx1xxxxx000100xxxxxxxxxx";
+
+  (*** SADDW2 ***)
+  "01001110xx1xxxxx000100xxxxxxxxxx";
+
   (*** SHA256 Intrinsics ***)
   (*** SHA256H ***)
   "01011110000xxxxx010000xxxxxxxxxx";

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -271,6 +271,18 @@ let iclasses =
   (*** SSUBW2 ***)
   "01001110xx1xxxxx001100xxxxxxxxxx";
 
+  (*** USUBL ***)
+  "00101110xx1xxxxx001000xxxxxxxxxx";
+
+  (*** USUBL2 ***)
+  "01101110xx1xxxxx001000xxxxxxxxxx";
+
+  (*** USUBW ***)
+  "00101110xx1xxxxx001100xxxxxxxxxx";
+
+  (*** USUBW2 ***)
+  "01101110xx1xxxxx001100xxxxxxxxxx";
+
   (*** SHA256 Intrinsics ***)
   (*** SHA256H ***)
   "01011110000xxxxx010000xxxxxxxxxx";

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -259,6 +259,18 @@ let iclasses =
   (*** SADDW2 ***)
   "01001110xx1xxxxx000100xxxxxxxxxx";
 
+  (*** SSUBL ***)
+  "00001110xx1xxxxx001000xxxxxxxxxx";
+
+  (*** SSUBL2 ***)
+  "01001110xx1xxxxx001000xxxxxxxxxx";
+
+  (*** SSUBW ***)
+  "00001110xx1xxxxx001100xxxxxxxxxx";
+
+  (*** SSUBW2 ***)
+  "01001110xx1xxxxx001100xxxxxxxxxx";
+
   (*** SHA256 Intrinsics ***)
   (*** SHA256H ***)
   "01011110000xxxxx010000xxxxxxxxxx";


### PR DESCRIPTION
Adds semantics, decoding, conversion registration, and hardware cosimulation coverage for `SADDW`, `SSUBL`, `SSUBW`, `USUBL`, `USUBW`, and their `2` forms. These instructions perform lane-wise arithmetic using 8-, 16-, or 32-bit narrow elements and 16-, 32-, or 64-bit destination elements:

  - `SADDW` adds sign-extended narrow `Vm` lanes to already-wide `Vn` lanes.
  - `SSUBL` and `USUBL` widen both narrow operands before computing `Vn - Vm`.
  - `SSUBW` and `USUBW` widen narrow `Vm` lanes and subtract them from the already-wide `Vn` lanes.

The signed forms use sign extension; the unsigned forms use zero extension.

These instructions are needed by the x265 AArch64 NEON proof work.

  ### Implementation
`Q = 0` selects the base form and reads each narrow operand from the low half of its source register. `Q = 1` selects the corresponding `2` form and reads the high half. The decoder supports 8-, 16-, and 32-bit narrow elements and rejects the undefined `size = 11` encoding.

The new semantics are registered as expanded SIMD rules. The simulator masks cover every family, source size, and base/`2` form, including the undefined size encodings.

  ### Validation
  - Assembled all 30 valid family, source-size, and `Q` combinations with LLVM and checked their opcode fields.
  - Fresh HOL checks decoded all 30 valid representatives and confirmed that ten `size = 11` representatives decode to `NONE`.
  - Confirmed that the decoder clauses and simulator masks do not overlap existing instruction classes.
  - Full 16-worker AArch64 `make -C arm sematest` passed 54,079 cases with zero failures, including 1,857 valid executions and 586 undefined-size rejections.
