### PR TITLE
Arm: Add four-register LD1 and ST1

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -91,6 +91,18 @@ let arm_ldstp_q = new_definition `arm_ldstp_q ld Rt Rt2 =
 let arm_ldstp_2q = new_definition `arm_ldstp_2q ld Rt =
   let Rtt:(5 word) = word ((val Rt + 1) MOD 32) in
   (if ld then arm_LDP else arm_STP) (QREG' Rt) (QREG' Rtt)`;;
+let arm_ldstp_4q = new_definition `arm_ldstp_4q ld Rt =
+  let Rt2:(5 word) = word ((val Rt + 1) MOD 32) in
+  let Rt3:(5 word) = word ((val Rt + 2) MOD 32) in
+  let Rt4:(5 word) = word ((val Rt + 3) MOD 32) in
+  (if ld then arm_LDP4 else arm_STP4)
+    (QREG' Rt) (QREG' Rt2) (QREG' Rt3) (QREG' Rt4)`;;
+let arm_ldstp_4d = new_definition `arm_ldstp_4d ld Rt =
+  let Rt2:(5 word) = word ((val Rt + 1) MOD 32) in
+  let Rt3:(5 word) = word ((val Rt + 2) MOD 32) in
+  let Rt4:(5 word) = word ((val Rt + 3) MOD 32) in
+  (if ld then arm_LDP4 else arm_STP4)
+    (DREG' Rt) (DREG' Rt2) (DREG' Rt3) (DREG' Rt4)`;;
 let arm_ldst2 = new_definition `arm_ldst2 ld Rt =
   let Rtt:(5 word) = word ((val Rt + 1) MOD 32) in
   (if ld then arm_LD2 else arm_ST2) (QREG' Rt) (QREG' Rtt)`;;
@@ -418,6 +430,31 @@ let decode = new_definition `!w:int32. decode w =
   //   No offset, datasize = 128
   | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b1010:4; size:2; Rn:5; Rt:5] ->
     SOME (arm_ldstp_2q is_ld Rt (XREG_SP Rn) No_Offset)
+
+  // LD1/ST1 (multiple structures), 4 registers,
+  //   Post-immediate offset and post-register offset, and no offset.
+  // Similar to LDP/STP of SIMD registers, but for four consecutive registers,
+  // assuming little-endian architecture (see the 1-register note above).
+
+  // datasize = 128
+  //   Post-immediate offset (Rm = 31) and post-register offset
+  | [0:1; 1:1; 0b0011001:7; is_ld; 0:1; Rm:5; 0b0010:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_4q is_ld Rt (XREG_SP Rn)
+      (if val Rm = 31 then (Postimmediate_Offset (word 64))
+                      else Postreg_Offset (XREG' Rm)))
+  //   No offset, datasize = 128
+  | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b0010:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_4q is_ld Rt (XREG_SP Rn) No_Offset)
+
+  // datasize = 64
+  //   Post-immediate offset (Rm = 31) and post-register offset
+  | [0:1; 0:1; 0b0011001:7; is_ld; 0:1; Rm:5; 0b0010:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_4d is_ld Rt (XREG_SP Rn)
+      (if val Rm = 31 then (Postimmediate_Offset (word 32))
+                      else Postreg_Offset (XREG' Rm)))
+  //   No offset, datasize = 64
+  | [0:1; 0:1; 0b0011000:7; is_ld; 0b000000:6; 0b0010:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_4d is_ld Rt (XREG_SP Rn) No_Offset)
 
   // LD2/ST2 (multiple structures), 2 registers, immediate offset, Post-immediate offset
   // datasize = 64
@@ -1467,7 +1504,7 @@ let PURE_DECODE_CONV =
     add_thms [arm_adcop; arm_addop; arm_adv_simd_expand_imm;
               arm_bfmop; arm_ccop; arm_csop;
               arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
-              arm_ldst2; arm_ldstp_2q; arm_ldst3] rw;
+              arm_ldst2; arm_ldstp_2q; arm_ldstp_4q; arm_ldstp_4d; arm_ldst3] rw;
     (* .. that have bitmatch exprs inside *)
     List.iter (fun def_th ->
         let Some (conceal_th, opaque_const, opaque_arity, opaque_def, opaque_conv) =

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2620,6 +2620,60 @@ let arm_STP = define
             else (=))
          else ASSIGNS entirety) s`;;
 
+(* Four-register contiguous load/store for little-endian LD1/ST1. *)
+
+let arm_LDP4 = define
+ `arm_LDP4 (Rt1:(armstate,N word)component)
+           (Rt2:(armstate,N word)component)
+           (Rt3:(armstate,N word)component)
+           (Rt4:(armstate,N word)component) Rn off =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            orthogonal_components Rt1 Rt2 /\
+            orthogonal_components Rt1 Rt3 /\
+            orthogonal_components Rt1 Rt4 /\
+            orthogonal_components Rt2 Rt3 /\
+            orthogonal_components Rt2 Rt4 /\
+            orthogonal_components Rt3 Rt4 /\
+            (offset_writesback off
+             ==> orthogonal_components Rt1 Rn /\ orthogonal_components Rt2 Rn /\
+                 orthogonal_components Rt3 Rn /\ orthogonal_components Rt4 Rn)
+         then
+           let w = dimindex(:N) DIV 8 in
+           Rt1 := read (memory :> wbytes addr) s ,,
+           Rt2 := read (memory :> wbytes(word_add addr (word w))) s ,,
+           Rt3 := read (memory :> wbytes(word_add addr (word(2 * w)))) s ,,
+           Rt4 := read (memory :> wbytes(word_add addr (word(3 * w)))) s ,,
+           events := CONS (EventLoad (addr,4 * w)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
+let arm_STP4 = define
+ `arm_STP4 (Rt1:(armstate,N word)component)
+           (Rt2:(armstate,N word)component)
+           (Rt3:(armstate,N word)component)
+           (Rt4:(armstate,N word)component) Rn off =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            (offset_writesback off
+             ==> orthogonal_components Rt1 Rn /\ orthogonal_components Rt2 Rn /\
+                 orthogonal_components Rt3 Rn /\ orthogonal_components Rt4 Rn)
+         then
+           let w = dimindex(:N) DIV 8 in
+           memory :> wbytes addr := read Rt1 s ,,
+           memory :> wbytes(word_add addr (word w)) := read Rt2 s ,,
+           memory :> wbytes(word_add addr (word(2 * w))) := read Rt3 s ,,
+           memory :> wbytes(word_add addr (word(3 * w))) := read Rt4 s ,,
+           events := CONS (EventStore (addr,4 * w)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
 (* There is a bit of duplication in the following defintions.
   We have to do this because one step in symbolic execution
   doesn't handle let binding of pairs. *)
@@ -3625,4 +3679,5 @@ let ARM_OPERATION_CLAUSES =
 let ARM_LOAD_STORE_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)
       [arm_LDR; arm_STR; arm_LDRB; arm_STRB; arm_LDP; arm_STP;
+       arm_LDP4; arm_STP4;
        arm_LD2_ALT; arm_ST2_ALT; arm_LD1R; arm_LD3_ALT; arm_ST3_ALT];;

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -571,10 +571,53 @@ let cosimulate_ldst3() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LD1/ST1 (multiple structures), 4 registers, for datasizes
+ *** 64 and 128, addressing modes no-offset, post-immediate and post-register.
+ *** The four consecutive registers span 32 bytes (datasize 64) or 64 bytes
+ *** (datasize 128); the post-immediate writeback is exactly that span.
+ ***)
+
+let cosimulate_ldst1_4reg() =
+  let datasize = Random.int 2
+  and isld = Random.int 2
+  and esize = Random.int 4
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  let someoffset = Random.int 2 in
+  let regoffr = Random.int 32 in
+  (* No-offset form has Rm = 0 and bit23 = 0; the post forms set bit23 = 1,
+     with Rm = 31 selecting post-immediate and Rm = Xm post-register. As in
+     cosimulate_ldst3, avoid a base of SP or Rm aliasing the base for the
+     post-register form. *)
+  let regoff =
+    if someoffset = 0 then 0
+    else if regoffr = rn || rn = 31 || Random.bool() then 31
+    else regoffr in
+  let stackoff =
+    if rn = 31 then Random.int 12 * 16
+    else Random.int 192 in
+  (* Four 8- or 16-byte registers span 32 or 64 bytes. The post-immediate
+     form (Rm = 31) writes the base back by that span. *)
+  let postinc = if someoffset = 1 && regoff = 31 then 32 * (datasize + 1) else 0 in
+  let code =
+    pow2 30 */ num datasize +/
+    pow2 24 */ num 0b001100 +/
+    pow2 23 */ num someoffset +/
+    pow2 22 */ num isld +/
+    pow2 16 */ num regoff +/
+    pow2 12 */ num 0b0010 +/
+    pow2 10 */ num esize +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 (stackoff + postinc)]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
-    cosimulate_ldst3; cosimulate_ldstu
+    cosimulate_ldst3; cosimulate_ldstu; cosimulate_ldst1_4reg
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -556,6 +556,30 @@ let check_insns () =
     (*** st1 (2 registers, Post-immediate offset) 128-bit ***)
     "01001100100111111010xxxxxxxxxxxx";
 
+    (*** ld1 (4 registers, Post-immediate and register offset) 128-bit ***)
+    "01001100110xxxxx0010xxxxxxxxxxxx";
+
+    (*** st1 (4 registers, Post-immediate and register offset) 128-bit ***)
+    "01001100100xxxxx0010xxxxxxxxxxxx";
+
+    (*** ld1 (4 registers, no offset) 128-bit ***)
+    "01001100010000000010xxxxxxxxxxxx";
+
+    (*** st1 (4 registers, no offset) 128-bit ***)
+    "01001100000000000010xxxxxxxxxxxx";
+
+    (*** ld1 (4 registers, Post-immediate and register offset) 64-bit ***)
+    "00001100110xxxxx0010xxxxxxxxxxxx";
+
+    (*** st1 (4 registers, Post-immediate and register offset) 64-bit ***)
+    "00001100100xxxxx0010xxxxxxxxxxxx";
+
+    (*** ld1 (4 registers, no offset) 64-bit ***)
+    "00001100010000000010xxxxxxxxxxxx";
+
+    (*** st1 (4 registers, no offset) 64-bit ***)
+    "00001100000000000010xxxxxxxxxxxx";
+
     (*** ld2 (2 register, Post-immediate offset) ***)
     "0x001100110111111000xxxxxxxxxxxx";
 


### PR DESCRIPTION
Adds semantics, decoding, conversion registration, and hardware cosimulation coverage for the four-register `LD1` and `ST1` multiple-structure forms.

`LD1` loads four consecutive SIMD registers from contiguous memory, while `ST1` stores them. The 64-bit `D` forms transfer 32 bytes and the 128-bit `Q` forms transfer 64 bytes. These forms are needed by the x265 AArch64 proof work.

### Implementation

The decoder supports all four element-size fields with no offset, post-immediate writeback (`#32` for `D` and `#64` for `Q`), and post-register writeback. Register lists wrap modulo 32, so a list beginning at `V29` continues through `V0`.

`arm_LDP4` and `arm_STP4` model the operation as four contiguous little-endian loads or stores and record the complete 32- or 64-byte `EventLoad` or `EventStore` span. A bounded memory generator exercises every addressing mode safely against hardware.

### Validation

  - Checked all 48 load/store, register-width, addressing-mode, and size-field combinations against LLVM using wrapped register lists and SP bases; LLVM rejected two incorrect post-immediate amounts.
  - Fresh HOL checks decoded the same 48 representatives, preserved ten nearby load/store decodes, exercised both load/store clauses, confirmed the 32- and 64-byte event spans, and reported `axioms() = 3`.
  - Confirmed that the four decoder clauses and eight simulator masks do not overlap existing instruction classes and that every legal combination maps to exactly one decoder and simulator class.
  - Full four-worker native AArch64 `make -C arm sematest` passed 12,067 register and 1,343 memory cases (13,410 total) with zero failures. It directly executed 149 new forms and sampled 44 of the 48 field combinations; the exhaustive LLVM and HOL checks cover all 48.

