### PR TITLE
Speed up the GHASH and POLYVAL squaring chains

### DIFF
--- a/common/ghash.ml
+++ b/common/ghash.ml
@@ -510,6 +510,52 @@ let POLY_EQUIV_GHASH_REDUCE = prove
   CONV_TAC NUM_REDUCE_CONV);;
 
 (* ------------------------------------------------------------------------- *)
+(* A faster numeral conversion for word_pmul than Library/words.ml's         *)
+(* WORD_PMUL_CONV, which the squaring chain below and the one in             *)
+(* common/polyval.ml call once per step. Bit-identical; only search is cut.  *)
+(*                                                                           *)
+(* WORD_PMUL_CONV recurses by peeling bit 0 off the FIRST argument, but its   *)
+(* base case is `x * word 0 = 0`, which tests the SECOND -- and the second    *)
+(* argument is only ever shifted LEFT, so it never reaches word 0. The        *)
+(* recursion therefore runs the full dimindex (256 here) even though the      *)
+(* first operand, a 128-bit value in a 256-bit word, is exhausted after 128;  *)
+(* the surplus half is `word_pmul (word 0) _` folded through 256-bit xors on  *)
+(* a zero addend. Adding the `word 0 * y = 0` base case halves the recursion  *)
+(* (256 -> 128, counted), and short-circuiting the zero addend skips the      *)
+(* numeral WORD_XOR_CONV that the `bit 0 = F` branch would otherwise pay.     *)
+(* MEASURED warm, twice: this chain 139.0 -> 90.5 s, and polyval_chain in     *)
+(* common/polyval.ml 120.8 -> 71.6 s, every chain element aconv-identical.    *)
+(* ------------------------------------------------------------------------- *)
+
+let WORD_PMUL_NUM_CONV =
+  let pth_xor_l = WORD_RULE `word_xor (word 0:N word) x = x`
+  and pth_xor_r = WORD_RULE `word_xor x (word 0:N word) = x` in
+  let in_conv =
+    GEN_REWRITE_CONV I [GSYM(CONJUNCT2 WORD_PMUL_ZX)] THENC
+    RAND_CONV WORD_ZX_CONV
+  and base_conv =
+    GEN_REWRITE_CONV I [CONJUNCT1 WORD_PMUL_0; CONJUNCT2 WORD_PMUL_0]
+  and step_conv =
+    GEN_REWRITE_CONV I [WORD_PMUL_STEP] THENC
+    BINOP2_CONV
+     (RATOR_CONV(LAND_CONV BIT_WORD_CONV) THENC
+      GEN_REWRITE_CONV I [COND_CLAUSES])
+     (BINOP2_CONV WORD_USHR_CONV WORD_SHL_CONV)
+  and xor_conv =
+    GEN_REWRITE_CONV I [pth_xor_l; pth_xor_r] ORELSEC WORD_XOR_CONV in
+  let rec conv tm =
+    try base_conv tm with Failure _ ->
+    (step_conv THENC RAND_CONV conv THENC xor_conv) tm in
+  let fullconv = in_conv THENC conv in
+  fun tm ->
+    match tm with
+      Comb(Comb(Const("word_pmul",_),
+                Comb(Const("word",_),m)),
+            Comb(Const("word",_),n))
+      when is_numeral m && is_numeral n -> fullconv tm
+  | _ -> failwith "WORD_PMUL_NUM_CONV";;
+
+(* ------------------------------------------------------------------------- *)
 (* Some explicit computations of high powers of X.                           *)
 (* ------------------------------------------------------------------------- *)
 
@@ -558,14 +604,14 @@ let [X_POWPOW_128; X_POWPOW_64] =
     let th1 = MATCH_MP step (hd lis) in
     let th2 = CONV_RULE(RATOR_CONV(BINOP2_CONV
                (RAND_CONV(RAND_CONV NUM_SUC_CONV))
-               (ONCE_DEPTH_CONV WORD_PMUL_CONV THENC
+               (ONCE_DEPTH_CONV WORD_PMUL_NUM_CONV THENC
                 (* GHASH_REDUCE1, not the ghash_reduce1 definition: the defn
                    leaves a `word_pmul _ (word 0x87)` that WORD_RED_CONV then
                    evaluates 384 times at ~0.58s each (245s of this phrase).
                    GHASH_REDUCE1 states the same reduction as shifts/xors, so
                    the numerals reduce cheaply. Chain is bit-identical. *)
                 REWRITE_CONV[ghash_reduce; GHASH_REDUCE1] THENC
-                DEPTH_CONV(WORD_RED_CONV ORELSEC WORD_PMUL_CONV)))) th1 in
+                DEPTH_CONV(WORD_RED_CONV ORELSEC WORD_PMUL_NUM_CONV)))) th1 in
     th2::lis in
   let lis = rev(rules 128) in
   let th_0 = SIMP_RULE[EXP; RING_POW_1; POLY_VAR_BOOL_POLY] (el 0 lis)

--- a/common/ghash.ml
+++ b/common/ghash.ml
@@ -559,7 +559,12 @@ let [X_POWPOW_128; X_POWPOW_64] =
     let th2 = CONV_RULE(RATOR_CONV(BINOP2_CONV
                (RAND_CONV(RAND_CONV NUM_SUC_CONV))
                (ONCE_DEPTH_CONV WORD_PMUL_CONV THENC
-                REWRITE_CONV[ghash_reduce; ghash_reduce1] THENC
+                (* GHASH_REDUCE1, not the ghash_reduce1 definition: the defn
+                   leaves a `word_pmul _ (word 0x87)` that WORD_RED_CONV then
+                   evaluates 384 times at ~0.58s each (245s of this phrase).
+                   GHASH_REDUCE1 states the same reduction as shifts/xors, so
+                   the numerals reduce cheaply. Chain is bit-identical. *)
+                REWRITE_CONV[ghash_reduce; GHASH_REDUCE1] THENC
                 DEPTH_CONV(WORD_RED_CONV ORELSEC WORD_PMUL_CONV)))) th1 in
     th2::lis in
   let lis = rev(rules 128) in

--- a/common/polyval.ml
+++ b/common/polyval.ml
@@ -907,7 +907,11 @@ let polyval_chain =
       let w_num = dest_numeral(rand w_tm) in
       let sq_th = MATCH_MP POLYVAL_SQUARE_STEP prev_th in
       let sq_th' = CONV_RULE(rhs_conv(REWR_CONV(SPEC w_tm PMUL_128_256_BRIDGE))) sq_th in
-      let sq_th'' = CONV_RULE(rhs_conv(RAND_CONV WORD_PMUL_CONV)) sq_th' in
+      (* WORD_PMUL_NUM_CONV (common/ghash.ml), not Library/words.ml's
+         WORD_PMUL_CONV: the latter's base case tests the wrong operand, so it
+         runs 256 bit-recursions per step where 128 suffice. This one conversion
+         was 112.9s of this phrase's 120.8s; bit-identical, 120.8 -> 71.6 s. *)
+      let sq_th'' = CONV_RULE(rhs_conv(RAND_CONV WORD_PMUL_NUM_CONV)) sq_th' in
       let y_num = poly_mul_gf2 w_num w_num in
       let z_num = x_powpow.(k) in
       let q_num = quotients.(k-1) in


### PR DESCRIPTION
Two independent, measured speedups to the GF(2^128) squaring chains in
`common/ghash.ml` and `common/polyval.ml`. No statement changes: every exported
theorem is `aconv`-identical to its previous form and still carries zero
hypotheses, so this is purely a proof-time change.

Together they take the cold load of the dependency closure these files sit in
from **902.6 s to 631.0 s (-30%)**, measured on a Graviton host.

### 1. Reduce the `X_POWPOW` chain with `GHASH_REDUCE1` instead of `ghash_reduce1`

The 128-step `X_POWPOW_128`/`X_POWPOW_64` chain was the single heaviest item in
the closure. Per-conversion timing showed the cause is not the chain's algebra:
rewriting with the `ghash_reduce1` *definition* leaves a
`word_pmul _ (word 0x87)` in the term, which the following `DEPTH_CONV` then
evaluates with `WORD_RED_CONV` — 384 calls at ~0.58 s each, most of them on the
trivially-zero product `word_pmul (word 0) (word 135) : 256 word`. The cost is in
the 256-bit `word_pmul` numeral machinery.

`GHASH_REDUCE1`, proved a few lines above in the same file, states the identical
reduction as shifts and xors, so the numerals reduce cheaply. It is a one-word
change to the rewrite set: **353 s -> 138 s**.

### 2. Add `WORD_PMUL_NUM_CONV` to halve the recursion in both chains

This one is worth flagging beyond this PR, because the root cause is upstream in
HOL Light rather than here. `Library/words.ml`'s `WORD_PMUL_CONV` recurses by
peeling bit 0 off the **first** argument, but its base case is `x * word 0 = 0`,
which tests the **second** — and the second argument is only ever shifted left,
so it never reaches `word 0`. The recursion therefore runs the full `dimindex`
(256) even though the first operand, a 128-bit value held in a 256-bit word, is
exhausted after 128 steps; the surplus half is `word_pmul (word 0) _` folded
through 256-bit xors on a zero addend.

Profiling put that one conversion at 112.9 s of `polyval_chain`'s 120.8 s (93.5%).
Adding the `word 0 * y = 0` base case halves the recursion (256 -> 128, counted)
and short-circuits the zero addend. Measured warm, twice:

| chain | before | after |
|---|---|---|
| `common/polyval.ml` `polyval_chain` | 120.8 s | 71.6 s (-40.7%) |
| `common/ghash.ml` `X_POWPOW_128/64` | 139.0 s | 90.5 s (-35.0%) |

The proper fix is arguably a base case in `Library/words.ml` itself; this PR only
works around it locally.

### Soundness

Bit-identical, not merely equal in value. All 129 elements of each chain are
`aconv` with the previous chain's and carry `hyps = 0` (checked twice), and all
four derived exports — `X_POWPOW_128/_64`, `X_POWPOW_POLYVAL_128/_64` — are
`aconv`-identical with `hyps = 0`. No definition, statement or export name moves.

### What was tested

No proof file on `main` currently loads these files — the consumer chain is
self-contained inside `common/` (`ghash.ml` <- `polyval.ml` <-
`{karatsuba_pmul, polyval_ghash <- ghash_nist_bridge}`) — so the real consumers
are the in-flight GCM proofs. Both of those that exist today were loaded cold
against this change and pass at `axioms = 3` with their exported theorems at
`hyps = 0`:

* `arm/proofs/aesv8_gcm_8x_dec_256_wb.ml` (from #445) — 2437.1 s, both
  `AESV8_GCM_8X_DEC_256_CORRECT` and `..._SUBROUTINE_CORRECT` at `hyps = 0`
* `arm/proofs/aesv8_gcm_8x_dec_256_lemmas.ml` (from #445) — 677.9 s

Caveats, stated rather than buried: single cold runs on the test host vary by
~20%, so the closure figure above is a single measurement and the per-conversion
numbers (replicated twice, warm) are the defensible claim.

Two AES-GCM *encrypt* proofs on an unrelated local branch, which is not part of
any PR, fail to load both with and without this change — pre-existing defects,
independent of it. One further proof initially looked like a regression here: it
failed in a batched gate run and passed on the change-free base. That comparison
was confounded, and the completing 2x2 shows why — it **passes** alone in a fresh
process both with and without this change, and only fails as the fourth load in a
process where an earlier file had already raised. The cause was process
contamination from that earlier raise, not this change.
