### PR TITLE
 Arm: Model URHADD, UADALP, ADDV, SMAX, UMAX, and SHRN2

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -998,6 +998,30 @@ let decode = new_definition `!w:int32. decode w =
     let elements = datasize DIV esize in
     SOME(arm_UMAXV (QREG' Rd) (QREG' Rn) elements esize)
 
+  | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b011001:6; Rn:5; Rd:5] ->
+    // SMAX (signed element-wise maximum). size=11 (esize=64) UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize = 8 * 2 EXP (val size) in
+      let datasize = if q then 128 else 64 in
+      SOME (arm_SMAX_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
+
+  | [0:1; q; 0b101110:6; size:2; 0b1:1; Rm:5; 0b011001:6; Rn:5; Rd:5] ->
+    // UMAX (unsigned element-wise maximum). size=11 (esize=64) UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize = 8 * 2 EXP (val size) in
+      let datasize = if q then 128 else 64 in
+      SOME (arm_UMAX_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
+
+  | [0:1; q; 0b101110:6; size:2; 0b1:1; Rm:5; 0b000101:6; Rn:5; Rd:5] ->
+    // URHADD (unsigned rounding halving add). size=11 (esize=64) UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
+    else
+      let esize = 8 * 2 EXP (val size) in
+      let datasize = if q then 128 else 64 in
+      SOME (arm_URHADD_VEC (QREG' Rd) (QREG' Rn) (QREG' Rm) esize datasize)
+
   | [0:1; q; 0b101110:6; size:2; 0b1:1; Rm:5; 0b100000:6; Rn:5; Rd:5] ->
     // UMLAL (vector, Q = 0). UMLAL2 (vector, Q=1)
     if size = (word 0b11: (2)word) then NONE // "UNDEFINED"

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -998,6 +998,23 @@ let decode = new_definition `!w:int32. decode w =
     let elements = datasize DIV esize in
     SOME(arm_UMAXV (QREG' Rd) (QREG' Rn) elements esize)
 
+  | [0:1; q; 0b001110:6; size:2; 0b110001101110:12; Rn:5; Rd:5] ->
+    // ADDV (across-vector add reduction). size=10 with q=0 (2s) UNALLOCATED;
+    // size=11 UNDEFINED. Result is esize-wide scalar in low bits of Rd.
+    if size = word 0b10 /\ ~q \/ size = word 0b11 then NONE else
+    let esize = 8 * 2 EXP (val size) in
+    let datasize = if q then 128 else 64 in
+    let elements = datasize DIV esize in
+    SOME(arm_ADDV (QREG' Rd) (QREG' Rn) elements esize)
+
+  | [0:1; q; 0b101110:6; size:2; 0b100000011010:12; Rn:5; Rd:5] ->
+    // UADALP (unsigned pairwise add and accumulate long). size=11 UNDEFINED.
+    if size = (word 0b11: (2)word) then NONE
+    else
+      let esize: (64)word = word_shl (word 8: (64)word) (val size) in
+      let datasize = if q then 128 else 64 in
+      SOME (arm_UADALP (QREG' Rd) (QREG' Rn) (val esize) datasize)
+
   | [0:1; q; 0b001110:6; size:2; 0b1:1; Rm:5; 0b011001:6; Rn:5; Rd:5] ->
     // SMAX (signed element-wise maximum). size=11 (esize=64) UNDEFINED.
     if size = (word 0b11: (2)word) then NONE // "UNDEFINED"

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -853,7 +853,8 @@ let decode = new_definition `!w:int32. decode w =
         SOME (arm_SSHLL_VEC (QREG' Rd) (QREG' Rn) shift esize)
 
   | [0:1; q; 0b0011110:7; immh:4; immb:3; 0b100001:6; Rn:5; Rd:5] ->
-    // SHRN (or MOVI with cmode=1000 when immh=0 and Q=1)
+    // SHRN (Q=0, low half) / SHRN2 (Q=1, high half)
+    // (or MOVI with cmode=1000 when immh=0 and Q=1)
     if immh = (word 0b0:(4)word) then
       if q then
         let abcdefgh:(8)word = word_join immb Rn in
@@ -862,15 +863,14 @@ let decode = new_definition `!w:int32. decode w =
         | SOME imm -> SOME (arm_MOVI (QREG' Rd) imm)
         | NONE -> NONE
       else NONE
-    else if q then NONE // writing to the upper part is unsupported yet
     else if bit 3 immh then NONE // "UNDEFINED"
     else
       let esize = 8 * 2 EXP (3 - word_clz immh) in
-      // datasize is 64, part is 0
-      let elements = 64 DIV esize in
+      // esize is the destination (narrow) element size
       let shift = (2 * esize) - val(word_join immh immb: (7)word) in
       // round is false
-      SOME (arm_SHRN (QREG' Rd) (QREG' Rn) shift esize)
+      if q then SOME (arm_SHRN2 (QREG' Rd) (QREG' Rn) shift esize)
+      else SOME (arm_SHRN (QREG' Rd) (QREG' Rn) shift esize)
 
   | [0:1; q; 0b001111:6; sz:2; L:1; M:1; R:4; 0b1100:4; H:1; 0:1; Rn:5; Rd:5] ->
     // SQDMULH (by element)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2333,6 +2333,64 @@ let arm_UMAX_VEC = define
             else simd8 word_umax n m in
           (Rd := word_zx d:(128)word) s`;;
 
+(*** UADALP <Vd>.<Ta>, <Vn>.<Tb>: unsigned pairwise add and ACCUMULATE long.  ***)
+(*** Like UADDLP but the pairwise sums are added into the existing Rd lanes.   ***)
+(*** Vn holds 2*N narrow esize-bit lanes; each adjacent pair is zero-extended  ***)
+(*** to 2*esize, summed, and added to the corresponding wide Rd lane.          ***)
+(*** datasize is 64 or 128 according to Q. 64-bit forms zero the high half.    ***)
+let arm_UADALP = define
+ `arm_UADALP Rd Rn esize datasize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let d:(128)word = read Rd (s:armstate) in
+        if datasize = 128 then
+          if esize = 32 then
+            let res = usimd2
+              (\x. word_add (word_zx (word_subword x (0,32):(32)word):(64)word)
+                            (word_zx (word_subword x (32,32):(32)word):(64)word)) n in
+            (Rd := simd2 word_add d res) s
+          else if esize = 16 then
+            let res = usimd4
+              (\x. word_add (word_zx (word_subword x (0,16):(16)word):(32)word)
+                            (word_zx (word_subword x (16,16):(16)word):(32)word)) n in
+            (Rd := simd4 word_add d res) s
+          else // esize=8
+            let res = usimd8
+              (\x. word_add (word_zx (word_subword x (0,8):(8)word):(16)word)
+                            (word_zx (word_subword x (8,8):(8)word):(16)word)) n in
+            (Rd := simd8 word_add d res) s
+        else
+          let n:(64)word = word_subword n (0,64) in
+          let d:(64)word = word_subword d (0,64) in
+          let d:(64)word =
+            if esize = 32 then
+              let res:(64)word =
+                word_add (word_zx (word_subword n (0,32):(32)word):(64)word)
+                         (word_zx (word_subword n (32,32):(32)word):(64)word) in
+              word_add d res
+            else if esize = 16 then
+              let res = usimd2
+                (\x. word_add (word_zx (word_subword x (0,16):(16)word):(32)word)
+                              (word_zx (word_subword x (16,16):(16)word):(32)word)) n in
+              simd2 word_add d res
+            else // esize=8
+              let res = usimd4
+                (\x. word_add (word_zx (word_subword x (0,8):(8)word):(16)word)
+                              (word_zx (word_subword x (8,8):(8)word):(16)word)) n in
+              simd4 word_add d res in
+          (Rd := word_zx d:(128)word) s`;;
+
+(*** ADDV <V><d>, <Vn>.<T>: across-vector add reduction.  The scalar result   ***)
+(*** is the sum (modulo 2^esize) of all lanes of Vn.<T>.  Modelled like        ***)
+(*** UADDLV / UMAXV but with summation and NO widening (result is esize-wide,  ***)
+(*** placed in the low bits of Rd).  Kernel needs 8h (8 lanes of 16) and 4s.   ***)
+let arm_ADDV = define
+ `arm_ADDV Rd Rn elements esize =
+    \s:armstate.
+        let n:128 word = read Rn s in
+        let d = nsum (0..elements-1)
+                    (\i. val(word_subword n (esize*i,esize):int128)) in
+        (Rd := (word (d MOD 2 EXP esize):128 word)) s`;;
+
 let arm_USRA_VEC = define
  `arm_USRA_VEC Rd Rn shift esize datasize =
     \s. let n:(128)word = read Rn s in
@@ -3559,6 +3617,7 @@ let arm_URHADD_VEC_ALT =
   REWRITE_RULE[word_urhadd] (EXPAND_SIMD_RULE arm_URHADD_VEC);;
 let arm_SMAX_VEC_ALT =    EXPAND_SIMD_RULE arm_SMAX_VEC;;
 let arm_UMAX_VEC_ALT =    EXPAND_SIMD_RULE arm_UMAX_VEC;;
+let arm_UADALP_ALT =      EXPAND_SIMD_RULE arm_UADALP;;
 let arm_USHR_VEC_ALT =   EXPAND_SIMD_RULE arm_USHR_VEC;;
 let arm_USRA_VEC_ALT =   EXPAND_SIMD_RULE arm_USRA_VEC;;
 let arm_UZP1_ALT =       EXPAND_SIMD_RULE arm_UZP1;;
@@ -3592,6 +3651,21 @@ let arm_UADDLV_ALT =
    `arm_UADDLV Rd Rn 4 16`;
    `arm_UADDLV Rd Rn 8 16`;
    `arm_UADDLV Rd Rn 4 32`];;
+
+let arm_ADDV_ALT =
+  (end_itlist CONJ o
+   map (REWRITE_RULE[WORD_ADD; WORD_VAL] o
+        CONV_RULE(TOP_DEPTH_CONV let_CONV) o
+        CONV_RULE
+         (NUM_REDUCE_CONV THENC
+          ONCE_DEPTH_CONV EXPAND_NSUM_CONV THENC
+          NUM_REDUCE_CONV) o
+        GEN_REWRITE_CONV I [arm_ADDV]))
+  [`arm_ADDV Rd Rn 8 8`;
+   `arm_ADDV Rd Rn 16 8`;
+   `arm_ADDV Rd Rn 4 16`;
+   `arm_ADDV Rd Rn 8 16`;
+   `arm_ADDV Rd Rn 4 32`];;
 
 let arm_UMAXV_ALT =
   (end_itlist CONJ o
@@ -3647,7 +3721,7 @@ let arm_ST3_ALT = end_itlist CONJ
 let ARM_OPERATION_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)
     (*** Alphabetically sorted, new alphabet appears in the next line ***)
-      [arm_ADC; arm_ADCS_ALT; arm_ADD; arm_ADD_VEC_ALT; arm_ABS_VEC_ALT; arm_ADDS_ALT; arm_ADR;
+      [arm_ADC; arm_ADCS_ALT; arm_ADD; arm_ADD_VEC_ALT; arm_ADDV_ALT; arm_ABS_VEC_ALT; arm_ADDS_ALT; arm_ADR;
        arm_ADRP; arm_AND; arm_AND_VEC; arm_ANDS; arm_ASR; arm_ASRV;
        arm_B; arm_BCAX; arm_BFM; arm_BIC; arm_BIC_VEC; arm_BICS; arm_BIF; arm_BIT;
        arm_BL; arm_BL_ABSOLUTE; arm_Bcond;
@@ -3683,7 +3757,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
        arm_TBL_ALT; arm_TBL2_ALT;
        arm_TRN1_ALT; arm_TRN2_ALT;
-       arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UMAX_VEC_ALT; arm_UMAXV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
+       arm_UADALP_ALT; arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UMAX_VEC_ALT; arm_UMAXV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
        arm_UMLAL_VEC_ALT; arm_UMLAL2_VEC_ALT;
        arm_UMLSL_VEC_ALT; arm_UMLSL2_VEC_ALT;
        arm_UMSUBL;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1668,6 +1668,25 @@ let arm_SHRN = define
         // equivalent to word_zx res:(128)word, but use word_subword instead
         (Rd := word_subword res (0,128)) s`;;
 
+(*** SHRN2: same shift-right-narrow as SHRN but the narrowed lanes are        ***)
+(*** written into the HIGH 64 bits of Vd, preserving its low 64 bits.         ***)
+(*** esize is Rd's (destination, narrow) element size.                        ***)
+let arm_SHRN2 = define
+ `arm_SHRN2 Rd Rn amnt esize = // esize is Rd's element size
+    \s. let n:(128)word = read Rn s in
+        let d:(128)word = read Rd s in
+        let res:(64)word =
+          if esize = 32 then
+            usimd2 (\(x:(64)word).
+              word_subword (word_ushr x amnt) (0,32):(32)word) n
+          else if esize = 16 then
+            usimd4 (\(x:(32)word).
+              word_subword (word_ushr x amnt) (0,16):(16)word) n
+          else // esize = 8
+            usimd8 (\(x:(16)word).
+              word_subword (word_ushr x amnt) (0,8):(8)word) n in
+        (Rd := word_join res (word_subword d (0,64):(64)word):(128)word) s`;;
+
 let arm_SMULH = define
  `arm_SMULH Rd Rn Rm =
     \s. let n:N word = read Rn (s:armstate)
@@ -3438,6 +3457,7 @@ let arm_REV32_VEC_ALT =  EXPAND_SIMD_RULE arm_REV32_VEC;;
 let arm_SHL_VEC_ALT =    EXPAND_SIMD_RULE arm_SHL_VEC;;
 let arm_SSHR_VEC_ALT =   EXPAND_SIMD_RULE arm_SSHR_VEC;;
 let arm_SHRN_ALT =       EXPAND_SIMD_RULE arm_SHRN;;
+let arm_SHRN2_ALT =      EXPAND_SIMD_RULE arm_SHRN2;;
 let arm_SLI_VEC_ALT =    EXPAND_SIMD_RULE arm_SLI_VEC;;
 let arm_SMLAL_VEC_ALT =  EXPAND_SIMD_RULE arm_SMLAL_VEC;;
 let arm_SMLAL2_VEC_ALT = EXPAND_SIMD_RULE arm_SMLAL2_VEC;;
@@ -3574,7 +3594,7 @@ let ARM_OPERATION_CLAUSES =
        arm_PMUL_VEC_ALT;
        arm_PMULL_VEC_ALT; arm_PMULL2_VEC_ALT;
        arm_RET; arm_REV; arm_REV32_VEC_ALT; arm_REV64_VEC_ALT; arm_RORV;
-       arm_SBC; arm_SBCS_ALT; arm_SBFM; arm_SHL_VEC_ALT; arm_SHRN_ALT;
+       arm_SBC; arm_SBCS_ALT; arm_SBFM; arm_SHL_VEC_ALT; arm_SHRN_ALT; arm_SHRN2_ALT;
        arm_SRSHR_VEC_ALT;
        arm_SSHR_VEC_ALT;
        arm_SLI_VEC_ALT; arm_SRI_VEC_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2263,6 +2263,76 @@ let arm_USHL_VEC = define
             else simd8 word_ushl n m in
           (Rd := word_zx d:(128)word) s`;;
 
+(*** URHADD <Vd>.<T>, <Vn>.<T>, <Vm>.<T>: unsigned rounding halving add.     ***)
+(*** Each lane is (UInt(n_i) + UInt(m_i) + 1) >> 1, kept in esize bits.        ***)
+(*** No widening: lanes stay esize wide.  esize 8/16 are the kernel needs;     ***)
+(*** 32 is also modelled for completeness.  datasize 64 or 128.               ***)
+let word_urhadd = define
+ `(word_urhadd:N word->N word->N word) x y =
+    word((val x + val y + 1) DIV 2)`;;
+
+let arm_URHADD_VEC = define
+ `arm_URHADD_VEC Rd Rn Rm esize datasize =
+    \s. let n = read Rn s
+        and m = read Rm (s:armstate) in
+        if datasize = 128 then
+          let d:(128)word =
+            if esize = 32 then simd4 word_urhadd n m
+            else if esize = 16 then simd8 word_urhadd n m
+            else simd16 word_urhadd n m in
+          (Rd := d) s
+        else
+          let n:(64)word = word_subword n (0,64) in
+          let m:(64)word = word_subword m (0,64) in
+          let d:(64)word =
+            if esize = 32 then simd2 word_urhadd n m
+            else if esize = 16 then simd4 word_urhadd n m
+            else simd8 word_urhadd n m in
+          (Rd := word_zx d:(128)word) s`;;
+
+(*** SMAX <Vd>.<T>, <Vn>.<T>, <Vm>.<T>: signed element-wise maximum.          ***)
+(*** Each destination lane is the signed max of the two source lanes.         ***)
+let arm_SMAX_VEC = define
+ `arm_SMAX_VEC Rd Rn Rm esize datasize =
+    \s. let n = read Rn s
+        and m = read Rm (s:armstate) in
+        if datasize = 128 then
+          let d:(128)word =
+            if esize = 32 then simd4 word_imax n m
+            else if esize = 16 then simd8 word_imax n m
+            else simd16 word_imax n m in
+          (Rd := d) s
+        else
+          let n:(64)word = word_subword n (0,64) in
+          let m:(64)word = word_subword m (0,64) in
+          let d:(64)word =
+            if esize = 32 then simd2 word_imax n m
+            else if esize = 16 then simd4 word_imax n m
+            else simd8 word_imax n m in
+          (Rd := word_zx d:(128)word) s`;;
+
+(*** UMAX <Vd>.<T>, <Vn>.<T>, <Vm>.<T>: unsigned element-wise maximum.         ***)
+(*** Each destination lane is the unsigned max of the two source lanes.       ***)
+(*** (Distinct from UMAXV, the across-vector reduction.)                       ***)
+let arm_UMAX_VEC = define
+ `arm_UMAX_VEC Rd Rn Rm esize datasize =
+    \s. let n = read Rn s
+        and m = read Rm (s:armstate) in
+        if datasize = 128 then
+          let d:(128)word =
+            if esize = 32 then simd4 word_umax n m
+            else if esize = 16 then simd8 word_umax n m
+            else simd16 word_umax n m in
+          (Rd := d) s
+        else
+          let n:(64)word = word_subword n (0,64) in
+          let m:(64)word = word_subword m (0,64) in
+          let d:(64)word =
+            if esize = 32 then simd2 word_umax n m
+            else if esize = 16 then simd4 word_umax n m
+            else simd8 word_umax n m in
+          (Rd := word_zx d:(128)word) s`;;
+
 let arm_USRA_VEC = define
  `arm_USRA_VEC Rd Rn shift esize datasize =
     \s. let n:(128)word = read Rn s in
@@ -3485,6 +3555,10 @@ let arm_USHLL_VEC_ALT =  EXPAND_SIMD_RULE arm_USHLL_VEC;;
 let arm_USHLL2_VEC_ALT = EXPAND_SIMD_RULE arm_USHLL2_VEC;;
 let arm_SSHLL_VEC_ALT =  EXPAND_SIMD_RULE arm_SSHLL_VEC;;
 let arm_SSHLL2_VEC_ALT = EXPAND_SIMD_RULE arm_SSHLL2_VEC;;
+let arm_URHADD_VEC_ALT =
+  REWRITE_RULE[word_urhadd] (EXPAND_SIMD_RULE arm_URHADD_VEC);;
+let arm_SMAX_VEC_ALT =    EXPAND_SIMD_RULE arm_SMAX_VEC;;
+let arm_UMAX_VEC_ALT =    EXPAND_SIMD_RULE arm_UMAX_VEC;;
 let arm_USHR_VEC_ALT =   EXPAND_SIMD_RULE arm_USHR_VEC;;
 let arm_USRA_VEC_ALT =   EXPAND_SIMD_RULE arm_USRA_VEC;;
 let arm_UZP1_ALT =       EXPAND_SIMD_RULE arm_UZP1;;
@@ -3598,6 +3672,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SRSHR_VEC_ALT;
        arm_SSHR_VEC_ALT;
        arm_SLI_VEC_ALT; arm_SRI_VEC_ALT;
+       arm_SMAX_VEC_ALT;
        arm_SMLAL_VEC_ALT; arm_SMLAL2_VEC_ALT;
        arm_SMLSL_VEC_ALT; arm_SMLSL2_VEC_ALT;
        arm_SMULL_VEC_ALT; arm_SMULL2_VEC_ALT;
@@ -3608,13 +3683,14 @@ let ARM_OPERATION_CLAUSES =
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
        arm_TBL_ALT; arm_TBL2_ALT;
        arm_TRN1_ALT; arm_TRN2_ALT;
-       arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UMAXV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
+       arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UMAX_VEC_ALT; arm_UMAXV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
        arm_UMLAL_VEC_ALT; arm_UMLAL2_VEC_ALT;
        arm_UMLSL_VEC_ALT; arm_UMLSL2_VEC_ALT;
        arm_UMSUBL;
        arm_UMULL_VEC_ALT; arm_UMULL2_VEC_ALT;
        arm_UMULH;
        arm_UMIN_VEC_ALT;
+       arm_URHADD_VEC_ALT;
        arm_USHL_VEC_ALT;
        arm_USHLL_VEC_ALT; arm_USHLL2_VEC_ALT;
        arm_USHR_VEC_ALT; arm_USRA_VEC_ALT; arm_UZP1_ALT;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -253,6 +253,9 @@ let iclasses =
   (*** REV32 ***)
   "01101110xx100000000010xxxxxxxxxx";
 
+  (*** SMAX (signed element-wise maximum) ***)
+  "0x001110xx1xxxxx011001xxxxxxxxxx";
+
   (*** SHA256 Intrinsics ***)
   (*** SHA256H ***)
   "01011110000xxxxx010000xxxxxxxxxx";
@@ -367,8 +370,14 @@ let iclasses =
   (*** UADDLV ***)
   "0x101110xx110000001110xxxxxxxxxx";
 
+  (*** UMAX (unsigned element-wise maximum) ***)
+  "0x101110xx1xxxxx011001xxxxxxxxxx";
+
   (*** UMAXV ***)
   "0x101110xx110000101010xxxxxxxxxx";
+
+  (*** URHADD (unsigned rounding halving add) ***)
+  "0x101110xx1xxxxx000101xxxxxxxxxx";
 
   (*** UMIN, vector ***)
   "0x101110xx1xxxxx011011xxxxxxxxxx";

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -289,6 +289,12 @@ let iclasses =
   "000011110001xxxx100001xxxxxxxxxx"; (* q=0, immh!=0 *)
   "0000111100001xxx100001xxxxxxxxxx"; (* q=0, immh!=0 *)
 
+  (*** SHRN2 (make sure immh is nonzero) ***)
+  "0100111101xxxxxx100001xxxxxxxxxx"; (* immh<3> = 1, UNDEFINED *)
+  "01001111001xxxxx100001xxxxxxxxxx"; (* q=1, immh!=0 *)
+  "010011110001xxxx100001xxxxxxxxxx"; (* q=1, immh!=0 *)
+  "0100111100001xxx100001xxxxxxxxxx"; (* q=1, immh!=0 *)
+
   (*** SMLAL ***)
   "00001110xx1xxxxx100000xxxxxxxxxx";
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -253,6 +253,9 @@ let iclasses =
   (*** REV32 ***)
   "01101110xx100000000010xxxxxxxxxx";
 
+  (*** ADDV (across-vector add reduction) ***)
+  "0x001110xx110001101110xxxxxxxxxx";
+
   (*** SMAX (signed element-wise maximum) ***)
   "0x001110xx1xxxxx011001xxxxxxxxxx";
 
@@ -363,6 +366,9 @@ let iclasses =
 
   (*** TRN1 and TRN2 ***)
   "0x001110xx0xxxxx0x1010xxxxxxxxxx";
+
+  (*** UADALP (unsigned pairwise add and accumulate long) ***)
+  "0x101110xx100000011010xxxxxxxxxx";
 
   (*** UADDLP ***)
   "01101110xx100000001010xxxxxxxxxx";


### PR DESCRIPTION
Adds semantics, decoding, conversion registration, and hardware cosimulation coverage for `URHADD`, `UADALP`, `ADDV`, `SMAX`, `UMAX`, and `SHRN2`. These instructions provide lane-wise arithmetic, reductions, and high-half narrowing:

  - `URHADD` computes the rounded unsigned average of corresponding source lanes.
  - `SMAX` and `UMAX` select the larger value in each lane using signed or unsigned comparison.
  - `UADALP` zero-extends and adds adjacent unsigned source lanes, then accumulates each sum into a double-width destination lane.
  - `ADDV` sums all source lanes into a scalar result at the original element width.
  - `SHRN2` shifts wide source lanes right, narrows them, and writes the results to the high destination half while preserving the low half.

  These instructions are needed by the x265 AArch64 NEON proof work.

  ### Implementation

  The new decoder clauses support 8-, 16-, and 32-bit elements in the architecturally valid 64- and 128-bit arrangements and reject reserved or unallocated size encodings. `ADDV` reduces the sum modulo the scalar element width, and 64-bit vector forms clear the unused high half.

  `SHRN2` extends the existing `SHRN` decoder clause for `Q = 1`. The `immh = 0` modified-immediate encodings remain unchanged. The new semantics are registered as expanded SIMD rules, and broad simulator masks exercise both valid and reserved encodings.

  ### Validation

  - Assembled all 85 legal instruction, form, size, and shift combinations with LLVM 11, checked their opcode fields, and confirmed that 12 representative reserved forms are rejected.
  - Fresh HOL checks decoded all 85 legal forms, preserved all 56 existing `SHRN` forms, and confirmed that 12 reserved encodings decode to `NONE`. Two modified-immediate regressions and six arithmetic boundary checks also passed with `axioms() = 3`.
  - Confirmed that the five new decoder clauses and nine simulator masks do not overlap existing instruction classes.
  - Full 64-worker AArch64 `make -C arm sematest` passed 366,255 cases with zero failures, including 10,475 valid new-form executions across all 85 legal combinations and 3,633 expected reserved-size rejections.