### PR TITLE
Arm: Decode two-register LD1 and ST1 post-register forms

### DIFF
--- a/arm/proofs/decode.ml
+++ b/arm/proofs/decode.ml
@@ -411,10 +411,12 @@ let decode = new_definition `!w:int32. decode w =
     SOME (arm_ldst_q is_ld Rt (XREG_SP Rn) No_Offset)
 
   // LD1/ST1 (multiple structures), 2 registers,
-  //   Post-index with immediate offset, datasize = 128
+  //   Post-immediate offset and post-register offset, datasize = 128
   // Similar to LDP of SIMD registers, assuming little-endian architecture.
-  | [0:1; 1:1; 0b0011001:7; is_ld; 0:1; 0b11111:5; 0b1010:4; size:2; Rn:5; Rt:5] ->
-    SOME (arm_ldstp_2q is_ld Rt (XREG_SP Rn) (Postimmediate_Offset (word 32)))
+  | [0:1; 1:1; 0b0011001:7; is_ld; 0:1; Rm:5; 0b1010:4; size:2; Rn:5; Rt:5] ->
+    SOME (arm_ldstp_2q is_ld Rt (XREG_SP Rn)
+      (if val Rm = 31 then (Postimmediate_Offset (word 32))
+                      else Postreg_Offset (XREG' Rm)))
   //   No offset, datasize = 128
   | [0:1; 1:1; 0b0011000:7; is_ld; 0b000000:6; 0b1010:4; size:2; Rn:5; Rt:5] ->
     SOME (arm_ldstp_2q is_ld Rt (XREG_SP Rn) No_Offset)

--- a/arm/proofs/simulator.ml
+++ b/arm/proofs/simulator.ml
@@ -440,33 +440,44 @@ let cosimulate_ldst_12() =
     [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
 
 
-(*** This covers LD1 and ST1 with two registers, with the
- *** addressing modes, no-offset and post-immediate offset.
+(*** This covers LD1 and ST1 with two registers, with the addressing modes
+ *** no-offset, post-immediate offset and post-register offset.
  ***)
 
 let cosimulate_ldst_1_2reg() =
-  let someoffset = Random.int 2
+  let mode = Random.int 3
   and rn = Random.int 32
   and isld = Random.int 2
   and rt = Random.int 32
   and esize = Random.int 4 in
+  let someoffset = if mode = 0 then 0 else 1 in
+  let rm =
+    if mode = 0 then 0
+    else if mode = 1 then 31
+    else
+      let candidate = Random.int 31 in
+      if candidate = rn then (candidate + 1) mod 31 else candidate in
+  let regoff = if mode = 2 then 1 + Random.int 64 else 0 in
   let stackoff =
     if rn = 31 then Random.int 14 * 16
     else Random.int 224 in
-  let postinc = someoffset * 32 in
+  let postinc = if mode = 1 then 32 else regoff in
   let code =
     pow2 24 */ num 0b01001100 +/
     pow2 23 */ num someoffset +/
     pow2 22 */ num isld +/
-    pow2 16 */ num(0b011111 * someoffset) +/
+    pow2 16 */ num rm +/
     pow2 12 */ num 0b1010 +/
     pow2 10 */ num esize +/
     pow2 5 */ num rn +/
     num rt in
+  let setoffset = if mode = 2 then [movz_Xn_imm rm regoff] else [] in
   if rn = 31 then
-    [add_Xn_SP_imm 31 stackoff; code; sub_Xn_SP_imm 31 (stackoff + postinc)]
+    [add_Xn_SP_imm 31 stackoff] @ setoffset @
+    [code; sub_Xn_SP_imm 31 (stackoff + postinc)]
   else
-    [add_Xn_SP_imm rn stackoff; code; sub_Xn_SP_Xn rn];;
+    [add_Xn_SP_imm rn stackoff] @ setoffset @
+    [code; sub_Xn_SP_Xn rn];;
 
 (*** This covers LDRB and STRB with unshifted register
  *** There are several more supported addressing modes to cover.

--- a/arm/proofs/simulator_iclasses.ml
+++ b/arm/proofs/simulator_iclasses.ml
@@ -550,11 +550,11 @@ let check_insns () =
     (*** st1 (1 register, no Post-immediate offset) ***)
     "0x001100000000000111xxxxxxxxxxxx";
 
-    (*** ld1 (2 registers, Post-immediate offset) 128-bit ***)
-    "01001100110111111010xxxxxxxxxxxx";
+    (*** ld1 (2 registers, Post-immediate and register offset) 128-bit ***)
+    "01001100110xxxxx1010xxxxxxxxxxxx";
 
-    (*** st1 (2 registers, Post-immediate offset) 128-bit ***)
-    "01001100100111111010xxxxxxxxxxxx";
+    (*** st1 (2 registers, Post-immediate and register offset) 128-bit ***)
+    "01001100100xxxxx1010xxxxxxxxxxxx";
 
     (*** ld2 (2 register, Post-immediate offset) ***)
     "0x001100110111111000xxxxxxxxxxxx";


### PR DESCRIPTION
Adds post-register writeback decoding and hardware cosimulation coverage for the 128-bit, two-register `LD1` and `ST1` multiple-structure forms.

These instructions transfer two consecutive SIMD registers between memory and the register file, for 32 bytes total. The post-register form uses `Xn` as the memory address and then advances it by `Xm`. This form is needed by x265 AArch64 NEON proof work.

  ### Implementation

The decoder reuses the existing `arm_ldstp_2q` semantics. `Rm = 31` retains the existing post-immediate `#32` behavior; any other `Rm` selects `Postreg_Offset (XREG' Rm)`. Consecutive register lists continue to wrap modulo 32.

The simulator now exercises no-offset, post-immediate, and post-register forms for loads and stores across all four element arrangements. The instruction masks are widened to include register writeback.

  ### Validation

  - LLVM 11 assembled post-register and post-immediate loads and stores for all four element arrangements, producing the same 16 exact encodings used by the HOL checks.
  - Fresh HOL checks decoded all 16 representatives. `check_insns()` confirmed that the changed decoder clause and simulator masks do not overlap existing classes.
  - Focused AArch64 hardware cosimulation passed 144 cases, covering every load/store, element arrangement, and addressing-mode combination.
  - Full 64-worker AArch64 `make -C arm sematest` passed 328,908 register and 36,670 memory cases (365,578 total) with zero failures, including 1,509 post-register executions (739 loads and 770 stores).

