### PR TITLE
Arm: Model SIMD LD1/ST1, LD2/ST2, LDR/STR, and LDUR/STUR forms

### DIFF
--- a/arm/proofs/arm.ml
+++ b/arm/proofs/arm.ml
@@ -251,6 +251,36 @@ let DREG_EXPAND_CLAUSES = prove
    D31 = Q31 :> zerotop_64`,
   REWRITE_TAC(!component_alias_thms));;
 
+(* Expand the scalar SIMD&FP sub-registers (S/H/B) down to the full Q register
+   (using the Qn aliases, so the result matches the Q-register state exposed by
+   the cosimulator's regfile) composed with the appropriate zerotop chain.  This
+   lets reads/writes of the S/H/B components reduce against the Q-register state
+   in the same way the existing WREG/DREG expand clauses do.  The decoder
+   produces SREG n / HREG n / BREG n with a concrete index n, so we enumerate
+   the 32 registers; the Qn alias on the RHS is what the input/regfile rewrite
+   knows about. *)
+
+let SREG_EXPAND_CLAUSES = prove
+ (list_mk_conj (map (fun i ->
+    let s = string_of_int i in
+    parse_term("SREG "^s^" = (Q"^s^" :> zerotop_64) :> zerotop_32")) (0--31)),
+  REWRITE_TAC[SREG; DREG] THEN REWRITE_TAC(!component_alias_thms));;
+
+let HREG_EXPAND_CLAUSES = prove
+ (list_mk_conj (map (fun i ->
+    let s = string_of_int i in
+    parse_term("HREG "^s^" = ((Q"^s^" :> zerotop_64) :> zerotop_32) :> zerotop_16"))
+    (0--31)),
+  REWRITE_TAC[HREG; SREG; DREG] THEN REWRITE_TAC(!component_alias_thms));;
+
+let BREG_EXPAND_CLAUSES = prove
+ (list_mk_conj (map (fun i ->
+    let s = string_of_int i in
+    parse_term("BREG "^s^
+      " = (((Q"^s^" :> zerotop_64) :> zerotop_32) :> zerotop_16) :> zerotop_8"))
+    (0--31)),
+  REWRITE_TAC[BREG; HREG; SREG; DREG] THEN REWRITE_TAC(!component_alias_thms));;
+
 let READ_SHIFTEDREG_CLAUSES = prove
  (`read (Shiftedreg Rn LSL n) s = word_shl (read Rn s) n /\
    read (Shiftedreg Rn LSR n) s = word_ushr (read Rn s) n /\
@@ -303,11 +333,15 @@ let ARM_EXEC_CONV =
     GEN_REWRITE_CONV ONCE_DEPTH_CONV [CONJUNCT2 SEQ_ID]) ORELSEC
    (GEN_REWRITE_CONV I ARM_OPERATION_CLAUSES THENC
     REWRITE_CONV [condition_semantics])) THENC
-  REWRITE_CONV[WREG_EXPAND_CLAUSES; DREG_EXPAND_CLAUSES] THENC
+  REWRITE_CONV[WREG_EXPAND_CLAUSES; DREG_EXPAND_CLAUSES;
+               SREG_EXPAND_CLAUSES; HREG_EXPAND_CLAUSES; BREG_EXPAND_CLAUSES] THENC
   REWRITE_CONV[READ_RVALUE; ARM_ZERO_REGISTER;
                ASSIGN_ZEROTOP_32; ASSIGN_ZEROTOP_64;
+               ASSIGN_ZEROTOP_16; ASSIGN_ZEROTOP_8;
                READ_ZEROTOP_32; WRITE_ZEROTOP_32;
                READ_ZEROTOP_64; WRITE_ZEROTOP_64;
+               READ_ZEROTOP_16; WRITE_ZEROTOP_16;
+               READ_ZEROTOP_8; WRITE_ZEROTOP_8;
                READ_SHIFTEDREG_CLAUSES; READ_EXTENDEDREG_CLAUSES;
                READ_LANE_CLAUSES] THENC
   DEPTH_CONV(WORD_NUM_RED_CONV ORELSEC WORD_WORD_OPERATION_CONV);;

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -397,6 +397,12 @@ let decode = new_definition `!w:int32. decode w =
   | [0b00:2; 0b1111001:7; is_ld; 0:1; imm9:9; 0b00:2; Rn:5; Rt:5] ->
     SOME (arm_ldst_q is_ld Rt (XREG_SP Rn) (Immediate_Offset (word_sx imm9)))
 
+  // LDUR/STUR (SIMD&FP), unscaled immediate, sizes 64 (D) and 32 (S)
+  | [0b11:2; 0b1111000:7; is_ld; 0:1; imm9:9; 0b00:2; Rn:5; Rt:5] ->
+    SOME (arm_ldst_d is_ld Rt (XREG_SP Rn) (Immediate_Offset (word_sx imm9)))
+  | [0b10:2; 0b1111000:7; is_ld; 0:1; imm9:9; 0b00:2; Rn:5; Rt:5] ->
+    SOME (arm_ldst_s is_ld Rt (XREG_SP Rn) (Immediate_Offset (word_sx imm9)))
+
   // LDUR/STUR, only sizes 64 and 32
   | [0b1:1; x; 0b1110000:7; is_ld; 0:1; imm9:9; 0b00:2; Rn:5; Rt:5] ->
     SOME (arm_ldst is_ld x Rt (XREG_SP Rn) (Immediate_Offset (word_sx imm9)))

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -91,6 +91,16 @@ let arm_ldstp_q = new_definition `arm_ldstp_q ld Rt Rt2 =
 let arm_ldstp_2q = new_definition `arm_ldstp_2q ld Rt =
   let Rtt:(5 word) = word ((val Rt + 1) MOD 32) in
   (if ld then arm_LDP else arm_STP) (QREG' Rt) (QREG' Rtt)`;;
+let arm_ldstp_3q = new_definition `arm_ldstp_3q ld Rt =
+  let Rt2:(5 word) = word ((val Rt + 1) MOD 32) in
+  let Rt3:(5 word) = word ((val Rt + 2) MOD 32) in
+  (if ld then arm_LDP3 else arm_STP3)
+    (QREG' Rt) (QREG' Rt2) (QREG' Rt3)`;;
+let arm_ldstp_3d = new_definition `arm_ldstp_3d ld Rt =
+  let Rt2:(5 word) = word ((val Rt + 1) MOD 32) in
+  let Rt3:(5 word) = word ((val Rt + 2) MOD 32) in
+  (if ld then arm_LDP3 else arm_STP3)
+    (DREG' Rt) (DREG' Rt2) (DREG' Rt3)`;;
 let arm_ldst2 = new_definition `arm_ldst2 ld Rt =
   let Rtt:(5 word) = word ((val Rt + 1) MOD 32) in
   (if ld then arm_LD2 else arm_ST2) (QREG' Rt) (QREG' Rtt)`;;
@@ -418,6 +428,16 @@ let decode = new_definition `!w:int32. decode w =
   //   No offset, datasize = 128
   | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b1010:4; size:2; Rn:5; Rt:5] ->
     SOME (arm_ldstp_2q is_ld Rt (XREG_SP Rn) No_Offset)
+
+  // LD1/ST1 (multiple structures), 3 registers, No offset.
+  // Like LDP/STP but for three consecutive registers (opcode 0110),
+  // assuming little-endian architecture (see the 1-register note above).
+  //   No offset, datasize = 128
+  | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b0110:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_3q is_ld Rt (XREG_SP Rn) No_Offset)
+  //   No offset, datasize = 64
+  | [0:1; 0:1; 0b0011000:7; is_ld; 0b000000:6; 0b0110:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_3d is_ld Rt (XREG_SP Rn) No_Offset)
 
   // LD2/ST2 (multiple structures), 2 registers, immediate offset, Post-immediate offset
   // datasize = 64
@@ -1467,7 +1487,7 @@ let PURE_DECODE_CONV =
     add_thms [arm_adcop; arm_addop; arm_adv_simd_expand_imm;
               arm_bfmop; arm_ccop; arm_csop;
               arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
-              arm_ldst2; arm_ldstp_2q; arm_ldst3] rw;
+              arm_ldst2; arm_ldstp_2q; arm_ldstp_3q; arm_ldstp_3d; arm_ldst3] rw;
     (* .. that have bitmatch exprs inside *)
     List.iter (fun def_th ->
         let Some (conceal_th, opaque_const, opaque_arity, opaque_def, opaque_conv) =

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -101,6 +101,8 @@ let arm_ldstp_3d = new_definition `arm_ldstp_3d ld Rt =
   let Rt3:(5 word) = word ((val Rt + 2) MOD 32) in
   (if ld then arm_LDP3 else arm_STP3)
     (DREG' Rt) (DREG' Rt2) (DREG' Rt3)`;;
+let arm_ldst_lane = new_definition `arm_ldst_lane ld Rt =
+  (if ld then arm_LD1_LANE else arm_ST1_LANE) (QREG' Rt)`;;
 let arm_ldst2 = new_definition `arm_ldst2 ld Rt =
   let Rtt:(5 word) = word ((val Rt + 1) MOD 32) in
   (if ld then arm_LD2 else arm_ST2) (QREG' Rt) (QREG' Rtt)`;;
@@ -462,6 +464,19 @@ let decode = new_definition `!w:int32. decode w =
   | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b1000:4; size:2; Rn:5; Rt:5] ->
     let esize = 8 * 2 EXP (val size) in
     SOME (arm_ldst2 is_ld Rt (XREG_SP Rn) No_Offset 128 esize)
+
+  // LD1/ST1 (single structure, single lane), 32-bit (.s) form.
+  // asisdlso class: opcode = 100, size = 00, lane index = (Q:S).
+  // No offset
+  | [0:1; q; 0b0011010:7; is_ld; 0b000000:6; 0b100:3; sb; 0b00:2; Rn:5; Rt:5] ->
+    SOME (arm_ldst_lane is_ld Rt (XREG_SP Rn) No_Offset 32
+            (2 * (if q then 1 else 0) + (if sb then 1 else 0)))
+  // Post-index: Rm = 11111 -> post-immediate (#4); otherwise post-register (Xm)
+  | [0:1; q; 0b0011011:7; is_ld; 0:1; Rm:5; 0b100:3; sb; 0b00:2; Rn:5; Rt:5] ->
+    SOME (arm_ldst_lane is_ld Rt (XREG_SP Rn)
+            (if val Rm = 31 then (Postimmediate_Offset (word 4))
+                            else Postreg_Offset (XREG' Rm))
+            32 (2 * (if q then 1 else 0) + (if sb then 1 else 0)))
 
   // LD1R, Post-immediate offset, size 64 and 128
   | [0b0:1; q; 0b001101110111111100:18; size:2; Rn:5; Rt:5] ->
@@ -1499,7 +1514,8 @@ let PURE_DECODE_CONV =
     add_thms [arm_adcop; arm_addop; arm_adv_simd_expand_imm;
               arm_bfmop; arm_ccop; arm_csop;
               arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
-              arm_ldst2; arm_ldstp_2q; arm_ldstp_3q; arm_ldstp_3d; arm_ldst3] rw;
+              arm_ldst2; arm_ldstp_2q; arm_ldstp_3q; arm_ldstp_3d;
+              arm_ldst3; arm_ldst_lane] rw;
     (* .. that have bitmatch exprs inside *)
     List.iter (fun def_th ->
         let Some (conceal_th, opaque_const, opaque_arity, opaque_def, opaque_conv) =

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -451,6 +451,18 @@ let decode = new_definition `!w:int32. decode w =
     let esize = 8 * 2 EXP (val size) in
     SOME (arm_ldst2 is_ld Rt (XREG_SP Rn) (Postimmediate_Offset (word 32)) 128 esize)
 
+  // LD2/ST2 (multiple structures), 2 registers, No offset
+  // datasize = 64
+  | [0:1; 0:1; 0b0011000:7; is_ld; 0b000000:6; 0b1000:4; size:2; Rn:5; Rt:5] ->
+    if size = (word 0b11:(2)word) then NONE // "UNDEFINED"
+    else
+      let esize = 8 * 2 EXP (val size) in
+      SOME (arm_ldst2 is_ld Rt (XREG_SP Rn) No_Offset 64 esize)
+  // datasize = 128
+  | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b1000:4; size:2; Rn:5; Rt:5] ->
+    let esize = 8 * 2 EXP (val size) in
+    SOME (arm_ldst2 is_ld Rt (XREG_SP Rn) No_Offset 128 esize)
+
   // LD1R, Post-immediate offset, size 64 and 128
   | [0b0:1; q; 0b001101110111111100:18; size:2; Rn:5; Rt:5] ->
     let esize = 8 * (2 EXP (val size)) in

--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -13,6 +13,9 @@ let XREG' = new_definition `XREG' (n:5 word) = XREG (val n)`;;
 let WREG' = new_definition `WREG' (n:5 word) = WREG (val n)`;;
 let QREG' = new_definition `QREG' (n:5 word) = QREG (val n)`;;
 let DREG' = new_definition `DREG' (n:5 word) = DREG (val n)`;;
+let SREG' = new_definition `SREG' (n:5 word) = SREG (val n)`;;
+let HREG' = new_definition `HREG' (n:5 word) = HREG (val n)`;;
+let BREG' = new_definition `BREG' (n:5 word) = BREG (val n)`;;
 
 let QLANE = define
  `QLANE reg 8 ix = QREG' reg :> LANE_B ix /\
@@ -79,6 +82,12 @@ let arm_ldst_q = new_definition `arm_ldst_q ld Rt =
   (if ld then arm_LDR else arm_STR) (QREG' Rt)`;;
 let arm_ldst_d = new_definition `arm_ldst_d ld Rt =
   (if ld then arm_LDR else arm_STR) (DREG' Rt)`;;
+let arm_ldst_s = new_definition `arm_ldst_s ld Rt =
+  (if ld then arm_LDR else arm_STR) (SREG' Rt)`;;
+let arm_ldst_h = new_definition `arm_ldst_h ld Rt =
+  (if ld then arm_LDR else arm_STR) (HREG' Rt)`;;
+let arm_ldst_bv = new_definition `arm_ldst_bv ld Rt =
+  (if ld then arm_LDR else arm_STR) (BREG' Rt)`;;
 let arm_ldstb = new_definition `arm_ldstb ld Rt =
   (if ld then arm_LDRB else arm_STRB) (WREG' Rt)`;;
 let arm_ldstp = new_definition `arm_ldstp ld x Rt Rt2 =
@@ -332,11 +341,19 @@ let decode = new_definition `!w:int32. decode w =
 
   // SIMD ld,st operations
   // LDR/STR (immediate, SIMD&FP), Unsigned offset, no writeback
-  // Currently only supports sizes 128 and 64 (not 32, 16 or 8)
+  // Sizes 128 and 64; sub-64 (32/16/8) handled by the three clauses below.
   | [0b00:2; 0b111101:6; 0b1:1; is_ld; imm12:12; Rn:5; Rt:5] ->
     SOME (arm_ldst_q is_ld Rt (XREG_SP Rn) (Immediate_Offset (word (val imm12 * 16))))
   | [0b11:2; 0b111101:6; 0b0:1; is_ld; imm12:12; Rn:5; Rt:5] ->
     SOME (arm_ldst_d is_ld Rt (XREG_SP Rn) (Immediate_Offset (word (val imm12 * 8))))
+  // LDR/STR (immediate, SIMD&FP), Unsigned offset, sizes 32/16/8 (S/H/B)
+  // opc = 01 (LDR) or 00 (STR); size = 10 (S), 01 (H), 00 (B); scale = size.
+  | [0b10:2; 0b111101:6; 0b0:1; is_ld; imm12:12; Rn:5; Rt:5] ->
+    SOME (arm_ldst_s is_ld Rt (XREG_SP Rn) (Immediate_Offset (word (val imm12 * 4))))
+  | [0b01:2; 0b111101:6; 0b0:1; is_ld; imm12:12; Rn:5; Rt:5] ->
+    SOME (arm_ldst_h is_ld Rt (XREG_SP Rn) (Immediate_Offset (word (val imm12 * 2))))
+  | [0b00:2; 0b111101:6; 0b0:1; is_ld; imm12:12; Rn:5; Rt:5] ->
+    SOME (arm_ldst_bv is_ld Rt (XREG_SP Rn) (Immediate_Offset (word (val imm12))))
   // Post-immediate offset, sizes 128 and 64
   | [0b00:2; 0b1111001:7; is_ld; 0:1; imm9:9; 0b01:2; Rn:5; Rt:5] ->
     SOME (arm_ldst_q is_ld Rt (XREG_SP Rn) (Postimmediate_Offset (word_sx imm9)))
@@ -1311,6 +1328,12 @@ let REG_CONV =
       TRANS (CONV_RULE (RAND_CONV (RAND_CONV WORD_RED_CONV))
         (SPEC (mk_comb (`word:num->5 word`, mk_numeral (num i))) th'))) A in
     F XREG' xs, F WREG' ws, F QREG' qs,F DREG' ds in
+  (* SREG'/HREG'/BREG' have no named aliases; just reduce to SREG/HREG/BREG n *)
+  let ss',hs',bs' =
+    let G th' = Array.init 32 (fun i ->
+      CONV_RULE (RAND_CONV (RAND_CONV WORD_RED_CONV))
+        (SPEC (mk_comb (`word:num->5 word`, mk_numeral (num i))) th')) in
+    G SREG', G HREG', G BREG' in
   function
   | Comb(Const("XREG",_),n) -> xs.(Num.int_of_num (dest_numeral n))
   | Comb(Const("WREG",_),n) -> ws.(Num.int_of_num (dest_numeral n))
@@ -1322,6 +1345,12 @@ let REG_CONV =
     qs'.(Num.int_of_num (dest_numeral n))
   | Comb(Const("DREG'",_),Comb(Const("word",_),n)) ->
     ds'.(Num.int_of_num (dest_numeral n))
+  | Comb(Const("SREG'",_),Comb(Const("word",_),n)) ->
+    ss'.(Num.int_of_num (dest_numeral n))
+  | Comb(Const("HREG'",_),Comb(Const("word",_),n)) ->
+    hs'.(Num.int_of_num (dest_numeral n))
+  | Comb(Const("BREG'",_),Comb(Const("word",_),n)) ->
+    bs'.(Num.int_of_num (dest_numeral n))
   | Comb(Const("XREG_SP",_),Comb(Const("word",_),n)) ->
     xsp.(Num.int_of_num (dest_numeral n))
   | Comb(Const("WREG_SP",_),Comb(Const("word",_),n)) ->
@@ -1510,10 +1539,11 @@ let PURE_DECODE_CONV =
     add_conv (`_MATCH:A->(A->B->bool)->B`, 2, MATCH_CONV) rw;
 
     (* components and instructions *)
-    List.iter (fun tm -> add_conv (tm, 1, REG_CONV) rw) [`XREG'`; `WREG'`; `QREG'`; `DREG'`; `XREG_SP`; `WREG_SP`];
+    List.iter (fun tm -> add_conv (tm, 1, REG_CONV) rw) [`XREG'`; `WREG'`; `QREG'`; `DREG'`; `SREG'`; `HREG'`; `BREG'`; `XREG_SP`; `WREG_SP`];
     add_thms [arm_adcop; arm_addop; arm_adv_simd_expand_imm;
               arm_bfmop; arm_ccop; arm_csop;
-              arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
+              arm_ldst; arm_ldst_q; arm_ldst_d; arm_ldst_s; arm_ldst_h; arm_ldst_bv;
+              arm_ldstb; arm_ldstp; arm_ldstp_q; arm_ldstp_d;
               arm_ldst2; arm_ldstp_2q; arm_ldstp_3q; arm_ldstp_3d;
               arm_ldst3; arm_ldst_lane] rw;
     (* .. that have bitmatch exprs inside *)

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2910,6 +2910,60 @@ let arm_STP3 = define
             else (=))
          else ASSIGNS entirety) s`;;
 
+(* LD1/ST1 (single structure, single lane). Loads/stores one element of a
+   vector register, leaving the other lanes intact for LD1 (asisdlso class).
+   esize selects the lane width (8/16/32/64), ix the lane index. *)
+
+let arm_LD1_LANE = define
+ `arm_LD1_LANE (Rt:(armstate,(128)word)component) Rn off esize ix =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            (offset_writesback off ==> orthogonal_components Rt Rn)
+         then
+           let old:(128)word = read Rt s in
+           let nu:(128)word =
+             (if esize = 64 then
+                word_insert old (64 * ix,64)
+                  ((read (memory :> wbytes addr) s):(64)word)
+              else if esize = 32 then
+                word_insert old (32 * ix,32)
+                  ((read (memory :> wbytes addr) s):(32)word)
+              else if esize = 16 then
+                word_insert old (16 * ix,16)
+                  ((read (memory :> wbytes addr) s):(16)word)
+              else
+                word_insert old (8 * ix,8)
+                  ((read (memory :> wbytes addr) s):(8)word)) in
+           Rt := nu ,,
+           events := CONS (EventLoad (addr,esize DIV 8)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
+let arm_ST1_LANE = define
+ `arm_ST1_LANE (Rt:(armstate,(128)word)component) Rn off esize ix =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            (offset_writesback off ==> orthogonal_components Rt Rn)
+         then
+           let v:(128)word = read Rt s in
+           (if esize = 64 then
+              memory :> wbytes addr := (word_subword v (64 * ix,64):(64)word)
+            else if esize = 32 then
+              memory :> wbytes addr := (word_subword v (32 * ix,32):(32)word)
+            else if esize = 16 then
+              memory :> wbytes addr := (word_subword v (16 * ix,16):(16)word)
+            else
+              memory :> wbytes addr := (word_subword v (8 * ix,8):(8)word)) ,,
+           events := CONS (EventStore (addr,esize DIV 8)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
 (* ------------------------------------------------------------------------- *)
 (* SHA-related SIMD operations                                               *)
 (* ------------------------------------------------------------------------- *)
@@ -3522,6 +3576,19 @@ let arm_ZIP2_ALT =       EXPAND_SIMD_RULE arm_ZIP2;;
 let arm_LD2_ALT =        EXPAND_SIMD_RULE arm_LD2;;
 let arm_ST2_ALT =        EXPAND_SIMD_RULE arm_ST2;;
 
+(*** Single-lane LD1/ST1: specialise the esize cascade to the 32-bit (.s)
+ *** form actually decoded, leaving the lane index ix symbolic. ***)
+let arm_LD1_LANE_ALT =
+  (CONV_RULE(TOP_DEPTH_CONV let_CONV) o
+   CONV_RULE NUM_REDUCE_CONV o
+   GEN_REWRITE_CONV I [arm_LD1_LANE])
+  `arm_LD1_LANE Rt Rn off 32 ix`;;
+let arm_ST1_LANE_ALT =
+  (CONV_RULE(TOP_DEPTH_CONV let_CONV) o
+   CONV_RULE NUM_REDUCE_CONV o
+   GEN_REWRITE_CONV I [arm_ST1_LANE])
+  `arm_ST1_LANE Rt Rn off 32 ix`;;
+
 let arm_SQDMULH_VEC_ALT =
   REWRITE_RULE[word_2smulh] (EXPAND_SIMD_RULE arm_SQDMULH_VEC);;
 
@@ -3673,4 +3740,5 @@ let ARM_LOAD_STORE_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)
       [arm_LDR; arm_STR; arm_LDRB; arm_STRB; arm_LDP; arm_STP;
        arm_LDP3; arm_STP3;
-       arm_LD2_ALT; arm_ST2_ALT; arm_LD1R; arm_LD3_ALT; arm_ST3_ALT];;
+       arm_LD2_ALT; arm_ST2_ALT; arm_LD1R; arm_LD3_ALT; arm_ST3_ALT;
+       arm_LD1_LANE_ALT; arm_ST1_LANE_ALT];;

--- a/arm/proofs/instruction.ml
+++ b/arm/proofs/instruction.ml
@@ -2863,6 +2863,53 @@ let arm_ST3 = define
             else (=))
          else ASSIGNS entirety) s`;;
 
+(* Three-register contiguous load/store for little-endian LD1/ST1. *)
+
+let arm_LDP3 = define
+ `arm_LDP3 (Rt1:(armstate,N word)component)
+           (Rt2:(armstate,N word)component)
+           (Rt3:(armstate,N word)component) Rn off =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            orthogonal_components Rt1 Rt2 /\
+            orthogonal_components Rt1 Rt3 /\
+            orthogonal_components Rt2 Rt3 /\
+            (offset_writesback off
+             ==> orthogonal_components Rt1 Rn /\ orthogonal_components Rt2 Rn /\
+                 orthogonal_components Rt3 Rn)
+         then
+           let w = dimindex(:N) DIV 8 in
+           Rt1 := read (memory :> wbytes addr) s ,,
+           Rt2 := read (memory :> wbytes(word_add addr (word w))) s ,,
+           Rt3 := read (memory :> wbytes(word_add addr (word(2 * w)))) s ,,
+           events := CONS (EventLoad (addr,3 * w)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
+let arm_STP3 = define
+ `arm_STP3 (Rt1:(armstate,N word)component)
+           (Rt2:(armstate,N word)component)
+           (Rt3:(armstate,N word)component) Rn off =
+    \s. let base = read Rn s in
+        let addr = word_add base (offset_address off s) in
+        (if (Rn = SP ==> aligned 16 base) /\
+            (offset_writesback off
+             ==> orthogonal_components Rt1 Rn /\ orthogonal_components Rt2 Rn /\
+                 orthogonal_components Rt3 Rn)
+         then
+           let w = dimindex(:N) DIV 8 in
+           memory :> wbytes addr := read Rt1 s ,,
+           memory :> wbytes(word_add addr (word w)) := read Rt2 s ,,
+           memory :> wbytes(word_add addr (word(2 * w))) := read Rt3 s ,,
+           events := CONS (EventStore (addr,3 * w)) (read events s) ,,
+           (if offset_writesback off
+            then Rn := word_add base (offset_writeback off s)
+            else (=))
+         else ASSIGNS entirety) s`;;
+
 (* ------------------------------------------------------------------------- *)
 (* SHA-related SIMD operations                                               *)
 (* ------------------------------------------------------------------------- *)
@@ -3625,4 +3672,5 @@ let ARM_OPERATION_CLAUSES =
 let ARM_LOAD_STORE_CLAUSES =
   map (CONV_RULE(TOP_DEPTH_CONV let_CONV) o SPEC_ALL)
       [arm_LDR; arm_STR; arm_LDRB; arm_STRB; arm_LDP; arm_STP;
+       arm_LDP3; arm_STP3;
        arm_LD2_ALT; arm_ST2_ALT; arm_LD1R; arm_LD3_ALT; arm_ST3_ALT];;

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -571,10 +571,37 @@ let cosimulate_ldst3() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LD1/ST1 (multiple structures), 3 registers, no offset,
+ *** for datasizes 64 and 128.
+ ***)
+
+let cosimulate_ldst1_3reg() =
+  let datasize = Random.int 2
+  and isld = Random.int 2
+  and esize = Random.int 4
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  let stackoff =
+    if rn = 31 then Random.int 13 * 16
+    else Random.int 208 in
+  let code =
+    pow2 30 */ num datasize +/
+    pow2 24 */ num 0b001100 +/
+    pow2 22 */ num isld +/
+    pow2 12 */ num 0b0110 +/
+    pow2 10 */ num esize +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 stackoff]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
-    cosimulate_ldst3; cosimulate_ldstu
+    cosimulate_ldst3; cosimulate_ldstu;
+    cosimulate_ldst1_3reg
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -624,11 +624,56 @@ let cosimulate_ldst2_noofs() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LD1/ST1 (single structure, single lane), 32-bit (.s) form,
+ *** addressing modes no-offset, post-immediate (#4) and post-register.
+ *** The lane index is (Q:S). For LD1 the other lanes are preserved.
+ ***)
+
+let cosimulate_ldst1_lane() =
+  let isld = Random.int 2
+  and rn = Random.int 32
+  and rt = Random.int 32
+  and index = Random.int 4 in
+  let q = index / 2 and sbit = index mod 2 in
+  (* someoffset = 0 : no offset (const = 0011010, Rm = 0)
+     someoffset = 1 : post-index (const = 0011011); Rm = 11111 selects the
+       post-immediate (#4) form, otherwise Rm = Xm selects post-register.
+     The post-register form (which advances the base by the full value of Xm)
+     is only used when the base is not SP and Xm <> base, since otherwise it
+     either corrupts the harness stack pointer or aliases the base. *)
+  let someoffset = Random.int 2 in
+  let regoffr = Random.int 32 in
+  let rm =
+    if someoffset = 0 then 0
+    else if rn = 31 || regoffr = rn || Random.bool() then 31
+    else regoffr in
+  let constfield = if someoffset = 0 then 0b0011010 else 0b0011011 in
+  let stackoff =
+    if rn = 31 then Random.int 14 * 16
+    else Random.int 224 in
+  (* The post-immediate form (Rm = 31) advances the base by the element size
+     (4 bytes for .s); the post-register form advances it by Xm. *)
+  let postinc = if someoffset = 1 && rm = 31 then 4 else 0 in
+  let code =
+    pow2 30 */ num q +/
+    pow2 23 */ num constfield +/
+    pow2 22 */ num isld +/
+    pow2 16 */ num rm +/
+    pow2 13 */ num 0b100 +/
+    pow2 12 */ num sbit +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 (stackoff + postinc)]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
     cosimulate_ldst3; cosimulate_ldstu;
-    cosimulate_ldst1_3reg; cosimulate_ldst2_noofs
+    cosimulate_ldst1_3reg; cosimulate_ldst2_noofs;
+    cosimulate_ldst1_lane
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -697,12 +697,43 @@ let cosimulate_ldst_simd_bhs() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LDUR/STUR (SIMD&FP, unscaled immediate) for sizes 64 (D)
+ *** and 32 (S). The 9-bit immediate is a signed, unscaled byte offset.
+ ***)
+
+let cosimulate_ldstu_simd() =
+  let is_d = Random.int 2 in
+  let size = if is_d = 1 then 0b11 else 0b10 in
+  let access = if is_d = 1 then 8 else 4 in
+  let isld = Random.int 2
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  let stackoff =
+    if rn = 31 then Random.int 17 * 16
+    else Random.int 257 in
+  let minoff = -stackoff
+  and maxoff = 256 - access - stackoff in
+  let off = minoff + Random.int (maxoff - minoff + 1) in
+  let encodedoff = if off < 0 then off + 512 else off in
+  let code =
+    pow2 30 */ num size +/
+    pow2 24 */ num 0b111100 +/
+    pow2 22 */ num isld +/
+    pow2 12 */ num encodedoff +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 stackoff]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
     cosimulate_ldst3; cosimulate_ldstu;
     cosimulate_ldst1_3reg; cosimulate_ldst2_noofs;
-    cosimulate_ldst1_lane; cosimulate_ldst_simd_bhs
+    cosimulate_ldst1_lane; cosimulate_ldst_simd_bhs;
+    cosimulate_ldstu_simd
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -597,11 +597,38 @@ let cosimulate_ldst1_3reg() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LD2/ST2 (multiple structures), 2 registers, no offset,
+ *** for datasizes 64 and 128 (size = 11 only valid for datasize 128).
+ ***)
+
+let cosimulate_ldst2_noofs() =
+  let datasize = Random.int 2
+  and isld = Random.int 2
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  (* size 11 (esize 64) only valid for datasize 128 *)
+  let esize = if datasize = 0 then Random.int 3 else Random.int 4 in
+  let stackoff =
+    if rn = 31 then Random.int 13 * 16
+    else Random.int 208 in
+  let code =
+    pow2 30 */ num datasize +/
+    pow2 24 */ num 0b001100 +/
+    pow2 22 */ num isld +/
+    pow2 12 */ num 0b1000 +/
+    pow2 10 */ num esize +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 stackoff]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
     cosimulate_ldst3; cosimulate_ldstu;
-    cosimulate_ldst1_3reg
+    cosimulate_ldst1_3reg; cosimulate_ldst2_noofs
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -668,12 +668,41 @@ let cosimulate_ldst1_lane() =
   else
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
+(*** This covers LDR/STR (SIMD&FP, immediate, unsigned offset) for the
+ *** sub-64 element sizes 32 (S), 16 (H) and 8 (B). The byte offset is the
+ *** 12-bit immediate scaled by the access size.
+ ***)
+
+let cosimulate_ldst_simd_bhs() =
+  let size = Random.int 3 (* 0=B, 1=H, 2=S *)
+  and isld = Random.int 2
+  and rn = Random.int 32
+  and rt = Random.int 32 in
+  let access = 1 lsl size in
+  let stackoff =
+    if rn = 31 then Random.int 15 * 16
+    else Random.int (256 - access) in
+  (* The accessed range is [stackoff + imm12*access, +access); keep it within
+     the 256-byte buffer, i.e. stackoff + imm12*access + access <= 256. *)
+  let imm12 = Random.int (1 + (256 - access - stackoff) / access) in
+  let code =
+    pow2 30 */ num size +/
+    pow2 23 */ num 0b1111010 +/
+    pow2 22 */ num isld +/
+    pow2 10 */ num imm12 +/
+    pow2 5 */ num rn +/
+    num rt in
+  if rn = 31 then
+    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 stackoff]
+  else
+    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+
 let memclasses =
    [cosimulate_ldstr; cosimulate_ldstp; cosimulate_ldst_12;
     cosimulate_ldst_1_2reg; cosimulate_ldstrb; cosimulate_ld1r;
     cosimulate_ldst3; cosimulate_ldstu;
     cosimulate_ldst1_3reg; cosimulate_ldst2_noofs;
-    cosimulate_ldst1_lane
+    cosimulate_ldst1_lane; cosimulate_ldst_simd_bhs
     ];;
 
 let run_random_memopsimulation() =

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -562,6 +562,9 @@ let check_insns () =
     (*** st2 (2 register, Post-immediate offset) ***)
     "0x001100100111111000xxxxxxxxxxxx";
 
+    (*** ld1 / st1 (3 registers, no offset) ***)
+    "0x0011000x0000000110xxxxxxxxxxxx";
+
     (*** ld1r (post immediate ofs) ***)
     "0x001101110111111100xxxxxxxxxxxx";
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -565,6 +565,9 @@ let check_insns () =
     (*** ld1 / st1 (3 registers, no offset) ***)
     "0x0011000x0000000110xxxxxxxxxxxx";
 
+    (*** ld2 / st2 (2 register, no offset) ***)
+    "0x0011000x0000001000xxxxxxxxxxxx";
+
     (*** ld1r (post immediate ofs) ***)
     "0x001101110111111100xxxxxxxxxxxx";
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -568,6 +568,12 @@ let check_insns () =
     (*** ld2 / st2 (2 register, no offset) ***)
     "0x0011000x0000001000xxxxxxxxxxxx";
 
+    (*** ld1 / st1 (single lane, .s) no offset ***)
+    "0x0011010x000000100x00xxxxxxxxxx";
+
+    (*** ld1 / st1 (single lane, .s) post-index ***)
+    "0x0011011x0xxxxx100x00xxxxxxxxxx";
+
     (*** ld1r (post immediate ofs) ***)
     "0x001101110111111100xxxxxxxxxxxx";
 

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -574,6 +574,10 @@ let check_insns () =
     (*** ld1 / st1 (single lane, .s) post-index ***)
     "0x0011011x0xxxxx100x00xxxxxxxxxx";
 
+    (*** ldur / stur (SIMD & FP), unscaled, sizes 64 and 32 ***)
+    "111111000x0xxxxxxxxx00xxxxxxxxxx";
+    "101111000x0xxxxxxxxx00xxxxxxxxxx";
+
     (*** ld1r (post immediate ofs) ***)
     "0x001101110111111100xxxxxxxxxxxx";
 


### PR DESCRIPTION
Adds instruction models, decoding, conversion support, and hardware cosimulation coverage for these AArch64 SIMD load/store forms:

- Three-register `LD1` and `ST1` for consecutive `D` or `Q` registers, with no offset, post-immediate writeback, or post-register writeback.
- No-offset, two-register `LD2` and `ST2`, which deinterleave loads and interleave stores.
- Single-lane `LD1` and `ST1` for 32-bit SIMD lanes, with no offset, `#4` post-immediate writeback, or post-register writeback.
- Scalar SIMD `LDR` and `STR` for `B`, `H`, and `S` registers with scaled unsigned offsets.
- Scalar SIMD `LDUR` and `STUR` for `S` and `D` registers with signed unscaled offsets.

These forms are needed by the x265 AArch64 proof work.

### Implementation

The three-register forms transfer contiguous 24- or 48-byte register lists, including lists that wrap from `V31` to `V0`. For post-indexed forms, `Rm = 31` advances the base by `#24` or `#48`; other `Rm` values select register writeback through `Xm`.

The `LD2`/`ST2`, single-lane, and scalar forms reuse the existing SIMD load/store semantics. New `B`, `H`, and `S` component expansions expose the complete `Q`-register state to symbolic execution.

### Validation

- LLVM 11 accepted 114 legal representatives and rejected ten invalid forms.
- Fresh HOL checks decoded all 114 legal representatives, proved five reserved forms decode to `NONE`, and confirmed that `ARM_MK_EXEC_RULE` loads the reported `0x4cdf6c34` instruction.
- Confirmed that the 13 new decoder clauses and seven simulator masks do not overlap existing instruction classes.
- Full 64-worker native AArch64 `make -C arm sematest` passed 368,780 cases with zero failures. This included 2,817 three-register `LD1`/`ST1` executions covering all 48 width, direction, arrangement, and addressing-mode combinations.
