### PR TITLE
Arm: Model XTN2, three-register TBL, 64-bit EXT, and DUP (element)

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -1092,12 +1092,13 @@ let decode = new_definition `!w:int32. decode w =
       let esize: (64)word = word_shl (word 8: (64)word) (val size) in
       SOME (arm_UZP2 (QREG' Rd) (QREG' Rn) (QREG' Rm) (val esize))
 
-  | [0:1; 0:1; 0b001110:6; size:2; 0b100001001010:12; Rn:5; Rd:5] ->
-    // XTN
+  | [0:1; q; 0b001110:6; size:2; 0b100001001010:12; Rn:5; Rd:5] ->
+    // XTN (q=0, low half) / XTN2 (q=1, high half)
     if size = (word 0b11: (2)word) then NONE // "UNDEFINED"
     else
       let esize: (64)word = word_shl (word 8: (64)word) (val size) in
-      SOME (arm_XTN (QREG' Rd) (QREG' Rn) (val esize))
+      if q then SOME (arm_XTN2 (QREG' Rd) (QREG' Rn) (val esize))
+      else SOME (arm_XTN (QREG' Rd) (QREG' Rn) (val esize))
 
   | [0:1; q; 0b001110:6; size:2; 0:1; Rm:5; 0:1; op; 0b1110:4; Rn:5; Rd:5] ->
     // ZIP1 (op = 0) and ZIP2 (op = 1)

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -544,13 +544,16 @@ let decode = new_definition `!w:int32. decode w =
     SOME (arm_DUP_GEN (QREG' Rd) (XREG' Rn) esize datasize)
 
   | [0:1; q; 0b101110000:9; Rm:5; 0:1; imm4:4; 0:1; Rn:5; Rd:5] ->
-    // EXT
+    // EXT (q=1, 128-bit Q-form; q=0, 64-bit D-form)
     if ~q /\ bit 3 imm4 then NONE // "UNDEFINED"
     else if q then
       let pos = (val imm4) * 8 in
       // datasize is fixed to 128.
       SOME (arm_EXT (QREG' Rd) (QREG' Rn) (QREG' Rm) pos)
-    else NONE
+    else
+      let pos = (val imm4) * 8 in
+      // datasize is 64; DREG' reads/writes the low 64 bits (zeroing the top).
+      SOME (arm_EXT (DREG' Rd) (DREG' Rn) (DREG' Rm) pos)
 
   | [0:1; q; 1:1; 0b011110:6; immh:4; abc:3; cmode:4; 0b01:2; defgh:5; Rd:5] ->
     // MOVI (op=1), USHR (Vector), USRA (Vector), SLI (Vector), SRI (vector)

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -1123,6 +1123,14 @@ let decode = new_definition `!w:int32. decode w =
                   (QREG' (word_add Rn (word 1:(5)word)))
                   (QREG' Rm) datasize)
 
+  | [0:1; q; 0b001110000:9; Rm:5; 0b010000:6; Rn:5; Rd:5] ->
+    // TBL (3-register table, len = 2)
+    let datasize = if q then 128 else 64 in
+    SOME(arm_TBL3 (QREG' Rd) (QREG' Rn)
+                  (QREG' (word_add Rn (word 1:(5)word)))
+                  (QREG' (word_add Rn (word 2:(5)word)))
+                  (QREG' Rm) datasize)
+
   | [0b11001110000:11; Rm:5; 0:1; Ra:5; Rn:5; Rd:5] ->
     // EOR3
     SOME (arm_EOR3 (QREG' Rd) (QREG' Rn) (QREG' Rm) (QREG' Ra))

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -543,6 +543,16 @@ let decode = new_definition `!w:int32. decode w =
     let datasize = if q then 128 else 64 in
     SOME (arm_DUP_GEN (QREG' Rd) (XREG' Rn) esize datasize)
 
+  | [0:1; q; 0b001110000:9; imm5:5; 0b000001:6; Rn:5; Rd:5] ->
+    // DUP (element): broadcast Vn.<T>[index] across Vd
+    let size = word_ctz imm5 in
+    if size > 3 then NONE else
+    if size = 3 /\ ~q then NONE else
+    let esize = 8 * 2 EXP size in
+    let idx = (val imm5) DIV (2 EXP (size + 1)) in
+    let datasize = if q then 128 else 64 in
+    SOME (arm_DUP_ELEM (QREG' Rd) (QREG' Rn) idx esize datasize)
+
   | [0:1; q; 0b101110000:9; Rm:5; 0:1; imm4:4; 0:1; Rn:5; Rd:5] ->
     // EXT (q=1, 128-bit Q-form; q=0, 64-bit D-form)
     if ~q /\ bit 3 imm4 then NONE // "UNDEFINED"

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2518,6 +2518,24 @@ let arm_TBL2 = define
              usimd8 (\x. word_subword table (8 * val x,8):byte) (word_zx m:int64) in
           (Rd := word_zx d:(128)word) s`;;
 
+(*** TBL (3-register table, len = 2): the lookup table is the concatenation    ***)
+(*** of three consecutive 128-bit registers (48 bytes); indices >= 48 read 0.  ***)
+let arm_TBL3 = define
+ `arm_TBL3 Rd Rn1 Rn2 Rn3 Rm datasize =
+    \s:armstate.
+        let n1:int128 = read Rn1 s in
+        let n2:int128 = read Rn2 s in
+        let n3:int128 = read Rn3 s in
+        let table:(384)word = word_join n3 (word_join n2 n1:(256)word) in
+        let m = read Rm s in
+        if datasize = 128 then
+          let d = usimd16 (\x. word_subword table (8 * val x,8):byte) m in
+          (Rd := d) s
+        else
+          let d =
+             usimd8 (\x. word_subword table (8 * val x,8):byte) (word_zx m:int64) in
+          (Rd := word_zx d:(128)word) s`;;
+
 (* ------------------------------------------------------------------------- *)
 (* Load and store instructions.                                              *)
 (* ------------------------------------------------------------------------- *)
@@ -3465,6 +3483,7 @@ let arm_SRI_VEC_ALT =    EXPAND_SIMD_RULE arm_SRI_VEC;;
 let arm_SUB_VEC_ALT =    EXPAND_SIMD_RULE arm_SUB_VEC;;
 let arm_TBL_ALT =        EXPAND_SIMD_RULE arm_TBL;;
 let arm_TBL2_ALT =       EXPAND_SIMD_RULE arm_TBL2;;
+let arm_TBL3_ALT =       EXPAND_SIMD_RULE arm_TBL3;;
 let arm_TRN1_ALT =       EXPAND_SIMD_RULE arm_TRN1;;
 let arm_TRN2_ALT =       EXPAND_SIMD_RULE arm_TRN2;;
 let arm_UADDLP_ALT =     EXPAND_SIMD_RULE arm_UADDLP;;
@@ -3603,7 +3622,7 @@ let ARM_OPERATION_CLAUSES =
        arm_SQDMULH_VEC_ALT;
        arm_SQRDMULH_VEC_ALT;
        arm_SUB; arm_SUB_VEC_ALT; arm_SUBS_ALT;
-       arm_TBL_ALT; arm_TBL2_ALT;
+       arm_TBL_ALT; arm_TBL2_ALT; arm_TBL3_ALT;
        arm_TRN1_ALT; arm_TRN2_ALT;
        arm_UADDLP_ALT; arm_UADDLV_ALT; arm_UMAXV_ALT; arm_UBFM; arm_UMOV; arm_UMADDL;
        arm_UMLAL_VEC_ALT; arm_UMLAL2_VEC_ALT;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2324,6 +2324,22 @@ let arm_XTN = define
           let nlow:(64)word = usimd8 (\x. word_subword x (0,8): (8)word) n in
           (Rd := (word_zx nlow:(128)word)) s`;;
 
+(*** XTN2: same extract-narrow as XTN but the narrowed lanes are written into  ***)
+(*** the HIGH 64 bits of Vd, preserving its low 64 bits (Q=1 form).            ***)
+(*** esize is Rd's (destination, narrow) element size.                         ***)
+let arm_XTN2 = define
+ `arm_XTN2 Rd Rn esize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        let d:(128)word = read Rd s in
+        let res:(64)word =
+          if esize = 32 then
+            usimd2 (\x. word_subword x (0,32): (32)word) n
+          else if esize = 16 then
+            usimd4 (\x. word_subword x (0,16): (16)word) n
+          else // esize=8
+            usimd8 (\x. word_subword x (0,8): (8)word) n in
+        (Rd := word_join res (word_subword d (0,64):(64)word):(128)word) s`;;
+
 
 let word_split_lohi = new_definition
  `(word_split_lohi:(N tybit0)word->((N)word # (N)word)) x =
@@ -3470,6 +3486,7 @@ let arm_USRA_VEC_ALT =   EXPAND_SIMD_RULE arm_USRA_VEC;;
 let arm_UZP1_ALT =       EXPAND_SIMD_RULE arm_UZP1;;
 let arm_UZP2_ALT =       EXPAND_SIMD_RULE arm_UZP2;;
 let arm_XTN_ALT =        EXPAND_SIMD_RULE arm_XTN;;
+let arm_XTN2_ALT =       EXPAND_SIMD_RULE arm_XTN2;;
 let arm_ZIP1_ALT =       EXPAND_SIMD_RULE arm_ZIP1;;
 let arm_ZIP2_ALT =       EXPAND_SIMD_RULE arm_ZIP2;;
 let arm_LD2_ALT =        EXPAND_SIMD_RULE arm_LD2;;
@@ -3599,7 +3616,7 @@ let ARM_OPERATION_CLAUSES =
        arm_USHLL_VEC_ALT; arm_USHLL2_VEC_ALT;
        arm_USHR_VEC_ALT; arm_USRA_VEC_ALT; arm_UZP1_ALT;
        arm_UZP2_ALT;
-       arm_XAR; arm_XTN_ALT;
+       arm_XAR; arm_XTN_ALT; arm_XTN2_ALT;
        arm_ZIP1_ALT; arm_ZIP2_ALT;
     (*** 32-bit backups since the ALT forms are 64-bit only ***)
        INST_TYPE[`:32`,`:N`] arm_ADCS;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -1216,6 +1216,26 @@ let arm_DUP_GEN = define
             else word_duplicate (word_zx n:8 word) in
           (Rd := word_zx d:(128)word) s`;;
 
+(*** DUP (element): broadcast a single esize-bit lane (index idx) of Vn        ***)
+(*** across the destination.  esize is the element size; idx is the source     ***)
+(*** lane index.  datasize is 64 or 128.                                       ***)
+let arm_DUP_ELEM = define
+ `arm_DUP_ELEM Rd Rn idx esize datasize =
+    \s. let n:(128)word = read Rn (s:armstate) in
+        if datasize = 128 then
+          let d:(128)word =
+            if esize = 64 then word_duplicate (word_subword n (64*idx,64):64 word)
+            else if esize = 32 then word_duplicate (word_subword n (32*idx,32):32 word)
+            else if esize = 16 then word_duplicate (word_subword n (16*idx,16):16 word)
+            else word_duplicate (word_subword n (8*idx,8):8 word) in
+          (Rd := d) s
+        else
+          let d:64 word =
+            if esize = 32 then word_duplicate (word_subword n (32*idx,32):32 word)
+            else if esize = 16 then word_duplicate (word_subword n (16*idx,16):16 word)
+            else word_duplicate (word_subword n (8*idx,8):8 word) in
+          (Rd := word_zx d:(128)word) s`;;
+
 let arm_EON = define
  `arm_EON Rd Rm Rn =
     \s. let m = read Rm s
@@ -3460,6 +3480,7 @@ let arm_CMGT_VEC_ALT =   EXPAND_SIMD_RULE arm_CMGT_VEC;;
 let arm_CMHI_VEC_ALT =   EXPAND_SIMD_RULE arm_CMHI_VEC;;
 let arm_CMLE_VEC_ZERO_ALT = EXPAND_SIMD_RULE arm_CMLE_VEC_ZERO;;
 let arm_CNT_ALT =        EXPAND_SIMD_RULE arm_CNT;;
+let arm_DUP_ELEM_ALT =   EXPAND_SIMD_RULE arm_DUP_ELEM;;
 let arm_DUP_GEN_ALT =    EXPAND_SIMD_RULE arm_DUP_GEN;;
 let arm_MLS_VEC_ALT =    EXPAND_SIMD_RULE arm_MLS_VEC;;
 let arm_MLA_VEC_ALT =    EXPAND_SIMD_RULE arm_MLA_VEC;;
@@ -3596,7 +3617,7 @@ let ARM_OPERATION_CLAUSES =
        arm_CBNZ_ALT; arm_CBZ_ALT; arm_CCMN; arm_CCMP; arm_CLZ;
        arm_CMGE_VEC_ALT; arm_CMGT_VEC_ALT; arm_CMHI_VEC_ALT; arm_CMLE_VEC_ZERO_ALT; arm_CNT_ALT;
        arm_CSEL; arm_CSINC; arm_CSINV; arm_CSNEG;
-       arm_DUP_GEN_ALT;
+       arm_DUP_ELEM_ALT; arm_DUP_GEN_ALT;
        arm_EON; arm_EOR; arm_EOR_VEC; arm_EOR3; arm_EXT; arm_EXTR;
        arm_FCSEL; arm_FMOV_FtoI; arm_FMOV_ItoF; arm_INS; arm_INS_GEN;
        arm_LSL; arm_LSLV; arm_LSR; arm_LSRV;

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -352,6 +352,9 @@ let iclasses =
   (*** TBL2 ***)
   "0x001110000xxxxx001000xxxxxxxxxx";
 
+  (*** TBL3 (3-register table, len = 2) ***)
+  "0x001110000xxxxx010000xxxxxxxxxx";
+
   (*** TRN1 and TRN2 ***)
   "0x001110xx0xxxxx0x1010xxxxxxxxxx";
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -153,7 +153,8 @@ let iclasses =
   "0x101110001xxxxx000111xxxxxxxxxx";
 
   (*** EXT ***)
-  "01101110000xxxxx0xxxx0xxxxxxxxxx"; (* 128 bits only *)
+  "01101110000xxxxx0xxxx0xxxxxxxxxx"; (* q=1, 128 bits *)
+  "00101110000xxxxx0xxxx0xxxxxxxxxx"; (* q=0, 64 bits or UNDEFINED *)
 
   (*** FCSEL, 32 and 64 bits ***)
   "00011110001xxxxxxxxx11xxxxxxxxxx";

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -427,8 +427,11 @@ let iclasses =
   (*** UZP2 ***)
   "01001110xx0xxxxx010110xxxxxxxxxx";
 
-  (*** XTN ***)
+  (*** XTN (q=0, low half) ***)
   "00001110xx100001001010xxxxxxxxxx";
+
+  (*** XTN2 (q=1, high half) ***)
+  "01001110xx100001001010xxxxxxxxxx";
 
   (*** ZIP1 ***)
   "0x001110xx0xxxxx001110xxxxxxxxxx";

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -145,9 +145,12 @@ let iclasses =
   "0x00111000100000010110xxxxxxxxxx";
   "0x001110xx100000010110xxxxxxxxxx";
 
-  (*** DUP ***)
+  (*** DUP (general, from Xn) ***)
   "01001110000x1000000011xxxxxxxxxx"; (* original DUP Vd.2d, xn *)
   "0x001110000xxxxx000011xxxxxxxxxx"; (* other variants too     *)
+
+  (*** DUP (element): broadcast Vn.<T>[index] across Vd ***)
+  "0x001110000xxxxx000001xxxxxxxxxx";
 
   (*** EOR ***)
   "0x101110001xxxxx000111xxxxxxxxxx";


### PR DESCRIPTION
Adds semantics, decoding, conversion registration, and hardware cosimulation coverage for `XTN2`, three-register `TBL`, 64-bit `EXT`, and `DUP` (element).

`XTN2` narrows each source lane and writes the results into the high half of the destination while preserving its low half. Three-register `TBL` looks up bytes in a 48-byte table formed from three consecutive vector registers. The 64-bit `EXT` form extracts an eight-byte window from two concatenated source registers, and `DUP` (element) broadcasts one source lane across the destination.

These forms are needed by x265 AArch64 NEON proof work.

  ### Implementation

`XTN2` extends the existing `XTN` decoder, with `Q` selecting the base or high-half form. Three-register `TBL` models register-list wraparound modulo 32 and returns zero for indices outside its 48-byte table. The 64-bit `EXT` form reuses `arm_EXT` through `DREG'` views and rejects `imm4[3] = 1`.

`DUP` (element) derives the element size from the least significant set bit of `imm5` and the source lane index from the remaining bits. It supports legal 64- and 128-bit destinations and rejects reserved immediate combinations.

  ### Validation

  - Checked all 71 new legal forms and 19 existing `XTN`/`EXT` forms against LLVM, and confirmed that LLVM rejects 15 reserved encodings.
  - Fresh HOL checks decoded all 71 new forms, preserved the 19 existing forms, proved the 15 reserved encodings decode to `NONE`, and checked 12 semantic boundaries with `axioms() = 3`.
  - Confirmed that the changed decoder clauses and five simulator masks do not overlap existing decoder clauses or simulator classes.
  - Full 64-worker AArch64 `make -C arm sematest` passed 366,749 cases with zero failures, including 5,147 valid executions covering all 71 new forms and 1,385 reserved-encoding rejections. Three-register `TBL` exercised all 32 table-start registers, including 116 wraparound
  executions.